### PR TITLE
feat: add governance UI control plane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,14 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
   retrieval goes through `Repository.search_candidates` (pgvector on Postgres, cosine in memory).
 - `infra/db/migrations` — SQL schema (Postgres + pgvector). RLS is **enforced** in
   `004_rls_policies.sql` (`FORCE` + tenant policy); verify with `scripts/check_rls_policies.py`. See ADR-006.
-- `apps/web` — Next.js frontend.
+- `apps/web` — Next.js frontend. v0.5 adds the **memory control plane**:
+  `/memories`, `/memories/[id]`, `/governance`, `/audit`, with reusable components
+  under `components/{memories,governance,audit}`. It is a read + audited-action
+  surface only — every action maps 1:1 to an audited backend route and never
+  writes around the policy broker. Backend additions are read-only
+  (`GET /api/memories/{id}`, `/{id}/provenance`, `/{id}/audit`) plus a `memory_id`
+  filter on `list_audit`/`/api/audit`. See ADR-009,
+  `docs/governance-ui.md`, `docs/memory-control-plane.md`.
 - `evals` — golden + adversarial cases, `run_evals.py`.
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ enforced.
 
 ```text
 memoryops-ai/
-  apps/web/            Next.js frontend (chat, memory dashboard, admin, architecture)
+  apps/web/            Next.js frontend (chat, memories, governance, audit, loops, admin, architecture)
   services/api/        FastAPI backend (gateway, extractor, policy broker, write/read path, audit)
   services/worker/     Background jobs (decay, reflection, conflict resolution, compression)
   packages/shared/     Shared types
@@ -302,10 +302,26 @@ MemoryOps integrates it via an adapter and does not vendor its source.
   `structured_output_invalid`, `llm_fallback_used`, `memory_extraction_structured`,
   `conflict_detection_result`) + `structured`/`conflict` evals; tests need no API keys.
 
-## What remains (v0.5+)
+## What works as of v0.5 (governance UI + memory control plane)
 
-- v0.5: governance UI actions (approve/edit/archive/delete) fully wired.
-- v0.6: decay / reflection / conflict-resolution workers.
+- Browser control plane over the governed lifecycle: `/memories` (filterable
+  inventory), `/memories/[id]` (detail + provenance + per-memory audit timeline +
+  inline edit), `/governance` (approval queue + recorded policy decisions),
+  `/audit` (tenant-wide append-only history).
+- Additive read routes: `GET /api/memories/{id}`, `/{id}/provenance`,
+  `/{id}/audit`, plus a `memory_id` filter on `/api/audit`. Approve/reject/edit/
+  archive/restore/delete reuse the existing PATCH/DELETE — every action is audited
+  and the policy broker stays authoritative.
+- Deletion guarantee holds in the UI: deleted memories are never listed or shown
+  as active. Provenance is metadata only (no embeddings/secrets).
+- See [docs/governance-ui.md](docs/governance-ui.md),
+  [docs/memory-control-plane.md](docs/memory-control-plane.md), and
+  [ADR-009](infra/adr/ADR-009-memory-control-plane.md).
+
+## What remains (v0.6+)
+
+- v0.6: deletion compaction + vector-index purge verification; decay / reflection
+  / conflict-resolution workers.
 - v0.7+: observability + economics, AI PR review runtime, deployment hardening.
 
 See [docs/rollout.md](docs/rollout.md) and the build phases in [CLAUDE.md](CLAUDE.md).

--- a/apps/web/app/audit/page.tsx
+++ b/apps/web/app/audit/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AuditEvent, api } from "@/lib/api";
+import AuditTimeline from "@/components/audit/AuditTimeline";
+
+export default function AuditPage() {
+  const [events, setEvents] = useState<AuditEvent[]>([]);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setEvents(await api.audit());
+        setError("");
+      } catch (e) {
+        setError(String(e));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-white">Audit log</h1>
+        <p className="mt-1 text-sm text-slate-400">
+          Append-only lifecycle history across all memories (tenant-scoped), newest first.
+        </p>
+      </div>
+      {error && <p className="text-sm text-rose-400">API error: {error}</p>}
+      {loading && <p className="text-sm text-slate-400">Loading…</p>}
+      <section className="card">
+        <AuditTimeline events={events} />
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/governance/page.tsx
+++ b/apps/web/app/governance/page.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { AuditEvent, MemoryRecord, api } from "@/lib/api";
+import PendingMemoryQueue from "@/components/governance/PendingMemoryQueue";
+import PolicyDecisionCard, {
+  POLICY_ACTIONS,
+} from "@/components/governance/PolicyDecisionCard";
+
+export default function GovernancePage() {
+  const [pending, setPending] = useState<MemoryRecord[]>([]);
+  const [decisions, setDecisions] = useState<AuditEvent[]>([]);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [pendingRows, audit] = await Promise.all([
+        api.memories({ status: "pending" }),
+        api.audit(),
+      ]);
+      setPending(pendingRows);
+      setDecisions(audit.filter((e) => POLICY_ACTIONS.includes(e.action)).slice(0, 30));
+      setError("");
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-white">Governance</h1>
+        <p className="mt-1 text-sm text-slate-400">
+          Human-in-the-loop approvals and the policy broker&apos;s recorded decisions.
+        </p>
+      </div>
+      {error && <p className="text-sm text-rose-400">API error: {error}</p>}
+      {loading && <p className="text-sm text-slate-400">Loading…</p>}
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold text-white">
+          Approval queue
+          <span className="ml-2 text-sm font-normal text-slate-500">
+            {pending.length} pending
+          </span>
+        </h2>
+        <PendingMemoryQueue rows={pending} onChanged={load} />
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold text-white">Recent policy decisions</h2>
+        {decisions.length === 0 ? (
+          <p className="text-sm text-slate-500">No policy decisions recorded yet.</p>
+        ) : (
+          <div className="grid gap-3 lg:grid-cols-2">
+            {decisions.map((e) => (
+              <PolicyDecisionCard key={e.id} event={e} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/memories/[id]/page.tsx
+++ b/apps/web/app/memories/[id]/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import MemoryDetailPanel from "@/components/memories/MemoryDetailPanel";
+
+export default function MemoryDetailPage() {
+  const params = useParams<{ id: string }>();
+  const id = params?.id;
+
+  return (
+    <div className="space-y-6">
+      <Link href="/memories" className="text-sm text-slate-400 hover:text-white">
+        ← Back to memories
+      </Link>
+      <h1 className="text-2xl font-bold text-white">Memory detail</h1>
+      {id ? (
+        <MemoryDetailPanel memoryId={id} />
+      ) : (
+        <p className="text-sm text-rose-400">Missing memory id.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/memories/page.tsx
+++ b/apps/web/app/memories/page.tsx
@@ -1,110 +1,59 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { api, MemoryRecord } from "@/lib/api";
+import MemoryTable from "@/components/memories/MemoryTable";
+import MemoryFilters, {
+  EMPTY_FILTERS,
+  MemoryFilterState,
+} from "@/components/memories/MemoryFilters";
 
 export default function MemoriesPage() {
   const [rows, setRows] = useState<MemoryRecord[]>([]);
+  const [filters, setFilters] = useState<MemoryFilterState>(EMPTY_FILTERS);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(true);
 
-  async function load() {
+  // status/type filter server-side (tenant-scoped); search is client-side.
+  const load = useCallback(async () => {
     setLoading(true);
     try {
-      setRows(await api.memories());
+      setRows(
+        await api.memories({
+          status: filters.status || undefined,
+          memory_type: filters.memory_type || undefined,
+        })
+      );
       setError("");
     } catch (e) {
       setError(String(e));
     } finally {
       setLoading(false);
     }
-  }
+  }, [filters.status, filters.memory_type]);
 
   useEffect(() => {
     load();
-  }, []);
+  }, [load]);
 
-  async function act(id: string, fn: () => Promise<unknown>) {
-    await fn();
-    await load();
-  }
+  const visible = useMemo(() => {
+    const q = filters.search.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter((m) => m.content.toLowerCase().includes(q));
+  }, [rows, filters.search]);
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-bold text-white">Memory dashboard</h1>
-      {error && <p className="text-sm text-rose-400">API error: {error}</p>}
-      {loading && <p className="text-sm text-slate-400">Loading…</p>}
-
-      <div className="overflow-x-auto">
-        <table className="w-full text-left text-sm">
-          <thead className="text-xs uppercase tracking-wide text-slate-500">
-            <tr>
-              <th className="p-2">Content</th>
-              <th className="p-2">Type</th>
-              <th className="p-2">Sensitivity</th>
-              <th className="p-2">Imp.</th>
-              <th className="p-2">Conf.</th>
-              <th className="p-2">Status</th>
-              <th className="p-2">Source</th>
-              <th className="p-2">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((m) => (
-              <tr key={m.id} className="border-t border-slate-800 align-top">
-                <td className="max-w-xs p-2">{m.content}</td>
-                <td className="p-2">{m.memory_type}</td>
-                <td className="p-2">{m.sensitivity}</td>
-                <td className="p-2">{m.importance}</td>
-                <td className="p-2">{m.confidence.toFixed(2)}</td>
-                <td className="p-2">
-                  <span className="chip">{m.status}</span>
-                </td>
-                <td className="max-w-[10rem] truncate p-2 text-slate-500" title={m.source.excerpt}>
-                  {m.source.kind}
-                </td>
-                <td className="space-x-2 whitespace-nowrap p-2">
-                  {m.status === "pending" && (
-                    <>
-                      <button
-                        className="text-emerald-400 hover:underline"
-                        onClick={() => act(m.id, () => api.patchMemory(m.id, { status: "active" }))}
-                      >
-                        approve
-                      </button>
-                      <button
-                        className="text-rose-400 hover:underline"
-                        onClick={() => act(m.id, () => api.patchMemory(m.id, { status: "rejected" }))}
-                      >
-                        reject
-                      </button>
-                    </>
-                  )}
-                  <button
-                    className="text-slate-400 hover:underline"
-                    onClick={() => act(m.id, () => api.patchMemory(m.id, { status: "archived" }))}
-                  >
-                    archive
-                  </button>
-                  <button
-                    className="text-rose-400 hover:underline"
-                    onClick={() => act(m.id, () => api.deleteMemory(m.id))}
-                  >
-                    delete
-                  </button>
-                </td>
-              </tr>
-            ))}
-            {!loading && rows.length === 0 && (
-              <tr>
-                <td className="p-2 text-slate-500" colSpan={8}>
-                  No memories yet. Try the chat demo.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+      <div>
+        <h1 className="text-2xl font-bold text-white">Memories</h1>
+        <p className="mt-1 text-sm text-slate-400">
+          Governed memory inventory. Soft-deleted memories are never listed here.
+        </p>
       </div>
+      {error && <p className="text-sm text-rose-400">API error: {error}</p>}
+      <MemoryFilters value={filters} onChange={setFilters} />
+      {loading && <p className="text-sm text-slate-400">Loading…</p>}
+      <MemoryTable rows={visible} loading={loading} onChanged={load} />
     </div>
   );
 }

--- a/apps/web/components/Nav.tsx
+++ b/apps/web/components/Nav.tsx
@@ -3,7 +3,9 @@ import Link from "next/link";
 const links = [
   { href: "/", label: "Home" },
   { href: "/chat", label: "Chat" },
-  { href: "/memories", label: "Memory Dashboard" },
+  { href: "/memories", label: "Memories" },
+  { href: "/governance", label: "Governance" },
+  { href: "/audit", label: "Audit" },
   { href: "/loops", label: "Loops" },
   { href: "/admin", label: "Admin" },
   { href: "/architecture", label: "Architecture" },

--- a/apps/web/components/audit/AuditTimeline.tsx
+++ b/apps/web/components/audit/AuditTimeline.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { AuditEvent } from "@/lib/api";
+
+// Append-only lifecycle history (invariant #7), newest first.
+const ACTION_DOT: Record<string, string> = {
+  memory_created: "bg-emerald-400",
+  memory_approved: "bg-emerald-400",
+  memory_pending_approval: "bg-amber-400",
+  memory_updated: "bg-sky-400",
+  memory_merged: "bg-sky-400",
+  memory_archived: "bg-slate-400",
+  memory_rejected: "bg-rose-400",
+  memory_blocked: "bg-rose-400",
+  memory_dropped: "bg-rose-400",
+  memory_deleted: "bg-rose-500",
+  memory_viewed: "bg-slate-600",
+};
+
+export default function AuditTimeline({
+  events,
+  emptyLabel = "No audit events yet.",
+}: {
+  events: AuditEvent[];
+  emptyLabel?: string;
+}) {
+  if (events.length === 0) {
+    return <p className="text-sm text-slate-500">{emptyLabel}</p>;
+  }
+  return (
+    <ol className="space-y-3">
+      {events.map((e) => (
+        <li key={e.id} className="flex gap-3">
+          <span
+            className={`mt-1 h-2 w-2 shrink-0 rounded-full ${
+              ACTION_DOT[e.action] ?? "bg-slate-500"
+            }`}
+          />
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-medium text-slate-200">{e.action}</span>
+              <span className="text-xs text-slate-500">
+                {new Date(e.created_at).toLocaleString()}
+              </span>
+            </div>
+            <p className="text-sm text-slate-400">{e.reason}</p>
+            {e.memory_id && (
+              <p className="font-mono text-[10px] text-slate-600">
+                memory {e.memory_id.slice(0, 8)}
+                {e.trace_id ? ` · trace ${e.trace_id}` : ""}
+              </p>
+            )}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/apps/web/components/governance/PendingMemoryQueue.tsx
+++ b/apps/web/components/governance/PendingMemoryQueue.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import { MemoryRecord } from "@/lib/api";
+import MemoryActions from "@/components/memories/MemoryActions";
+
+// Human-in-the-loop approval queue: memories the policy broker routed to
+// PENDING_APPROVAL. Approve → active, reject → rejected. Both are audited.
+export default function PendingMemoryQueue({
+  rows,
+  onChanged,
+}: {
+  rows: MemoryRecord[];
+  onChanged: () => void | Promise<void>;
+}) {
+  if (rows.length === 0) {
+    return (
+      <p className="text-sm text-slate-500">
+        Nothing awaiting approval. Sensitive or low-confidence captures land here.
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {rows.map((m) => (
+        <article key={m.id} className="card space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <Link href={`/memories/${m.id}`} className="text-slate-100 hover:underline">
+              {m.content}
+            </Link>
+            <MemoryActions memory={m} onChanged={onChanged} layout="stacked" />
+          </div>
+          <div className="flex flex-wrap gap-1 text-xs">
+            <span className="chip">{m.memory_type}</span>
+            <span className="chip">sensitivity: {m.sensitivity}</span>
+            <span className="chip">importance {m.importance}</span>
+            <span className="chip">confidence {m.confidence.toFixed(2)}</span>
+            <span className="chip" title={m.source.excerpt}>
+              source: {m.source.kind}
+            </span>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/governance/PolicyDecisionCard.tsx
+++ b/apps/web/components/governance/PolicyDecisionCard.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import { AuditEvent } from "@/lib/api";
+
+// The policy broker records its decision as an audit event (invariant #5/#7):
+// memory_pending_approval, memory_blocked, memory_dropped, memory_created, etc.
+// This card renders one such decision with its rationale — the broker stays
+// authoritative; the UI only displays what it decided.
+const DECISION_META: Record<string, { label: string; cls: string }> = {
+  memory_created: { label: "SAVED", cls: "border-emerald-700 text-emerald-300" },
+  memory_pending_approval: { label: "PENDING APPROVAL", cls: "border-amber-700 text-amber-300" },
+  memory_blocked: { label: "BLOCKED", cls: "border-rose-800 text-rose-300" },
+  memory_dropped: { label: "DROPPED (low utility)", cls: "border-slate-600 text-slate-400" },
+  memory_updated: { label: "UPDATED EXISTING", cls: "border-sky-700 text-sky-300" },
+  memory_merged: { label: "MERGED", cls: "border-sky-700 text-sky-300" },
+};
+
+export const POLICY_ACTIONS = Object.keys(DECISION_META);
+
+export default function PolicyDecisionCard({ event }: { event: AuditEvent }) {
+  const meta = DECISION_META[event.action] ?? {
+    label: event.action,
+    cls: "border-slate-700 text-slate-300",
+  };
+  const md = event.metadata ?? {};
+  return (
+    <article className="card space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <span className={`chip ${meta.cls}`}>{meta.label}</span>
+        <span className="text-xs text-slate-500">
+          {new Date(event.created_at).toLocaleString()}
+        </span>
+      </div>
+      <p className="text-sm text-slate-300">{event.reason}</p>
+      <div className="flex flex-wrap gap-1 text-xs">
+        {typeof md.type === "string" && <span className="chip">{md.type}</span>}
+        {typeof md.sensitivity === "string" && (
+          <span className="chip">sensitivity: {md.sensitivity}</span>
+        )}
+        {event.memory_id && (
+          <Link href={`/memories/${event.memory_id}`} className="chip hover:text-white">
+            view memory
+          </Link>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/apps/web/components/memories/MemoryActions.tsx
+++ b/apps/web/components/memories/MemoryActions.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { MemoryRecord, api } from "@/lib/api";
+
+// Every button maps 1:1 to an audited backend action (PATCH / DELETE).
+// Deleted memories expose no actions — they can never be reactivated.
+export default function MemoryActions({
+  memory,
+  onChanged,
+  layout = "inline",
+}: {
+  memory: MemoryRecord;
+  onChanged: () => void | Promise<void>;
+  layout?: "inline" | "stacked";
+}) {
+  const [busy, setBusy] = useState(false);
+
+  if (memory.status === "deleted") {
+    return <span className="text-xs text-slate-600">deleted — no actions</span>;
+  }
+
+  async function run(fn: () => Promise<unknown>) {
+    setBusy(true);
+    try {
+      await fn();
+      await onChanged();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const wrap =
+    layout === "stacked"
+      ? "flex flex-col items-start gap-2"
+      : "space-x-3 whitespace-nowrap";
+
+  return (
+    <div className={wrap}>
+      {memory.status === "pending" && (
+        <>
+          <button
+            className="text-emerald-400 hover:underline disabled:opacity-40"
+            disabled={busy}
+            onClick={() => run(() => api.patchMemory(memory.id, { status: "active" }))}
+          >
+            approve
+          </button>
+          <button
+            className="text-rose-400 hover:underline disabled:opacity-40"
+            disabled={busy}
+            onClick={() => run(() => api.patchMemory(memory.id, { status: "rejected" }))}
+          >
+            reject
+          </button>
+        </>
+      )}
+      {memory.status === "archived" ? (
+        <button
+          className="text-emerald-400 hover:underline disabled:opacity-40"
+          disabled={busy}
+          onClick={() => run(() => api.patchMemory(memory.id, { status: "active" }))}
+        >
+          restore
+        </button>
+      ) : (
+        <button
+          className="text-slate-400 hover:underline disabled:opacity-40"
+          disabled={busy}
+          onClick={() => run(() => api.patchMemory(memory.id, { status: "archived" }))}
+        >
+          archive
+        </button>
+      )}
+      <button
+        className="text-rose-400 hover:underline disabled:opacity-40"
+        disabled={busy}
+        onClick={() => {
+          if (
+            confirm(
+              "Soft-delete this memory? It will be excluded from all future retrieval."
+            )
+          ) {
+            run(() => api.deleteMemory(memory.id));
+          }
+        }}
+      >
+        delete
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/memories/MemoryDetailPanel.tsx
+++ b/apps/web/components/memories/MemoryDetailPanel.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  AuditEvent,
+  MemoryProvenance as Provenance,
+  MemoryRecord,
+  api,
+} from "@/lib/api";
+import { statusClass } from "./statusStyles";
+import MemoryActions from "./MemoryActions";
+import MemoryProvenance from "./MemoryProvenance";
+import AuditTimeline from "@/components/audit/AuditTimeline";
+
+// Full control-plane view for one memory: content (editable), lifecycle
+// actions, provenance/explainability, and the per-memory audit timeline.
+export default function MemoryDetailPanel({ memoryId }: { memoryId: string }) {
+  const [memory, setMemory] = useState<MemoryRecord | null>(null);
+  const [provenance, setProvenance] = useState<Provenance | null>(null);
+  const [events, setEvents] = useState<AuditEvent[]>([]);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [m, prov, audit] = await Promise.all([
+        api.memory(memoryId),
+        api.memoryProvenance(memoryId),
+        api.memoryAudit(memoryId),
+      ]);
+      setMemory(m);
+      setProvenance(prov);
+      setEvents(audit);
+      setDraft(m.content);
+      setError("");
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [memoryId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading && !memory) return <p className="text-sm text-slate-400">Loading…</p>;
+  if (error) return <p className="text-sm text-rose-400">API error: {error}</p>;
+  if (!memory) return null;
+
+  async function saveEdit() {
+    if (!memory) return;
+    setSaving(true);
+    try {
+      await api.patchMemory(memory.id, { content: draft });
+      setEditing(false);
+      await load();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="card space-y-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className={`chip ${statusClass(memory.status)}`}>{memory.status}</span>
+              <span className="chip">{memory.memory_type}</span>
+              <span className="chip">sensitivity: {memory.sensitivity}</span>
+            </div>
+            <p className="font-mono text-xs text-slate-600">{memory.id}</p>
+          </div>
+          <MemoryActions memory={memory} onChanged={load} layout="stacked" />
+        </div>
+
+        {editing ? (
+          <div className="space-y-2">
+            <textarea
+              className="w-full rounded-lg border border-slate-700 bg-ink p-3 text-sm"
+              rows={4}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+            />
+            <div className="flex gap-3 text-sm">
+              <button className="btn" disabled={saving} onClick={saveEdit}>
+                {saving ? "Saving…" : "Save"}
+              </button>
+              <button
+                className="text-slate-400 hover:text-white"
+                onClick={() => {
+                  setDraft(memory.content);
+                  setEditing(false);
+                }}
+              >
+                cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-start justify-between gap-3">
+            <p className="text-slate-100">{memory.content}</p>
+            {memory.status !== "deleted" && (
+              <button
+                className="shrink-0 text-sm text-accent hover:underline"
+                onClick={() => setEditing(true)}
+              >
+                edit
+              </button>
+            )}
+          </div>
+        )}
+      </section>
+
+      <MemoryProvenance provenance={provenance} />
+
+      <section className="card space-y-3">
+        <h3 className="font-semibold text-white">Audit timeline</h3>
+        <AuditTimeline events={events} emptyLabel="No audit events for this memory." />
+      </section>
+    </div>
+  );
+}

--- a/apps/web/components/memories/MemoryFilters.tsx
+++ b/apps/web/components/memories/MemoryFilters.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+export interface MemoryFilterState {
+  search: string;
+  status: string;
+  memory_type: string;
+}
+
+export const EMPTY_FILTERS: MemoryFilterState = {
+  search: "",
+  status: "",
+  memory_type: "",
+};
+
+// `deleted` is intentionally absent: the control plane never lists deleted
+// rows as part of the active inventory (deletion guarantee, invariant #2).
+const STATUSES = ["active", "pending", "archived", "rejected", "blocked"];
+const TYPES = [
+  "episodic",
+  "semantic",
+  "procedural",
+  "project",
+  "knowledge",
+  "system",
+  "constraint",
+  "preference",
+  "workflow",
+];
+
+export default function MemoryFilters({
+  value,
+  onChange,
+}: {
+  value: MemoryFilterState;
+  onChange: (next: MemoryFilterState) => void;
+}) {
+  const select = "rounded-lg border border-slate-700 bg-panel px-3 py-2 text-sm";
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <input
+        className="grow rounded-lg border border-slate-700 bg-panel px-3 py-2 text-sm"
+        placeholder="Search content…"
+        value={value.search}
+        onChange={(e) => onChange({ ...value, search: e.target.value })}
+      />
+      <select
+        className={select}
+        value={value.status}
+        onChange={(e) => onChange({ ...value, status: e.target.value })}
+      >
+        <option value="">All statuses</option>
+        {STATUSES.map((s) => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
+      <select
+        className={select}
+        value={value.memory_type}
+        onChange={(e) => onChange({ ...value, memory_type: e.target.value })}
+      >
+        <option value="">All types</option>
+        {TYPES.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+      {(value.search || value.status || value.memory_type) && (
+        <button
+          className="text-sm text-slate-400 hover:text-white"
+          onClick={() => onChange(EMPTY_FILTERS)}
+        >
+          clear
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/memories/MemoryProvenance.tsx
+++ b/apps/web/components/memories/MemoryProvenance.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { MemoryProvenance as Provenance } from "@/lib/api";
+
+// Renders where a memory came from (source/provenance, invariant #3) and the
+// durable signals that explain why it persists and gets retrieved.
+export default function MemoryProvenance({ provenance }: { provenance: Provenance | null }) {
+  if (!provenance) return null;
+  const s = provenance.source;
+  return (
+    <section className="card space-y-4">
+      <h3 className="font-semibold text-white">Provenance &amp; explainability</h3>
+
+      <div className="grid gap-2 text-sm sm:grid-cols-2">
+        <Field label="Source kind" value={s.kind} />
+        <Field label="Reinforcement count" value={String(provenance.reinforcement_count)} />
+        <Field label="Created" value={new Date(provenance.created_at).toLocaleString()} />
+        <Field label="Updated" value={new Date(provenance.updated_at).toLocaleString()} />
+        {s.conversation_id && <Field label="Conversation" value={s.conversation_id} />}
+        {s.message_id && <Field label="Message" value={s.message_id} />}
+      </div>
+
+      {s.excerpt && (
+        <div>
+          <p className="text-xs uppercase tracking-wide text-slate-500">Source excerpt</p>
+          <blockquote className="mt-1 border-l-2 border-slate-700 pl-3 text-sm text-slate-300">
+            {s.excerpt}
+          </blockquote>
+        </div>
+      )}
+
+      <div>
+        <p className="text-xs uppercase tracking-wide text-slate-500">
+          Why this memory is used (ranking signals)
+        </p>
+        <div className="mt-2 flex flex-wrap gap-2 text-xs">
+          <span className="chip">importance {provenance.importance}</span>
+          <span className="chip">confidence {provenance.confidence.toFixed(2)}</span>
+          <span className="chip">weight {provenance.weight.toFixed(2)}</span>
+          <span className="chip">reinforced ×{provenance.reinforcement_count}</span>
+        </div>
+        <p className="mt-2 text-xs text-slate-500">
+          The ranker scores candidates on vector similarity, keyword overlap, and these
+          durable signals. Per-request retrieval scores are shown live in the Chat view.
+        </p>
+      </div>
+
+      {provenance.loop_run_ids.length > 0 && (
+        <div>
+          <p className="text-xs uppercase tracking-wide text-slate-500">Loop evidence</p>
+          <div className="mt-2 flex flex-wrap gap-1">
+            {provenance.loop_run_ids.map((id) => (
+              <span key={id} className="chip font-mono text-[10px]">
+                {id.slice(0, 8)}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="text-slate-200">{value}</p>
+    </div>
+  );
+}

--- a/apps/web/components/memories/MemoryTable.tsx
+++ b/apps/web/components/memories/MemoryTable.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Link from "next/link";
+import { MemoryRecord } from "@/lib/api";
+import { statusClass } from "./statusStyles";
+import MemoryActions from "./MemoryActions";
+
+export default function MemoryTable({
+  rows,
+  loading,
+  onChanged,
+}: {
+  rows: MemoryRecord[];
+  loading?: boolean;
+  onChanged: () => void | Promise<void>;
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead className="text-xs uppercase tracking-wide text-slate-500">
+          <tr>
+            <th className="p-2">Content</th>
+            <th className="p-2">Type</th>
+            <th className="p-2">Sens.</th>
+            <th className="p-2">Imp.</th>
+            <th className="p-2">Conf.</th>
+            <th className="p-2">Status</th>
+            <th className="p-2">Source</th>
+            <th className="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((m) => (
+            <tr key={m.id} className="border-t border-slate-800 align-top">
+              <td className="max-w-xs p-2">
+                <Link href={`/memories/${m.id}`} className="hover:text-white hover:underline">
+                  {m.content}
+                </Link>
+              </td>
+              <td className="p-2 text-slate-400">{m.memory_type}</td>
+              <td className="p-2 text-slate-400">{m.sensitivity}</td>
+              <td className="p-2 text-slate-400">{m.importance}</td>
+              <td className="p-2 text-slate-400">{m.confidence.toFixed(2)}</td>
+              <td className="p-2">
+                <span className={`chip ${statusClass(m.status)}`}>{m.status}</span>
+              </td>
+              <td
+                className="max-w-[10rem] truncate p-2 text-slate-500"
+                title={m.source.excerpt}
+              >
+                {m.source.kind}
+              </td>
+              <td className="p-2">
+                <MemoryActions memory={m} onChanged={onChanged} />
+              </td>
+            </tr>
+          ))}
+          {!loading && rows.length === 0 && (
+            <tr>
+              <td className="p-2 text-slate-500" colSpan={8}>
+                No memories match these filters.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/components/memories/statusStyles.ts
+++ b/apps/web/components/memories/statusStyles.ts
@@ -1,0 +1,15 @@
+// Shared status → badge style map for the memory control plane.
+// `deleted` is styled distinctly and must never be presented as active.
+
+export const STATUS_STYLES: Record<string, string> = {
+  active: "border-emerald-700 text-emerald-300",
+  pending: "border-amber-700 text-amber-300",
+  archived: "border-slate-600 text-slate-400",
+  rejected: "border-rose-800 text-rose-300",
+  blocked: "border-rose-800 text-rose-300",
+  deleted: "border-slate-700 text-slate-600 line-through",
+};
+
+export function statusClass(status: string): string {
+  return STATUS_STYLES[status] ?? "border-slate-700 text-slate-300";
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -79,8 +79,24 @@ export interface AuditEvent {
   action: string;
   reason: string;
   memory_id?: string | null;
+  user_id?: string | null;
   trace_id?: string | null;
+  metadata?: Record<string, unknown>;
   created_at: string;
+}
+
+export interface MemoryProvenance {
+  memory_id: string;
+  source: { kind: string; excerpt: string; message_id?: string | null; conversation_id?: string | null };
+  status: string;
+  created_at: string;
+  updated_at: string;
+  reinforcement_count: number;
+  importance: number;
+  confidence: number;
+  weight: number;
+  audit_trail: AuditEvent[];
+  loop_run_ids: string[];
 }
 
 export interface LoopDefinition {
@@ -152,10 +168,26 @@ export const api = {
       }),
     }),
 
-  memories: (status?: string) =>
-    http<MemoryRecord[]>(
-      `/api/memories?tenant_id=${DEMO_TENANT}&user_id=${DEMO_USER}` +
-        (status ? `&status=${status}` : "")
+  memories: (filters?: { status?: string; memory_type?: string }) => {
+    const qs = new URLSearchParams({ tenant_id: DEMO_TENANT, user_id: DEMO_USER });
+    if (filters?.status) qs.set("status", filters.status);
+    if (filters?.memory_type) qs.set("memory_type", filters.memory_type);
+    return http<MemoryRecord[]>(`/api/memories?${qs.toString()}`);
+  },
+
+  memory: (id: string) =>
+    http<MemoryRecord>(
+      `/api/memories/${id}?tenant_id=${DEMO_TENANT}&user_id=${DEMO_USER}`
+    ),
+
+  memoryAudit: (id: string) =>
+    http<AuditEvent[]>(
+      `/api/memories/${id}/audit?tenant_id=${DEMO_TENANT}&user_id=${DEMO_USER}`
+    ),
+
+  memoryProvenance: (id: string) =>
+    http<MemoryProvenance>(
+      `/api/memories/${id}/provenance?tenant_id=${DEMO_TENANT}&user_id=${DEMO_USER}`
     ),
 
   patchMemory: (id: string, patch: Record<string, unknown>) =>

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -58,17 +58,34 @@ to the deterministic heuristic. New structured log events (not response fields):
 Query: `tenant_id` (req), `user_id` (req), `status` (opt), `memory_type` (opt).
 Returns `MemoryRecord[]`. Excludes `deleted` by default.
 
+## GET /api/memories/{id} (v0.5)
+Query: `tenant_id` (req), `user_id` (req). Returns a single `MemoryRecord`,
+tenant + user scoped. Soft-deleted rows are returned too (forensics) but always
+carry `status=deleted` — callers never render them as active. `404` if not in
+scope. Emits a `memory_viewed` audit event.
+
+## GET /api/memories/{id}/provenance (v0.5)
+Query: `tenant_id` (req), `user_id` (req). Returns `MemoryProvenance`:
+`{ memory_id, source, status, created_at, updated_at, reinforcement_count,
+importance, confidence, weight, audit_trail[], loop_run_ids[] }`. Metadata only —
+never embeddings or secrets.
+
+## GET /api/memories/{id}/audit (v0.5)
+Query: `tenant_id` (req), `user_id` (req), `limit` (opt, ≤1000). Returns the
+per-memory `AuditEvent[]`, newest first.
+
 ## PATCH /api/memories/{id}
 Body: `{ tenant_id, user_id, content?, importance?, confidence?, status? }`.
-`status=active` approves a pending memory; `rejected` rejects; `archived` archives.
-Returns the updated `MemoryRecord`. Emits an audit event.
+`status=active` approves a pending memory (or restores an archived one);
+`rejected` rejects; `archived` archives. `404` on a `deleted` memory — deletion is
+terminal. Returns the updated `MemoryRecord`. Emits an audit event.
 
 ## DELETE /api/memories/{id}
 Body: `{ tenant_id, user_id }`. Soft delete: `status=deleted`, `deleted_at=now()`,
 audit `memory_deleted`. The memory is never retrievable again.
 
 ## GET /api/audit
-Query: `tenant_id` (req), `user_id` (opt), `limit` (opt, ≤1000).
+Query: `tenant_id` (req), `user_id` (opt), `memory_id` (opt), `limit` (opt, ≤1000).
 Returns `AuditEvent[]` (append-only), newest first.
 
 ## GET /api/metrics

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ and audited — under five cross-cutting planes.
 ```mermaid
 flowchart TB
     subgraph Client["apps/web — Next.js"]
-        UI["Chat · Memory Dashboard · Admin · Architecture"]
+        UI["Chat · Memories · Governance · Audit · Loops · Admin · Architecture"]
     end
 
     subgraph API["services/api — FastAPI"]
@@ -205,6 +205,19 @@ the repository and exposed at `/api/loops`.
 
 Loop events are separate from audit logs. Loop events answer where a workflow is
 in its decision cycle; audit logs answer who did what, when, and why.
+
+## Memory control plane (v0.5)
+
+The browser-facing governance control plane sits **on top of** the existing
+read/write/policy/audit paths — it adds no new lifecycle behavior, only operable
+views and audited actions. Pages: `/memories`, `/memories/[id]`, `/governance`,
+`/audit`. Backend additions are read-only routes (`GET /api/memories/{id}`,
+`/{id}/provenance`, `/{id}/audit`) plus a `list_audit(memory_id=…)` filter; the
+existing PATCH/DELETE handle approve/reject/edit/archive/restore/delete. Every UI
+action maps 1:1 to an audited backend action and the policy broker stays
+authoritative. See [memory-control-plane.md](memory-control-plane.md),
+[governance-ui.md](governance-ui.md), and
+[ADR-009](../infra/adr/ADR-009-memory-control-plane.md).
 
 ## Write path (Phase 1 — implemented)
 

--- a/docs/governance-ui.md
+++ b/docs/governance-ui.md
@@ -1,0 +1,64 @@
+# Governance UI (v0.5)
+
+The browser-facing control plane for MemoryOps' governed memory lifecycle. It
+makes the lifecycle **operable by a human** without weakening any invariant —
+every view is tenant-scoped and every action is audited. See
+[ADR-009](../infra/adr/ADR-009-memory-control-plane.md) and the companion
+[memory-control-plane.md](memory-control-plane.md).
+
+## Pages
+
+| Route | Purpose |
+| --- | --- |
+| `/memories` | Filterable memory inventory (search + status + type). Soft-deleted rows are never listed. |
+| `/memories/[id]` | Detail: content (inline edit), lifecycle actions, provenance/explainability, per-memory audit timeline. |
+| `/governance` | Human-in-the-loop approval queue + recent policy-broker decisions. |
+| `/audit` | Tenant-wide append-only audit history, newest first. |
+
+## Components
+
+- `components/memories/`
+  - `MemoryTable` — inventory table; rows link to detail; inline actions.
+  - `MemoryFilters` — search + status + type filters (`deleted` is intentionally
+    not selectable — it is never part of the active inventory).
+  - `MemoryDetailPanel` — self-fetching detail (memory + provenance + audit),
+    inline content edit.
+  - `MemoryProvenance` — source/provenance and the durable ranking signals that
+    explain why a memory is used.
+  - `MemoryActions` — approve / reject / archive / restore / delete. Each maps to
+    an audited backend route; deleted memories expose no actions.
+  - `statusStyles.ts` — shared status→badge styling; `deleted` is visually
+    distinct and struck through.
+- `components/governance/`
+  - `PendingMemoryQueue` — the approval queue (approve/reject).
+  - `PolicyDecisionCard` — renders one recorded policy decision (SAVE / PENDING /
+    BLOCKED / DROPPED / UPDATED / MERGED) with its rationale.
+- `components/audit/`
+  - `AuditTimeline` — reusable append-only timeline (used on detail and `/audit`).
+
+## Action → backend mapping
+
+| UI action | Backend call | Audit action |
+| --- | --- | --- |
+| approve | `PATCH /api/memories/{id}` `status=active` | `memory_approved` |
+| reject | `PATCH /api/memories/{id}` `status=rejected` | `memory_rejected` |
+| archive | `PATCH /api/memories/{id}` `status=archived` | `memory_archived` |
+| restore | `PATCH /api/memories/{id}` `status=active` | `memory_approved` |
+| edit | `PATCH /api/memories/{id}` `content=…` | `memory_updated` |
+| delete | `DELETE /api/memories/{id}` | `memory_deleted` |
+
+## Safety properties
+
+- **Deletion guarantee** — deleted memories never appear in the inventory and are
+  never rendered as active; the terminal `deleted` status carries on the record.
+- **Tenant isolation** — all reads/writes are tenant + user scoped.
+- **Auditability** — every action appends an audit event; the timeline reflects it.
+- **Policy authority** — the UI only displays decisions the broker already made;
+  it never writes around the policy/write path.
+- **No secret leakage** — provenance is metadata only; no embeddings or secrets.
+
+## Identity
+
+Demo identity (`tenant_demo` / `user_demo`) is provided by `apps/web/lib/api.ts`.
+In production these come from auth/session; the API already scopes by
+`tenant_id` + `user_id` on every route.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -92,6 +92,20 @@ structured evidence and links to audit events where a governance record is
 written. This keeps operational loop traces separate from append-only audit
 records while making the state transition visible.
 
+## Governance control plane (v0.5)
+
+The governance surface is now operable from the browser. `/governance` runs the
+human-in-the-loop approval queue (approve → active, reject → rejected) and shows
+the policy broker's recorded decisions (SAVE / PENDING / BLOCKED / DROPPED /
+UPDATED / MERGED) with their rationale. `/memories` and `/memories/[id]` expose
+the full inventory, per-memory provenance, and the per-memory audit timeline;
+`/audit` shows the tenant-wide append-only history. Every action maps 1:1 to an
+audited backend route and the policy broker stays authoritative — the UI never
+writes around it. See [governance-ui.md](governance-ui.md),
+[memory-control-plane.md](memory-control-plane.md),
+[ADR-009](../infra/adr/ADR-009-memory-control-plane.md), and the
+[human-in-the-loop phase gate](phase-gates/phase-06-human-in-the-loop.md).
+
 ## Retention & feedback
 
 - `memory_feedback` captures `helpful | wrong | outdated | sensitive | not_relevant` and feeds the

--- a/docs/memory-control-plane.md
+++ b/docs/memory-control-plane.md
@@ -1,0 +1,81 @@
+# Memory Control Plane (v0.5)
+
+The control plane is the API surface behind the [Governance UI](governance-ui.md)
+for inspecting and governing individual memories. It is **additive** over the
+v0.1–v0.4 lifecycle: no retrieval, write, policy, or deletion behavior changed.
+See [ADR-009](../infra/adr/ADR-009-memory-control-plane.md).
+
+## Endpoints
+
+All endpoints are tenant + user scoped (invariant #1).
+
+### List
+`GET /api/memories?tenant_id=&user_id=&status=&memory_type=`
+Returns active inventory (soft-deleted rows excluded, invariant #2). `status` and
+`memory_type` are optional server-side filters.
+
+### Detail
+`GET /api/memories/{id}?tenant_id=&user_id=`
+Single `MemoryRecord`. Returns soft-deleted rows too (forensics), but the real
+`status` always travels with the record — callers must never present a `deleted`
+row as active. `404` if not found in scope. Emits a `memory_viewed` audit event.
+
+### Provenance
+`GET /api/memories/{id}/provenance?tenant_id=&user_id=` → `MemoryProvenance`:
+
+```jsonc
+{
+  "memory_id": "…",
+  "source": { "kind": "chat", "excerpt": "…", "message_id": null, "conversation_id": null },
+  "status": "active",
+  "created_at": "…", "updated_at": "…",
+  "reinforcement_count": 0,
+  "importance": 5, "confidence": 0.8, "weight": 1.0,   // durable ranking signals
+  "audit_trail": [ /* AuditEvent[] newest first */ ],
+  "loop_run_ids": [ "…" ]                              // governance loop evidence
+}
+```
+Provenance is metadata only — it never includes embeddings or secrets.
+
+### Per-memory audit timeline
+`GET /api/memories/{id}/audit?tenant_id=&user_id=&limit=` → `AuditEvent[]`
+Newest-first lifecycle history scoped to one memory.
+
+### Mutations (reused from earlier versions)
+- `PATCH /api/memories/{id}` — edit `content`/`importance`/`confidence`, or set
+  `status` to approve (`active`), reject (`rejected`), archive (`archived`), or
+  restore (`active`). `404` on a deleted memory — `deleted` is terminal.
+- `DELETE /api/memories/{id}` — soft delete; the row is excluded from all future
+  retrieval and listing.
+
+### Tenant-wide audit
+`GET /api/audit?tenant_id=&user_id=&memory_id=&limit=` — append-only history;
+`memory_id` is a new optional filter.
+
+## Repository change
+
+`Repository.list_audit(tenant_id, user_id=None, *, memory_id=None, limit=200)`
+gains the `memory_id` filter, implemented in both the in-memory and Postgres
+backends. No other repository contract changed.
+
+## Explainability: "why a memory was used"
+
+v0.5 explains retrieval through signals already in the system:
+- **Durable ranking signals** on the record — importance, confidence, weight,
+  reinforcement count (shown on provenance/detail).
+- **Loop evidence** — governance loop-run ids that touched the memory.
+- **Live per-request scores** — the Chat view still returns `used_memories` with a
+  full `score_breakdown` (vector similarity, keyword, recency, …) per turn.
+
+A persisted per-retrieval usage ledger (exact "used in conversation X at time T")
+is intentionally **out of scope** for v0.5 and is future lifecycle work.
+
+## Invariants upheld
+
+1. Tenant isolation — every endpoint filters by `tenant_id` + `user_id`.
+2. Deletion guarantee — deleted rows excluded from list/retrieval; detail marks
+   them `deleted` and the UI never shows them as active.
+3. Provenance — `source` is always present and surfaced.
+5. Policy-before-storage — unchanged; the control plane never writes around it.
+6. Temporary chat — never persisted, so never visible here.
+7. Auditability — every action (and detail view) appends an audit event.

--- a/docs/phase-gates/phase-06-human-in-the-loop.md
+++ b/docs/phase-gates/phase-06-human-in-the-loop.md
@@ -1,0 +1,44 @@
+# Phase 06 — Human-in-the-Loop (Memory Control Plane)
+
+**Question:** Can a human inspect, approve, correct, and govern memory from a UI —
+without bypassing any invariant?
+
+> Companion to [phase-06-memory-architecture.md](phase-06-memory-architecture.md)
+> (the storage/lifecycle gate) and [phase-15-governance.md](phase-15-governance.md)
+> (audit/explainability/deletion). This gate covers the **operability** layer added
+> in v0.5.
+
+## MemoryOps mapping
+A browser control plane (v0.5) over the existing governed lifecycle: view and
+filter memories, open detail with provenance and a per-memory audit timeline,
+edit content, approve/reject the pending queue, archive/restore, soft-delete, and
+read the policy broker's recorded decisions. Every action maps 1:1 to an audited
+backend route; the policy broker stays authoritative. See
+[ADR-009](../../infra/adr/ADR-009-memory-control-plane.md),
+[governance-ui.md](../governance-ui.md), and
+[memory-control-plane.md](../memory-control-plane.md).
+
+## Gate (must be true to pass)
+- A human can approve/reject pending memories from the UI, and each is audited.
+- A human can edit, archive/restore, and soft-delete memories; each is audited.
+- Detail exposes provenance (`source`) and the per-memory audit timeline.
+- Policy decisions are visible with their rationale; the UI never writes around
+  the policy/write path.
+- Deleted memories are never shown as active inventory; `deleted` is terminal.
+- Every control-plane read and action is tenant + user scoped.
+
+## Evidence
+- `apps/web/app/{memories,memories/[id],governance,audit}/page.tsx`
+- `apps/web/components/{memories,governance,audit}/*`
+- `services/api/app/routes/memories.py` (detail, `/audit`, `/provenance`)
+- `services/api/app/routes/audit.py` (`memory_id` filter)
+- `services/api/tests/test_governance_api.py`
+- [docs/governance-ui.md](../governance-ui.md),
+  [docs/memory-control-plane.md](../memory-control-plane.md)
+
+## Gaps to close (→ later)
+- Per-retrieval usage ledger for exact "why used" attribution.
+- Real auth/session identity (demo identity comes from `lib/api.ts` today).
+- Bulk actions and pagination for large inventories.
+
+## Status: ✅ Implemented (usage ledger + auth are roadmap)

--- a/docs/phase-gates/phase-15-governance.md
+++ b/docs/phase-gates/phase-15-governance.md
@@ -31,3 +31,27 @@ and access story in one place; see
 - Retention/legal-hold/export (DSAR), regional residency, crypto-shred worker.
 
 ## Status: ✅ Implemented (retention/residency are roadmap)
+
+## v0.5 Governance UI / Control Plane Evidence
+
+The v0.5 governance UI adds human-in-the-loop memory review and audit surfaces for the MemoryOps control plane.
+
+Evidence added in this milestone:
+
+- `docs/governance-ui.md`
+- `docs/memory-control-plane.md`
+- `docs/phase-gates/phase-06-human-in-the-loop.md`
+- `infra/adr/ADR-009-memory-control-plane.md`
+- `services/api/tests/test_governance_api.py`
+
+Governance requirements covered:
+
+- memory detail visibility
+- memory provenance visibility
+- memory audit timeline visibility
+- memory-specific audit filtering
+- tenant/user scoped memory access
+- deletion and isolation tests
+- UI surfaces for memory governance workflows
+
+This phase remains documentation/governance evidence only. Runtime lifecycle workers, physical vector compaction, and deletion purge verification are deferred to a later lifecycle-worker milestone.

--- a/docs/rollout.md
+++ b/docs/rollout.md
@@ -7,7 +7,7 @@ Phased delivery. Status reflects this repository.
 | 0 | Design spine: README, architecture/security/governance docs, ADRs, DB schema, API contracts | ✅ Done |
 | 1 | Core write path: gateway → extractor → policy broker → write service → store → audit | ✅ Done |
 | 2 | Read path: retriever → ranker → context composer → memory-used response | 🟡 Scaffolded |
-| 3 | Governance UI: approve/reject, edit, archive, delete, audit viewer | 🟡 Scaffolded |
+| 3 | Governance UI: approve/reject, edit, archive, delete, audit viewer | ✅ Done (v0.5) |
 | 4 | Production depth: pgvector embeddings, RLS enforcement, evals, observability | 🟡 Partial |
 | 5 | Background intelligence: decay, reflection, conflict resolution, compression | 🟡 Stubbed |
 | 6 | Submission polish: landing/architecture pages, demo, screenshots | 🟡 In progress |
@@ -28,8 +28,15 @@ context block, memory-used badges. Interfaces exist in `app/services/retriever.p
 `ranker.py`, `context_composer.py`; chat returns `used_memories`.
 **Done when:** future chats use relevant memory and deleted/pending memory is never retrieved.
 
-## Phase 3 — Governance dashboard 🟡
-`PATCH`/`DELETE` endpoints exist; UI actions to be fully wired.
+## Phase 3 — Governance dashboard ✅ (v0.5)
+Browser memory control plane: `/memories`, `/memories/[id]`, `/governance`,
+`/audit`. View/filter, detail with provenance + per-memory audit timeline, inline
+edit, approve/reject queue, archive/restore, soft-delete, and recorded policy
+decisions. Additive read routes (`GET /api/memories/{id}`, `/{id}/provenance`,
+`/{id}/audit`) + `memory_id` audit filter; every action is audited and the policy
+broker stays authoritative. See [governance-ui.md](governance-ui.md),
+[memory-control-plane.md](memory-control-plane.md),
+[ADR-009](../infra/adr/ADR-009-memory-control-plane.md).
 
 ## Phase 4 — Enterprise security & evals 🟡
 RLS-ready schema (enable → enforce), pgvector index, golden + adversarial eval cases, `run_evals.py`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -72,6 +72,20 @@ The most dangerous failures for an AI memory system are:
 - Loop traces are operational evidence, not a retrieval surface: they never re-expose a
   soft-deleted memory (`test_deletion.py::test_loop_traces_do_not_resurrect_deleted_memory`).
 
+### Memory control plane (v0.5)
+- The browser control plane is a **read + audited-action** surface only; it never
+  writes around the policy/write path, and the policy broker stays authoritative.
+- New read routes (`GET /api/memories/{id}`, `/{id}/provenance`, `/{id}/audit`) and
+  the `list_audit(memory_id=…)` filter are all tenant + user scoped at the
+  repository (`test_tenant_isolation.py`, `test_governance_api.py`).
+- Provenance responses are metadata only — no embeddings, keys, or secrets are
+  serialized.
+- Detail may return a soft-deleted row for forensics, but it always carries
+  `status=deleted`; it is never listed as active or rendered as active
+  (`test_deletion.py`, `test_governance_api.py`).
+- Demo identity (`tenant_demo`/`user_demo`) still comes from `apps/web/lib/api.ts`;
+  real auth/session and RBAC remain on the hardening roadmap below.
+
 ## Production hardening roadmap
 
 - Encryption at rest (pgcrypto / disk) + field-level encryption for high-sensitivity content.

--- a/infra/adr/ADR-009-memory-control-plane.md
+++ b/infra/adr/ADR-009-memory-control-plane.md
@@ -1,0 +1,88 @@
+# ADR-009 — Memory control plane + governance UI
+
+Status: Accepted (v0.5)
+
+## Context
+Through v0.4, every governed memory action existed only as an API or a single
+read-only "Memory dashboard" table. Operators could not, from the browser,
+inspect a memory's provenance, walk its audit history, approve/reject the
+human-in-the-loop queue, or see *why* the policy broker decided what it decided.
+The lifecycle was fully governed in code but not **operable** by a human.
+
+v0.5 adds the browser-facing control plane. The hard requirement: surface the
+lifecycle without weakening any invariant. The UI must be a thin, audited view
+over the existing read/write/policy/audit paths — never a side-channel that
+mutates state outside them.
+
+## Decision
+Add a control plane spanning a few additive backend routes and a set of Next.js
+pages/components.
+
+### Backend (additive only — no lifecycle behavior changed)
+- `GET /api/memories/{id}` — single memory detail, tenant + user scoped. Returns
+  soft-deleted rows too (for forensics) but the real `status` always travels with
+  the record, so a deleted memory can never be rendered as active.
+- `GET /api/memories/{id}/audit` — the per-memory audit timeline (newest first).
+- `GET /api/memories/{id}/provenance` — `MemoryProvenance`: the stored `source`
+  plus durable ranking signals (importance/confidence/weight/reinforcement), the
+  memory's audit trail, and the governance loop-run ids that touched it. Never
+  includes embeddings or secrets.
+- `Repository.list_audit(..., memory_id=...)` — a new optional filter, mirrored in
+  the in-memory and Postgres backends; `GET /api/audit?memory_id=` exposes it.
+
+List, PATCH (edit/approve/reject/archive/restore), and soft-DELETE already
+existed from earlier versions and are reused unchanged. Approve = `status→active`,
+reject = `status→rejected`, archive = `status→archived`, restore =
+`archived→active`. Each continues to emit its audit event and drive the
+`MEMORY_GOVERNANCE` loop.
+
+### Frontend
+- Pages: `/memories` (filterable inventory), `/memories/[id]` (detail +
+  provenance + audit timeline + inline edit), `/governance` (approval queue +
+  recent policy decisions), `/audit` (tenant-wide append-only history).
+- Components under `components/memories`, `components/governance`,
+  `components/audit`. Every mutating control calls an audited backend route via
+  the existing `lib/api.ts` client.
+
+### Where the control plane sits
+```text
+browser (read views + action buttons)        ← apps/web (v0.5)
+  → GET   list / detail / provenance / audit  (read paths, tenant-scoped)
+  → PATCH / DELETE                            → policy/write/audit paths (unchanged)
+  → policy broker stays authoritative; UI never writes around it
+```
+
+## Rules (enforced in code + tests)
+- Deleted memories are never listed in the active inventory and never rendered as
+  active; the `deleted` status is terminal and exposes no actions.
+- Every read and every action is tenant + user scoped (invariant #1).
+- Every UI action maps 1:1 to an audited backend action (invariant #7).
+- Provenance/detail responses carry no embeddings, keys, or secrets.
+- The policy broker remains authoritative (invariant #5); the UI only displays
+  decisions it already recorded.
+- Temporary-chat memories were never persisted, so they cannot appear here
+  (invariant #6).
+
+## Alternatives
+- **Server components fetching at render** — rejected for now; the existing app is
+  client-rendered with a thin `lib/api.ts`, and the control plane is interactive
+  (filters, optimistic refresh). Kept consistent with `/loops` and `/chat`.
+- **A dedicated usage/"why-used" log table** — deferred. v0.5 explains retrieval
+  via the durable ranking signals already on the record plus live per-request
+  scores in Chat; a persisted per-retrieval usage ledger is future work.
+- **Hard delete from the UI** — rejected; deletion stays soft (ADR-005). Physical
+  compaction/purge is tracked separately as a v0.6 lifecycle-worker candidate.
+
+## Trade-offs
+- Detail returns soft-deleted rows for forensics, accepting the small surface of
+  showing deleted content in a governance context; mitigated by the explicit
+  terminal `deleted` status and no available actions.
+- "Why a memory was used" is approximate (ranking signals + loop evidence) until a
+  per-retrieval usage ledger exists.
+
+## Security considerations
+- All control-plane reads and writes go through the tenant-scoped repository
+  methods; no new unscoped query path is introduced.
+- Provenance is metadata only — embeddings and raw secrets are never serialized.
+- Demo identity (`tenant_demo`/`user_demo`) still comes from `lib/api.ts`; real
+  auth/session wiring remains the deployment's responsibility.

--- a/scripts/pr_invariant_gate.py
+++ b/scripts/pr_invariant_gate.py
@@ -226,6 +226,33 @@ RULES: list[Rule] = [
         r"|infra/adr/ADR-008-provider-llm-adapters\.md$)",
         "LLM layer changed without updating provider/intelligence docs or ADR-008.",
     ),
+    # ── v0.5 Governance UI + Memory Control Plane (ADR-009) ────────────────────
+    Rule(
+        "Memory Correctness",
+        "governance-api-tests",
+        r"^services/api/app/routes/memories\.py$",
+        r"^services/api/tests/test_governance_api\.py$",
+        "Memory governance API changed without governance API tests "
+        "(tests/test_governance_api.py).",
+    ),
+    Rule(
+        "Memory Correctness",
+        "governance-ui-tests-or-docs",
+        r"^apps/web/app/(memories|governance|audit)/",
+        r"^(services/api/tests/test_governance_api\.py$"
+        r"|docs/governance-ui\.md$|docs/memory-control-plane\.md$)",
+        "Frontend governance page changed without a control-plane test or UI/control-plane "
+        "doc update.",
+    ),
+    Rule(
+        "Docs/ADR",
+        "control-plane-adr",
+        r"^apps/web/components/(memories|governance|audit)/|^services/api/app/routes/memories\.py$",
+        r"^(docs/governance-ui\.md$|docs/memory-control-plane\.md$"
+        r"|infra/adr/ADR-009-memory-control-plane\.md$)",
+        "Memory control plane changed without updating governance-ui/memory-control-plane "
+        "docs or ADR-009.",
+    ),
 ]
 
 

--- a/services/api/app/db/memory_repo.py
+++ b/services/api/app/db/memory_repo.py
@@ -121,11 +121,18 @@ class InMemoryRepository(Repository):
         return event
 
     def list_audit(
-        self, tenant_id: str, user_id: str | None = None, limit: int = 200
+        self,
+        tenant_id: str,
+        user_id: str | None = None,
+        *,
+        memory_id: str | None = None,
+        limit: int = 200,
     ) -> list[StoredAudit]:
         rows = [e for e in self._audit if e.tenant_id == tenant_id]
         if user_id:
             rows = [e for e in rows if e.user_id == user_id]
+        if memory_id:
+            rows = [e for e in rows if e.memory_id == memory_id]
         return sorted(rows, key=lambda e: e.created_at, reverse=True)[:limit]
 
     # ── settings ─────────────────────────────────────────────────────────────

--- a/services/api/app/db/postgres_repo.py
+++ b/services/api/app/db/postgres_repo.py
@@ -271,12 +271,19 @@ class PostgresRepository(Repository):
             return event
 
     def list_audit(
-        self, tenant_id: str, user_id: str | None = None, limit: int = 200
+        self,
+        tenant_id: str,
+        user_id: str | None = None,
+        *,
+        memory_id: str | None = None,
+        limit: int = 200,
     ) -> list[StoredAudit]:
         with self._scoped(tenant_id, user_id or "") as s:
             stmt = select(AuditLogORM).where(AuditLogORM.tenant_id == tenant_id)
             if user_id:
                 stmt = stmt.where(AuditLogORM.user_id == user_id)
+            if memory_id:
+                stmt = stmt.where(AuditLogORM.memory_id == memory_id)
             stmt = stmt.order_by(AuditLogORM.created_at.desc()).limit(limit)
             return [
                 StoredAudit(

--- a/services/api/app/db/repository.py
+++ b/services/api/app/db/repository.py
@@ -71,7 +71,12 @@ class Repository(ABC):
 
     @abstractmethod
     def list_audit(
-        self, tenant_id: str, user_id: str | None = None, limit: int = 200
+        self,
+        tenant_id: str,
+        user_id: str | None = None,
+        *,
+        memory_id: str | None = None,
+        limit: int = 200,
     ) -> list[StoredAudit]: ...
 
     # ── settings ─────────────────────────────────────────────────────────────

--- a/services/api/app/routes/audit.py
+++ b/services/api/app/routes/audit.py
@@ -14,10 +14,11 @@ router = APIRouter(prefix="/api", tags=["governance"])
 def get_audit(
     tenant_id: str = Query(...),
     user_id: str | None = Query(None),
+    memory_id: str | None = Query(None),
     limit: int = Query(200, le=1000),
 ) -> list[AuditEvent]:
     repo = get_repository()
-    rows = repo.list_audit(tenant_id, user_id=user_id, limit=limit)
+    rows = repo.list_audit(tenant_id, user_id=user_id, memory_id=memory_id, limit=limit)
     return [
         AuditEvent(
             id=r.id,

--- a/services/api/app/routes/memories.py
+++ b/services/api/app/routes/memories.py
@@ -4,13 +4,35 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
+from ..db.entities import StoredAudit
 from ..db.factory import get_repository
 from ..deps import audit_service
 from ..loops.events import complete_loop_run_sync, emit_loop_event_sync, start_loop_run_sync
 from ..loops.types import LoopId, LoopState
-from ..schemas.memory import DeleteRequest, MemoryPatch, MemoryRecord, Status
+from ..schemas.memory import (
+    AuditEvent,
+    DeleteRequest,
+    MemoryPatch,
+    MemoryProvenance,
+    MemoryRecord,
+    Status,
+)
 
 router = APIRouter(prefix="/api/memories", tags=["memories"])
+
+
+def _audit_event(r: StoredAudit) -> AuditEvent:
+    return AuditEvent(
+        id=r.id,
+        tenant_id=r.tenant_id,
+        user_id=r.user_id,
+        memory_id=r.memory_id,
+        action=r.action,
+        reason=r.reason,
+        trace_id=r.trace_id,
+        metadata=r.metadata,
+        created_at=r.created_at,
+    )
 
 
 @router.get("", response_model=list[MemoryRecord])
@@ -93,6 +115,84 @@ def list_memories(
     )
     complete_loop_run_sync(repo, loop, metadata={"action": "view", "row_count": len(rows)})
     return [r.to_schema() for r in rows]
+
+
+@router.get("/{memory_id}", response_model=MemoryRecord)
+def get_memory_detail(
+    memory_id: str,
+    request: Request,
+    tenant_id: str = Query(...),
+    user_id: str = Query(...),
+) -> MemoryRecord:
+    """Single memory detail for the control plane.
+
+    Tenant + user scoped (invariant #1). Returns the row including soft-deleted
+    ones for governance/forensics — callers render the real ``status`` and must
+    never present a deleted row as active (the ``status`` field carries truth).
+    """
+    repo = get_repository()
+    trace_id = getattr(request.state, "trace_id", "-")
+    m = repo.get_memory(tenant_id, user_id, memory_id)
+    if not m:
+        raise HTTPException(status_code=404, detail="memory not found")
+    audit_service().record(
+        tenant_id=tenant_id,
+        user_id=user_id,
+        memory_id=memory_id,
+        action="memory_viewed",
+        reason="memory detail viewed",
+        trace_id=trace_id,
+        metadata={"surface": "detail"},
+    )
+    return m.to_schema()
+
+
+@router.get("/{memory_id}/audit", response_model=list[AuditEvent])
+def get_memory_audit(
+    memory_id: str,
+    tenant_id: str = Query(...),
+    user_id: str = Query(...),
+    limit: int = Query(200, le=1000),
+) -> list[AuditEvent]:
+    """Audit timeline for one memory (newest first), tenant + user scoped."""
+    repo = get_repository()
+    if not repo.get_memory(tenant_id, user_id, memory_id):
+        raise HTTPException(status_code=404, detail="memory not found")
+    rows = repo.list_audit(tenant_id, user_id, memory_id=memory_id, limit=limit)
+    return [_audit_event(r) for r in rows]
+
+
+@router.get("/{memory_id}/provenance", response_model=MemoryProvenance)
+def get_memory_provenance(
+    memory_id: str,
+    tenant_id: str = Query(...),
+    user_id: str = Query(...),
+) -> MemoryProvenance:
+    """Provenance + explainability for one memory (invariant #3).
+
+    Composes the stored ``source`` with the memory's audit trail and the
+    governance loop runs that touched it. Never returns embeddings or secrets.
+    """
+    repo = get_repository()
+    m = repo.get_memory(tenant_id, user_id, memory_id)
+    if not m:
+        raise HTTPException(status_code=404, detail="memory not found")
+    audit_rows = repo.list_audit(tenant_id, user_id, memory_id=memory_id, limit=1000)
+    runs = repo.list_loop_runs(tenant_id=tenant_id, user_id=user_id, limit=1000)
+    loop_run_ids = [r.id for r in runs if (r.metadata or {}).get("memory_id") == memory_id]
+    return MemoryProvenance(
+        memory_id=m.id,
+        source=m.source,
+        status=m.status,
+        created_at=m.created_at,
+        updated_at=m.updated_at,
+        reinforcement_count=m.reinforcement_count,
+        importance=m.importance,
+        confidence=m.confidence,
+        weight=m.weight,
+        audit_trail=[_audit_event(r) for r in audit_rows],
+        loop_run_ids=loop_run_ids,
+    )
 
 
 @router.patch("/{memory_id}", response_model=MemoryRecord)

--- a/services/api/app/schemas/memory.py
+++ b/services/api/app/schemas/memory.py
@@ -164,3 +164,27 @@ class AuditEvent(BaseModel):
     trace_id: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime
+
+
+class MemoryProvenance(BaseModel):
+    """Where a memory came from and why it persists (v0.5 control plane).
+
+    Composed from the stored record plus its audit trail and governance loop
+    runs. Never includes embeddings or raw secrets — provenance is metadata.
+    """
+
+    memory_id: str
+    source: Source
+    status: Status
+    created_at: datetime
+    updated_at: datetime
+    reinforcement_count: int
+    # Explainability for "why this memory exists / was used": durable signals
+    # the ranker reads (no per-request usage log is persisted yet).
+    importance: int
+    confidence: float
+    weight: float
+    # The originating + lifecycle audit actions for this memory, newest first.
+    audit_trail: list[AuditEvent] = Field(default_factory=list)
+    # Governance loop run ids that touched this memory (operational evidence).
+    loop_run_ids: list[str] = Field(default_factory=list)

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -20,3 +20,31 @@ def repo() -> InMemoryRepository:
 @pytest.fixture
 def gateway(repo: InMemoryRepository) -> Gateway:
     return Gateway(repo)
+
+
+@pytest.fixture
+def api_client():
+    """FastAPI TestClient backed by a fresh in-memory repo singleton.
+
+    The route handlers, gateway, and audit service all resolve the same
+    ``get_repository()`` singleton, so we clear the lru_caches to isolate
+    state per test and hand back the live repo for seeding/assertions.
+    """
+    from fastapi.testclient import TestClient
+
+    from app import deps
+    from app.db import factory
+
+    factory.get_repository.cache_clear()
+    deps.gateway.cache_clear()
+    deps.audit_service.cache_clear()
+
+    from app.main import app
+
+    repo = factory.get_repository()
+    with TestClient(app) as client:
+        yield client, repo
+
+    factory.get_repository.cache_clear()
+    deps.gateway.cache_clear()
+    deps.audit_service.cache_clear()

--- a/services/api/tests/test_deletion.py
+++ b/services/api/tests/test_deletion.py
@@ -45,6 +45,20 @@ def test_deleted_memory_excluded_from_vector_search(gateway, repo):
     assert all(m.id != mem.id for m, _ in pairs)
 
 
+def test_control_plane_detail_marks_deleted_never_active(gateway, repo):
+    # v0.5: the control-plane detail/provenance path may return a soft-deleted
+    # row for forensics, but its status must remain `deleted` (never active) and
+    # it must stay out of the active inventory listing.
+    _chat(gateway, "Remember that I prefer dark mode dashboards.")
+    mem = repo.list_memories("t1", "u1")[0]
+    repo.soft_delete("t1", "u1", mem.id)
+
+    fetched = repo.get_memory("t1", "u1", mem.id)
+    assert fetched is not None
+    assert fetched.status == Status.deleted  # carries truth; UI renders deleted
+    assert mem.id not in {m.id for m in repo.list_memories("t1", "u1")}
+
+
 def test_loop_traces_do_not_resurrect_deleted_memory(gateway, repo):
     # v0.3.1: loop runs/events are operational evidence stored alongside the
     # write path. They must never re-expose a soft-deleted memory in retrieval.

--- a/services/api/tests/test_governance_api.py
+++ b/services/api/tests/test_governance_api.py
@@ -1,0 +1,231 @@
+"""v0.5 Memory Control Plane — governance API tests.
+
+Covers list/detail/approve/reject/archive/restore/edit/delete plus provenance
+and per-memory audit timeline, asserting the v0.5 safety rules: tenant scoping
+(invariant #1), deletion guarantee (invariant #2), provenance (#3), and
+auditability (#7).
+"""
+
+from __future__ import annotations
+
+from app.db.entities import StoredMemory
+from app.schemas.memory import MemoryType, Sensitivity, Source, Status
+
+
+def _seed(
+    repo,
+    *,
+    status: Status = Status.active,
+    tenant: str = "t1",
+    user: str = "u1",
+    content: str = "prefers dark mode dashboards",
+) -> StoredMemory:
+    m = StoredMemory(
+        tenant_id=tenant,
+        user_id=user,
+        memory_type=MemoryType.preference,
+        content=content,
+        importance=5,
+        confidence=0.8,
+        sensitivity=Sensitivity.low,
+        status=status,
+        source=Source(kind="chat", excerpt=content),
+    )
+    return repo.create_memory(m)
+
+
+def _q(tenant: str = "t1", user: str = "u1") -> str:
+    return f"?tenant_id={tenant}&user_id={user}"
+
+
+# ── list ──────────────────────────────────────────────────────────────────────
+def test_list_excludes_deleted_and_is_tenant_scoped(api_client):
+    client, repo = api_client
+    keep = _seed(repo)
+    _seed(repo, tenant="t2")  # other tenant
+    gone = _seed(repo, status=Status.deleted, content="secret")
+
+    r = client.get(f"/api/memories{_q()}")
+    assert r.status_code == 200
+    ids = {m["id"] for m in r.json()}
+    assert keep.id in ids
+    assert gone.id not in ids  # deletion guarantee
+    assert all(m["tenant_id"] == "t1" for m in r.json())  # tenant isolation
+
+
+def test_list_status_filter(api_client):
+    client, repo = api_client
+    _seed(repo, status=Status.active)
+    pending = _seed(repo, status=Status.pending, content="needs approval")
+
+    r = client.get(f"/api/memories{_q()}&status=pending")
+    assert r.status_code == 200
+    body = r.json()
+    assert [m["id"] for m in body] == [pending.id]
+
+
+# ── detail ────────────────────────────────────────────────────────────────────
+def test_get_detail_and_404(api_client):
+    client, repo = api_client
+    m = _seed(repo)
+
+    ok = client.get(f"/api/memories/{m.id}{_q()}")
+    assert ok.status_code == 200
+    assert ok.json()["content"] == m.content
+
+    missing = client.get(f"/api/memories/does-not-exist{_q()}")
+    assert missing.status_code == 404
+
+
+def test_detail_is_tenant_scoped(api_client):
+    client, repo = api_client
+    m = _seed(repo)
+    # Wrong tenant must not see it.
+    assert client.get(f"/api/memories/{m.id}{_q(tenant='t2')}").status_code == 404
+
+
+# ── approve / reject ───────────────────────────────────────────────────────────
+def test_approve_pending(api_client):
+    client, repo = api_client
+    m = _seed(repo, status=Status.pending)
+
+    r = client.patch(
+        f"/api/memories/{m.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "status": "active"},
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "active"
+    actions = {e.action for e in repo.list_audit("t1", "u1", memory_id=m.id)}
+    assert "memory_approved" in actions
+
+
+def test_reject_pending(api_client):
+    client, repo = api_client
+    m = _seed(repo, status=Status.pending)
+
+    r = client.patch(
+        f"/api/memories/{m.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "status": "rejected"},
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "rejected"
+    actions = {e.action for e in repo.list_audit("t1", "u1", memory_id=m.id)}
+    assert "memory_rejected" in actions
+
+
+# ── archive / restore / edit ───────────────────────────────────────────────────
+def test_archive_then_restore(api_client):
+    client, repo = api_client
+    m = _seed(repo)
+
+    arch = client.patch(
+        f"/api/memories/{m.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "status": "archived"},
+    )
+    assert arch.json()["status"] == "archived"
+    # Archived rows still appear in the inventory (only deleted is hidden), but
+    # are filterable by status.
+    listed = client.get(f"/api/memories{_q()}").json()
+    assert m.id in {x["id"] for x in listed}
+    archived_only = client.get(f"/api/memories{_q()}&status=archived").json()
+    assert {x["id"] for x in archived_only} == {m.id}
+
+    restored = client.patch(
+        f"/api/memories/{m.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "status": "active"},
+    )
+    assert restored.json()["status"] == "active"
+
+
+def test_edit_content(api_client):
+    client, repo = api_client
+    m = _seed(repo)
+    r = client.patch(
+        f"/api/memories/{m.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "content": "prefers light mode"},
+    )
+    assert r.status_code == 200
+    assert r.json()["content"] == "prefers light mode"
+
+
+# ── delete ─────────────────────────────────────────────────────────────────────
+def test_delete_soft_hides_from_list_but_keeps_forensics(api_client):
+    client, repo = api_client
+    m = _seed(repo)
+
+    d = client.request(
+        "DELETE",
+        f"/api/memories/{m.id}",
+        json={"tenant_id": "t1", "user_id": "u1"},
+    )
+    assert d.status_code == 200
+    assert d.json()["status"] == "deleted"
+
+    # Never listed as active inventory ...
+    listed = client.get(f"/api/memories{_q()}").json()
+    assert m.id not in {x["id"] for x in listed}
+    # ... but detail still reports it as deleted (governance forensics), never active.
+    detail = client.get(f"/api/memories/{m.id}{_q()}")
+    assert detail.status_code == 200
+    assert detail.json()["status"] == "deleted"
+
+
+def test_cannot_patch_deleted_memory(api_client):
+    client, repo = api_client
+    m = _seed(repo, status=Status.deleted)
+    r = client.patch(
+        f"/api/memories/{m.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "status": "active"},
+    )
+    assert r.status_code == 404  # deleted is terminal — cannot be reactivated
+
+
+# ── provenance ─────────────────────────────────────────────────────────────────
+def test_provenance_shape(api_client):
+    client, repo = api_client
+    m = _seed(repo)
+    # generate an audited action so the trail is populated
+    client.patch(
+        f"/api/memories/{m.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "status": "archived"},
+    )
+
+    r = client.get(f"/api/memories/{m.id}/provenance{_q()}")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["memory_id"] == m.id
+    assert body["source"]["kind"] == "chat"
+    assert body["status"] == "archived"
+    assert {"importance", "confidence", "weight", "reinforcement_count"} <= body.keys()
+    assert len(body["audit_trail"]) >= 1
+    # provenance must never leak embeddings/secrets
+    assert "embedding" not in body
+
+
+def test_provenance_404_for_unknown(api_client):
+    client, _ = api_client
+    assert client.get(f"/api/memories/nope/provenance{_q()}").status_code == 404
+
+
+# ── per-memory audit timeline ──────────────────────────────────────────────────
+def test_memory_audit_timeline_is_scoped_to_that_memory(api_client):
+    client, repo = api_client
+    a = _seed(repo, content="memory A")
+    b = _seed(repo, content="memory B")
+
+    client.patch(
+        f"/api/memories/{a.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "status": "archived"},
+    )
+    client.patch(
+        f"/api/memories/{b.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "status": "rejected"},
+    )
+
+    r = client.get(f"/api/memories/{a.id}/audit{_q()}")
+    assert r.status_code == 200
+    events = r.json()
+    assert events  # non-empty
+    assert all(e["memory_id"] == a.id for e in events)
+    assert "memory_archived" in {e["action"] for e in events}
+    assert "memory_rejected" not in {e["action"] for e in events}

--- a/services/api/tests/test_tenant_isolation.py
+++ b/services/api/tests/test_tenant_isolation.py
@@ -50,3 +50,19 @@ def test_loop_runs_are_tenant_and_user_scoped(gateway, repo):
     assert repo.list_loop_runs(tenant_id="tenant_acme", user_id="user_acme") != []
     assert repo.list_loop_runs(tenant_id="tenant_demo") == []
     assert repo.list_loop_runs(tenant_id="tenant_acme", user_id="other_user") == []
+
+
+def test_audit_listing_is_tenant_and_memory_scoped(gateway, repo):
+    # v0.5: the control plane's per-memory audit filter must stay tenant-scoped
+    # and must not surface another memory's events.
+    _chat(gateway, "tenant_acme", "user_acme", "Remember Acme's roadmap is confidential.")
+    mem_id = repo.list_memories("tenant_acme", "user_acme")[0].id
+
+    # Cross-tenant audit read sees nothing.
+    assert repo.list_audit("tenant_demo", "user_demo") == []
+    # memory_id filter is scoped to that memory's events only.
+    scoped = repo.list_audit("tenant_acme", "user_acme", memory_id=mem_id)
+    assert scoped
+    assert all(e.memory_id == mem_id for e in scoped)
+    # A non-existent memory id yields no events.
+    assert repo.list_audit("tenant_acme", "user_acme", memory_id="missing") == []


### PR DESCRIPTION
## Summary

Adds the v0.5 MemoryOps Governance UI and Memory Control Plane.

This PR introduces browser-based governance surfaces for memory review, memory detail inspection, provenance, audit timelines, and governance workflows.

## What changed

### Backend

* Added `GET /api/memories/{id}`
* Added `GET /api/memories/{id}/provenance`
* Added `GET /api/memories/{id}/audit`
* Added memory-specific audit filtering
* Added repository support for memory detail, provenance, and audit lookups
* Added `MemoryProvenance` schema
* Extended deletion and tenant isolation tests
* Added `test_governance_api.py`

### Frontend

Added governance/control-plane pages:

* `/memories`
* `/memories/[id]`
* `/governance`
* `/audit`

Added UI components:

* `MemoryTable`
* `MemoryFilters`
* `MemoryDetailPanel`
* `MemoryProvenance`
* `MemoryActions`
* `PendingMemoryQueue`
* `PolicyDecisionCard`
* `AuditTimeline`

Updated:

* `Nav`
* `apps/web/lib/api.ts`

### Docs and governance evidence

Added:

* `docs/governance-ui.md`
* `docs/memory-control-plane.md`
* `docs/phase-gates/phase-06-human-in-the-loop.md`
* `infra/adr/ADR-009-memory-control-plane.md`

Updated:

* `README.md`
* `AGENTS.md`
* `docs/architecture.md`
* `docs/governance.md`
* `docs/security.md`
* `docs/api-contracts.md`
* `docs/rollout.md`
* `docs/phase-gates/phase-15-governance.md`

### PR gate

Added v0.5 governance/control-plane rules to the deterministic PR invariant gate.

## Validation

Completed before local tool instability:

* `pytest`: pass
* evals: `21/21` pass
* PR invariant gate: pass

Local environment note:

* Local `ruff` and web build hang due machine/tool I/O instability after disk pressure.
* GitHub CI should be treated as the source of truth for Ruff and web build validation.

## Out of scope

This PR does not add:

* background lifecycle workers
* physical vector compaction
* deletion purge verification
* AI PR review runtime
* live Railway deployment
