### PR TITLE
feat: v0.7 physical deletion compaction + vector purge verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,13 +36,17 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
   (default `stub`). Powers structured extraction + conflict detection. LLM output is
   **advisory** — the policy broker stays authoritative and is never bypassed; tests need
   no API keys. See ADR-008.
-- `services/api/app/workers` — background memory lifecycle workers (v0.6). Off the chat
-  request path. Five jobs (decay, archive, deletion_verification, conflict_scan, reflection
-  — off by default) driven by `runner.py`
+- `services/api/app/workers` — background memory lifecycle workers (v0.6–v0.7). Off the chat
+  request path. Six jobs (decay, archive, deletion_compaction, deletion_verification,
+  conflict_scan, reflection — off by default) driven by `runner.py`
   (`python -m app.workers.runner --tenant T --user U --job all`). Tenant scoped, idempotent,
   retry-safe, audited; never resurrect deleted memory; the policy broker stays authoritative.
-  Hosted by the Railway `worker` service (scope enumeration is the orchestrator's job).
-  See ADR-010, `docs/background-lifecycle-workers.md`, `docs/deletion-verification.md`.
+  `deletion_compaction` (v0.7) clears soft-deleted memory's content + vector material after a
+  retention window, preserves the governance tombstone, and verifies the purge fail-closed —
+  not crypto-shred, no physical disk/index reclamation claim. Hosted by the Railway `worker`
+  service (scope enumeration is the orchestrator's job). See ADR-010, ADR-011,
+  `docs/background-lifecycle-workers.md`, `docs/deletion-compaction.md`,
+  `docs/vector-purge-verification.md`, `docs/deletion-verification.md`.
 - `services/api/app/db` — repository abstraction. `MEMORYOPS_STORAGE=memory|postgres`. Vector
   retrieval goes through `Repository.search_candidates` (pgvector on Postgres, cosine in memory).
 - `infra/db/migrations` — SQL schema (Postgres + pgvector). RLS is **enforced** in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,12 +40,17 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
   structured extraction + conflict detection. `MEMORYOPS_LLM_PROVIDER=stub|openai|anthropic|gemini`
   (default `stub`). LLM output is **advisory**: the policy broker stays authoritative
   and is never bypassed. Tests need no API keys. See ADR-008.
-- `services/api/app/workers` — background memory lifecycle workers (v0.6). Off the
-  chat request path. Five jobs: decay, archive, deletion_verification,
-  conflict_scan, reflection (off by default), driven by `runner.py`
-  (`python -m app.workers.runner --tenant T --user U --job all`). Tenant scoped,
-  idempotent, retry-safe, audited; never resurrect deleted memory; policy broker
-  stays authoritative. See ADR-010 and `docs/background-lifecycle-workers.md`.
+- `services/api/app/workers` — background memory lifecycle workers (v0.6–v0.7). Off
+  the chat request path. Six jobs: decay, archive, deletion_compaction,
+  deletion_verification, conflict_scan, reflection (off by default), driven by
+  `runner.py` (`python -m app.workers.runner --tenant T --user U --job all`).
+  Tenant scoped, idempotent, retry-safe, audited; never resurrect deleted memory;
+  policy broker stays authoritative. `deletion_compaction` (v0.7) clears
+  soft-deleted memory's content + vector material after a retention window,
+  preserves the governance tombstone, and verifies the purge fail-closed (not
+  crypto-shred / no physical disk reclamation claim). See ADR-010, ADR-011,
+  `docs/background-lifecycle-workers.md`, `docs/deletion-compaction.md`,
+  `docs/vector-purge-verification.md`.
 - `services/api/app/db` — repository abstraction. `MEMORYOPS_STORAGE=memory|postgres`. Vector
   retrieval goes through `Repository.search_candidates` (pgvector on Postgres, cosine in memory).
 - `infra/db/migrations` — SQL schema (Postgres + pgvector). RLS is **enforced** in

--- a/README.md
+++ b/README.md
@@ -337,13 +337,39 @@ MemoryOps integrates it via an adapter and does not vendor its source.
   [docs/deletion-verification.md](docs/deletion-verification.md), and
   [ADR-010](infra/adr/ADR-010-background-memory-lifecycle-workers.md).
 
-## What remains (v0.7+)
+## What works as of v0.7 (deletion compaction + vector purge verification)
 
-- Physical deletion compaction + vector-index purge / crypto-shred worker
-  (v0.6 verifies *logical* forgetting; see
-  [docs/deletion-verification.md](docs/deletion-verification.md)).
+- A sixth lifecycle job — **deletion compaction** — clears a soft-deleted memory's
+  content, normalized content, embedding/vector material, and provenance excerpt
+  (after a retention window), while **preserving the governance tombstone** (id,
+  tenant/user, `status='deleted'`, `deleted_at`, `source.kind`) and the full audit
+  trail. Run it with
+  `python -m app.workers.runner --tenant t1 --user u1 --job deletion_compaction`.
+- The purge is **verified fail-closed**: a still-reachable id, intact material, a
+  missing tombstone, or a verification-path error all record evidence and flag the
+  run — never a silent pass.
+- Honest scope: this is **auditable content/vector compaction + retrieval-exclusion
+  verification**. It is **not** crypto-shred and does **not** claim physical
+  disk/page erasure or pgvector reindex orchestration.
+- See [docs/deletion-compaction.md](docs/deletion-compaction.md),
+  [docs/vector-purge-verification.md](docs/vector-purge-verification.md), and
+  [ADR-011](infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md).
+
+## Roadmap
+
+- **v0.7** — physical deletion compaction + vector purge verification ✅
+- **v0.8** — Railway worker runtime + scheduled lifecycle orchestration
+- **v0.9** — retention policies + legal hold + consent-aware memory
+- **v0.10** — assistant SDK + example apps
+- **v1.0** — production-ready governed memory runtime
+
+## What remains (v0.8+)
+
+- Scheduled worker runtime with locks/leases, retries, and run history (v0.8).
+- Hard purge / crypto-shred and pgvector index reclamation (beyond v0.7's
+  auditable compaction).
 - Governed reflection write path; cross-tenant scope enumeration for fleet scheduling.
-- v0.7+: observability + economics, AI PR review runtime, deployment hardening.
+- Observability + economics, AI PR review runtime, deployment hardening.
 
 See [docs/rollout.md](docs/rollout.md) and the build phases in [CLAUDE.md](CLAUDE.md).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -340,6 +340,9 @@ one `(tenant_id, user_id)` scope:
 - **conflict_scan** — reuse v0.4 advisory conflict detection across the corpus to
   produce review candidates (no overwrite);
 - **reflection** — proposal-only, off by default (no write/delete);
+- **deletion_compaction** (v0.7) — clear a soft-deleted memory's content + vector
+  material after a retention window, preserve the governance tombstone, and verify
+  the purge fail-closed;
 - **deletion_verification** — read-only confirmation that deleted memory is
   unreachable, with pass/fail evidence.
 
@@ -349,8 +352,10 @@ authoritative — workers demote/flag/propose only). A worker failure is caught 
 recorded (`lifecycle_worker_failed`), never raised into a caller, so it cannot
 block chat. Workers add no HTTP route; they run via
 `python -m app.workers.runner` (hosted by the Railway `worker` service). See
-[ADR-010](../infra/adr/ADR-010-background-memory-lifecycle-workers.md) and
-[background-lifecycle-workers.md](background-lifecycle-workers.md).
+[ADR-010](../infra/adr/ADR-010-background-memory-lifecycle-workers.md),
+[ADR-011](../infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md),
+[background-lifecycle-workers.md](background-lifecycle-workers.md), and
+[deletion-compaction.md](deletion-compaction.md).
 
 ## Failure modes considered
 

--- a/docs/background-lifecycle-workers.md
+++ b/docs/background-lifecycle-workers.md
@@ -24,10 +24,15 @@ close that gap without weakening any invariant.
 | `archive` | Set stale, not-recently-used, non-pinned memory to `archived` | yes (status) | on |
 | `conflict_scan` | Flag contradicting memories as review candidates (advisory) | no | on |
 | `reflection` | Propose consolidation of low-importance clusters | no | **off** |
+| `deletion_compaction` | Clear soft-deleted memory's content + vector material; preserve tombstone; verify purge | yes (clears deleted payload) | on |
 | `deletion_verification` | Confirm deleted memory is unreachable; record evidence | no | on |
 
 `all` runs them in a deliberate order: mutating jobs first, then `reflection`,
-then read-only `deletion_verification` last so it observes the final state.
+then `deletion_compaction` (which clears already-deleted payload), then read-only
+`deletion_verification` last so it observes the final state. `deletion_compaction`
+only ever touches `status='deleted'` rows and preserves the governance tombstone —
+see [deletion-compaction.md](deletion-compaction.md) and
+[vector-purge-verification.md](vector-purge-verification.md) (v0.7, ADR-011).
 
 ## Operating principles (enforced in code + tests)
 
@@ -98,6 +103,7 @@ Thresholds are `Settings.workers_*` (see `app/core/config.py`):
 | `workers_reflection_enabled` | `false` | enable reflection proposals |
 | `workers_reflection_min_cluster_size` | 5 | min cluster to propose consolidation |
 | `workers_reflection_max_importance` | 3 | only cluster memory at/below this importance |
+| `workers_compaction_min_age_days` | 0 | min days since `deleted_at` before a deleted memory is compaction-eligible |
 
 `MEMORYOPS_WORKERS_REFLECTION=1` is the public toggle for reflection.
 
@@ -117,6 +123,8 @@ introduced by v0.6.
   deferred.
 - Cross-tenant scope enumeration is the orchestrator's responsibility; there is
   no repository method that lists all scopes yet.
-- Deletion verification covers **logical** forgetting only; physical vector
-  compaction / crypto-shred is staged — see
-  [deletion-verification.md](deletion-verification.md).
+- Deletion compaction (v0.7) clears deleted memory's content + vector material and
+  verifies the purge, but it is **not** crypto-shred and does **not** claim
+  physical disk/page erasure or pgvector index reclamation — see
+  [deletion-compaction.md](deletion-compaction.md) and
+  [vector-purge-verification.md](vector-purge-verification.md).

--- a/docs/deletion-compaction.md
+++ b/docs/deletion-compaction.md
@@ -1,0 +1,92 @@
+# Deletion Compaction — Clearing Deleted Memory's Content + Vector Material (v0.7)
+
+> Part of the [background lifecycle workers](background-lifecycle-workers.md).
+> Decision record: [ADR-011](../infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md).
+> See also: [deletion-verification.md](deletion-verification.md),
+> [vector-purge-verification.md](vector-purge-verification.md),
+> [security.md](security.md), [governance.md](governance.md).
+
+v0.6 proved **logical** deletion: a `status='deleted'` memory is unreachable
+(invariant #2). v0.7 adds the next layer — the **deletion compaction worker**
+clears the deleted memory's retrievable content and vector material, preserves the
+governance tombstone, and records audit evidence for every step.
+
+## What it does
+
+For each soft-deleted memory in a `(tenant_id, user_id)` scope that is past its
+retention/grace window (`workers_compaction_min_age_days`), the worker:
+
+1. compacts the row via `Repository.compact_deleted_memory`;
+2. emits `memory_content_compacted` and `memory_vector_purge_attempted`;
+3. **verifies** the purge (`verify_purged`, see
+   [vector-purge-verification.md](vector-purge-verification.md));
+4. on success emits `memory_vector_purge_verified` +
+   `memory_purge_tombstone_preserved`; on failure emits
+   `memory_vector_purge_failed` and the run is `completed_with_findings`.
+
+It only ever touches `status='deleted'` rows. Active and archived (not-deleted)
+memory is never compacted; deleted memory is never resurrected.
+
+## Cleared vs preserved
+
+| Cleared (payload) | Preserved (governance tombstone) |
+|--|--|
+| `content`, `normalized_content` | memory id |
+| embedding / vector material | `tenant_id`, `user_id` |
+| `source.excerpt` (content excerpt) | `status` (stays `deleted`), `deleted_at`, `created_at` |
+| | `source.kind` (provenance, invariant #3) |
+| | full audit trail + `metadata.compaction.*` marker |
+
+> Compaction must never destroy governance evidence. The row remains as a
+> content-free tombstone: you can still prove *that* a memory existed and *when /
+> why* it was deleted — you just can't read *what* it said.
+
+## Eligibility
+
+- status must be `deleted`;
+- deleted for at least `workers_compaction_min_age_days` (default `0`);
+- not already compacted (the repository filters those out → **idempotent**).
+
+## Running
+
+```bash
+cd services/api
+# compaction only, one scope
+.venv/bin/python -m app.workers.runner --tenant t1 --user u1 --job deletion_compaction
+# dry run: count eligible candidates, clear nothing
+.venv/bin/python -m app.workers.runner --tenant t1 --user u1 --job deletion_compaction --dry-run
+```
+
+`all` runs compaction **before** deletion verification so verification observes
+the compacted state. The CLI exits non-zero if any purge fails to verify.
+
+## Configuration
+
+| Setting | Default | Meaning |
+|---------|---------|---------|
+| `workers_compaction_min_age_days` | 0 | min days since `deleted_at` before a deleted memory is compaction-eligible (retention/grace window) |
+
+## Guarantees (enforced in code + tests)
+
+- **Tenant scoped** (invariant #1) — only the given scope is read/written.
+- **Idempotent + retry-safe** — re-running compacts nothing already compacted and
+  never corrupts the tombstone; a failed compaction can be retried safely.
+- **Never resurrects / reactivates** (invariant #2) — status stays `deleted`.
+- **Policy broker stays authoritative** — compaction is destructive-of-payload
+  only; it never creates or promotes memory.
+- **Audited, content-free** (invariant #7) — ids/counts/flags only, never the
+  cleared content.
+- **Never blocks chat** (invariant #4) — off the request path; failures are caught.
+
+## Limitations (kept honest)
+
+v0.7 is **auditable content/vector compaction + verification**. It is **not**:
+
+- cryptographic erasure (crypto-shred);
+- guaranteed physical disk / database-page byte reclamation;
+- pgvector ANN-index reindex / `VACUUM` orchestration;
+- a destructive hard `DELETE` (the tombstone is deliberately kept).
+
+See [vector-purge-verification.md](vector-purge-verification.md) for exactly what
+"purge" is verified at the application + repository level, and ADR-011 for the
+boundary between what we clear and what the storage engine owns.

--- a/docs/deletion-verification.md
+++ b/docs/deletion-verification.md
@@ -40,23 +40,26 @@ Audit metadata is content-free: memory ids, surface names, and counts only.
 |--|--|--|
 | Mechanism | `status='deleted'` soft delete; repository excludes from all reads | Remove the row and its vector from storage / the ANN index |
 | Guarantee | Never retrieved (invariant #2) | Bytes no longer present |
-| Verified by | **this worker** | a future compaction / crypto-shred worker |
-| Reversible | Yes (forensics/audit can still see it) | No (by design) |
+| Verified by | **this worker** | the [deletion compaction worker](deletion-compaction.md) (v0.7) |
+| Reversible | Yes (forensics/audit can still see it) | No — payload cleared (tombstone kept) |
 
-v0.6 verifies **logical** forgetting. It deliberately does **not** perform
-destructive row/index surgery: ANN index compaction and cryptographic erasure are
-operationally risky and are staged for a later milestone.
+v0.6 verifies **logical** forgetting. v0.7 adds **content/vector compaction** on
+top of it (see below). Neither claims cryptographic erasure or physical disk/page
+byte reclamation — those remain staged.
 
-## Future: vector compaction / crypto-shred worker
+## v0.7: deletion compaction + vector purge verification
 
-A later milestone will add a worker that, after logical deletion has been verified
-stable for a retention window, physically purges deleted rows and compacts the
-pgvector index — or, for the strongest guarantee, crypto-shreds per-tenant
-encryption keys so deleted ciphertext is unrecoverable. That worker will:
+The [deletion compaction worker](deletion-compaction.md) now clears a soft-deleted
+memory's content + vector material (after a retention window), preserves the
+governance tombstone + audit trail, and **verifies** the purge fail-closed (see
+[vector-purge-verification.md](vector-purge-verification.md)). It:
 
-- run only on rows already confirmed logically deleted and out of retention;
-- be tenant scoped, idempotent, and fully audited (`memory_purged`, `index_compacted`);
-- never run on the chat path.
+- runs only on rows already `status='deleted'` and past retention;
+- is tenant scoped, idempotent, and fully audited (`memory_content_compacted`,
+  `memory_vector_purge_verified`, `memory_purge_tombstone_preserved`, …);
+- never resurrects deleted memory and never runs on the chat path.
 
-Until then, deletion verification is the auditable bridge: deleted memory is
-provably unreachable, with evidence on every run.
+Logical verification (this worker) + compaction verification (v0.7) together are
+the auditable bridge: deleted memory is provably unreachable **and** its payload is
+provably cleared, with evidence on every run. Crypto-shred and physical
+disk/index reclamation remain future work (ADR-011).

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -121,6 +121,22 @@ is a *review candidate*, not an automatic change. See
 [background-lifecycle-workers.md](background-lifecycle-workers.md) and
 [ADR-010](../infra/adr/ADR-010-background-memory-lifecycle-workers.md).
 
+## Deletion compaction (v0.7)
+
+Forgetting is governed end to end. After logical deletion is verified, the
+**deletion compaction worker** clears a soft-deleted memory's content + vector
+material and records the purge as audit evidence:
+`deletion_compaction_started/completed/failed/skipped`, `memory_content_compacted`,
+`memory_vector_purge_attempted/verified/failed`, and
+`memory_purge_tombstone_preserved`. The governance **tombstone is preserved** —
+the row stays as a content-free record of *that*, *when*, and *why* a memory was
+deleted, with its audit trail intact — so compaction never destroys governance
+evidence. Verification is fail-closed. Honest scope: this is not crypto-shred or
+guaranteed physical erasure. See
+[deletion-compaction.md](deletion-compaction.md),
+[vector-purge-verification.md](vector-purge-verification.md), and
+[ADR-011](../infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md).
+
 ## Retention & feedback
 
 - `memory_feedback` captures `helpful | wrong | outdated | sensitive | not_relevant` and feeds the

--- a/docs/phase-gates/phase-13-deletion-compaction-vector-purge.md
+++ b/docs/phase-gates/phase-13-deletion-compaction-vector-purge.md
@@ -1,0 +1,54 @@
+# Phase 13 (addendum) — Deletion Compaction + Vector Purge Verification
+
+> Companion to [phase-12-background-lifecycle-workers.md](phase-12-background-lifecycle-workers.md)
+> and [phase-11-security.md](phase-11-security.md). v0.7 extends the *Forget* arc
+> from logical deletion verification to auditable content/vector compaction.
+> Decision record:
+> [ADR-011](../../infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md).
+
+**Question:** Once memory is soft-deleted and proven unreachable, how is its
+content + vector material actually *cleared* — with evidence, without destroying
+governance metadata, and without overclaiming physical/crypto erasure?
+
+## MemoryOps mapping
+A sixth lifecycle job — **deletion compaction** (`services/api/app/workers/
+deletion_compaction.py`) — clears the content, normalized content, embedding/vector
+material, and provenance excerpt of soft-deleted memory past a retention window,
+preserving the governance tombstone (id, tenant/user, `status='deleted'`,
+`deleted_at`, `source.kind`, audit trail). A fail-closed verifier
+(`workers/vector_purge.py`) then proves the memory is unreachable and the material
+was cleared. Additive repository methods (`list_deleted_for_compaction`,
+`compact_deleted_memory`) keep the change isolated. See
+[deletion-compaction.md](../deletion-compaction.md),
+[vector-purge-verification.md](../vector-purge-verification.md).
+
+## Gate (must be true to pass)
+- Only `status='deleted'` rows are compacted; active/archived memory is never
+  touched (invariant #1) and deleted memory is never resurrected/reactivated
+  (invariant #2).
+- Compaction clears retrievable content + vector material and clears the
+  provenance excerpt, while preserving the tombstone + audit trail.
+- Purge verification is **fail-closed**: reachable id, intact material, missing
+  tombstone, or a verification-path error all yield `fail`.
+- Compaction is tenant scoped, idempotent, and retry-safe (a re-run compacts
+  nothing already compacted; a failed run can complete on retry).
+- Every step writes content-free audit evidence (invariant #7); the policy broker
+  is never bypassed.
+- Workers never run on the chat path; failures are caught, never raised
+  (invariant #4).
+- Claims stay honest: **no** crypto-shred, **no** guaranteed physical disk/page
+  erasure, **no** pgvector reindex orchestration, **no** cross-tenant scheduler.
+
+## Evidence
+- `services/api/app/workers/deletion_compaction.py`, `workers/vector_purge.py`
+- `services/api/app/workers/schemas.py` (compaction job, audit events,
+  `PurgeVerification`), `workers/metrics.py` (`summarize_compaction_results`)
+- `services/api/app/db/{repository,memory_repo,postgres_repo,entities}.py`
+  (`list_deleted_for_compaction`, `compact_deleted_memory`, `apply_compaction`)
+- `services/api/tests/test_deletion_compaction_worker.py`,
+  `test_vector_purge_verification.py`
+- `services/api/tests/test_deletion.py`, `test_tenant_isolation.py`
+  (repo-level compaction safety)
+- `scripts/pr_invariant_gate.py` (deletion-compaction / vector-purge evidence rules)
+
+## Status: ✅ Implemented (v0.7)

--- a/docs/rollout.md
+++ b/docs/rollout.md
@@ -54,6 +54,28 @@ policy broker stays authoritative. Conflict resolution and reflection remain
 [deletion-verification.md](deletion-verification.md),
 [ADR-010](../infra/adr/ADR-010-background-memory-lifecycle-workers.md).
 
+## Phase 5 (cont.) — Deletion compaction + vector purge ✅ (v0.7)
+A sixth lifecycle job, **deletion compaction**, clears soft-deleted memory's
+content + vector material after a retention window, preserves the governance
+tombstone + audit trail, and **verifies** the purge fail-closed. Additive
+repository methods (`list_deleted_for_compaction`, `compact_deleted_memory`) keep
+it isolated. Honest scope: auditable content/vector compaction + retrieval-exclusion
+verification — **not** crypto-shred or guaranteed physical disk/index reclamation.
+See [deletion-compaction.md](deletion-compaction.md),
+[vector-purge-verification.md](vector-purge-verification.md),
+[phase-gates/phase-13-deletion-compaction-vector-purge.md](phase-gates/phase-13-deletion-compaction-vector-purge.md),
+[ADR-011](../infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md).
+
+## Public roadmap
+
+| Version | Scope | Status |
+|---------|-------|--------|
+| v0.7 | Physical deletion compaction + vector purge verification | ✅ Done |
+| v0.8 | Railway worker runtime + scheduled lifecycle orchestration | ⏳ Next |
+| v0.9 | Retention policies + legal hold + consent-aware memory | ⏳ Planned |
+| v0.10 | Assistant SDK + example apps | ⏳ Planned |
+| v1.0 | Production-ready governed memory runtime | ⏳ Planned |
+
 ## Production roadmap (beyond hackathon)
 
 - Swap heuristic LLM/embeddings for provider adapters (OpenAI/Anthropic/Gemini).

--- a/docs/security.md
+++ b/docs/security.md
@@ -97,13 +97,35 @@ The most dangerous failures for an AI memory system are:
   `test_deletion_verification_worker.py`).
 - **Deletion verification** continuously confirms soft-deleted memory is absent
   from active retrieval, default listing, and the vector candidate path, recording
-  pass/fail evidence (invariant #2). This verifies **logical** forgetting; physical
-  vector purge / crypto-shred is staged — see
+  pass/fail evidence (invariant #2). This verifies **logical** forgetting — see
   [deletion-verification.md](deletion-verification.md).
 - A worker failure can never block chat: exceptions are caught and recorded as
   `lifecycle_worker_failed`, never raised into a caller (invariant #4).
 - Worker audit metadata is content-free (ids / counts / flags only). Reflection is
   proposal-only and **disabled by default**.
+
+### Deletion compaction + vector purge verification (v0.7)
+- The **deletion compaction worker** clears a soft-deleted memory's `content`,
+  normalized content, embedding/vector material, and provenance excerpt after a
+  retention window, while preserving the governance tombstone (id, tenant/user,
+  `status='deleted'`, `deleted_at`, `source.kind`) and the full audit trail
+  (`test_deletion_compaction_worker.py`, `test_deletion.py`).
+- Only `status='deleted'` rows are ever compacted; active/archived memory is never
+  touched and deleted memory is never resurrected/reactivated (invariants #1, #2).
+- The purge is **verified fail-closed**: a still-reachable id, intact material, a
+  missing tombstone, or a verification-path error all record
+  `memory_vector_purge_failed` and flag the run — never a silent pass
+  (`test_vector_purge_verification.py`).
+- Every step is audited content-free: `deletion_compaction_started/completed/
+  failed/skipped`, `memory_content_compacted`, `memory_vector_purge_attempted/
+  verified/failed`, `memory_purge_tombstone_preserved`.
+- **Honest boundary.** v0.7 is auditable content/vector compaction +
+  retrieval-exclusion verification at the application + repository level. It is
+  **not** crypto-shred, does **not** guarantee physical disk/database-page byte
+  erasure, and does **not** orchestrate pgvector reindex/`VACUUM`. See
+  [deletion-compaction.md](deletion-compaction.md),
+  [vector-purge-verification.md](vector-purge-verification.md), and
+  [ADR-011](../infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md).
 
 ## Production hardening roadmap
 

--- a/docs/vector-purge-verification.md
+++ b/docs/vector-purge-verification.md
@@ -1,0 +1,65 @@
+# Vector / Content Purge Verification (v0.7)
+
+> Part of [deletion compaction](deletion-compaction.md).
+> Decision record: [ADR-011](../infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md).
+> Code: `services/api/app/workers/vector_purge.py`.
+
+Compaction *clears* a deleted memory's content + vector material. Verification
+*proves* it. `verify_purged` answers, for one compacted memory:
+
+1. Can it still appear in **active retrieval** (`retrieve_active`)?
+2. Can it still appear in the **default listing** (`list_memories`)?
+3. Can it still appear in the **vector candidate path** (`search_candidates`)?
+4. Is its retrievable **content** actually cleared?
+5. Is its **vector material** actually cleared?
+6. Is the **governance tombstone** still present?
+
+## Outcomes
+
+| Result | Meaning |
+|--------|---------|
+| `pass` | absent from all surfaces; content + vector cleared; tombstone present |
+| `fail` | reachable on a surface, OR material not cleared, OR tombstone missing, OR the verification path itself errored |
+| `skipped` | not applicable |
+| `not_supported` | backend genuinely cannot clear vector material (reserved; neither shipped backend hits this) |
+
+## Fail-closed
+
+Verification never silently passes. If a deleted/compacted id is still reachable,
+if the content or embedding is still present, if the tombstone vanished, or if the
+verification code path raises, the result is **`fail`**. The compaction worker
+turns a `fail` into a `memory_vector_purge_failed` audit event and marks the run
+`completed_with_findings` (the runner then exits non-zero).
+
+## What "purge" honestly means here
+
+This is the important, enterprise-safe distinction:
+
+> **MemoryOps verifies application-level vector-candidate exclusion and
+> repository-level vector/content material clearing.** Full database physical
+> storage reclamation (page-level overwrite, ANN-index compaction) depends on the
+> database / index engine and is documented as out of scope.
+
+What is verified:
+
+- **Application-level retrieval exclusion** — the id cannot surface through any
+  repository read path a caller could use.
+- **Repository-level material clearing** — `content`/`normalized_content` are
+  empty, the embedding is empty (`[]` in-memory) / `NULL` (Postgres vector column),
+  and the provenance excerpt is cleared.
+
+What is **not** claimed:
+
+- physical disk / database-page byte erasure;
+- pgvector index storage reclamation (`VACUUM` / reindex);
+- cryptographic erasure.
+
+That boundary is deliberate and stated so the deletion claim stays precise. See
+[deletion-compaction.md](deletion-compaction.md) and ADR-011.
+
+## Tests
+
+- `services/api/tests/test_vector_purge_verification.py` — pass, reachable-fail,
+  content-not-cleared-fail, missing-tombstone-fail, fail-closed-on-error.
+- `services/api/tests/test_deletion_compaction_worker.py` — end-to-end compaction
+  + verification, leak detection, idempotency, tenant isolation.

--- a/infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md
+++ b/infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md
@@ -1,0 +1,97 @@
+# ADR-011 — Physical Deletion Compaction + Vector-Index Purge Verification
+
+- Status: Accepted (v0.7)
+- Date: 2026-06-22
+- Supersedes: none
+- Related: ADR-005 (deletion guarantee), ADR-006 (pgvector + RLS retrieval),
+  ADR-010 (background lifecycle workers)
+
+## Context
+
+v0.6 proves **logical** deletion: a `status='deleted'` memory is unreachable from
+active retrieval, default listing, and the vector candidate path, and the deletion
+verification worker records auditable evidence of that on every run. But the row's
+**bytes are still present** — its content, its embedding/vector material, and its
+provenance excerpt all remain in storage. The strongest critique of any memory
+system is exactly this: "you *hide* deleted memory, you don't *clear* it."
+
+We want a precise, defensible claim:
+
+> Soft-deleted memory remains unreachable, its retrievable content + vector
+> material are cleared where supported, the purge is verified, the governance
+> tombstone is preserved, and every step is recorded as audit evidence.
+
+…without overclaiming cryptographic erasure or physical disk-page reclamation,
+which depend on the storage/index engine.
+
+## Decision
+
+Add a sixth lifecycle job — **deletion compaction** — plus a **vector purge
+verification** layer, both additive and off the chat path.
+
+### Compaction (what changes)
+
+For each soft-deleted memory past a retention/grace window
+(`workers_compaction_min_age_days`), the repository clears, in place:
+
+- `content`, `normalized_content`
+- the embedding / vector material (in-memory → `[]`; Postgres → vector column
+  `NULL`)
+- `source.excerpt` (content-bearing provenance excerpt)
+
+and **preserves the tombstone**: memory id, `tenant_id`/`user_id`, `status`
+(stays `deleted`), `deleted_at`, `created_at`, `source.kind`, plus the full audit
+trail. A content-free marker (`metadata.compaction.*`) records `compacted`,
+`compacted_at`, `reason`, and `purge_status`.
+
+### Verification (what is proven)
+
+After compaction, `verify_purged` confirms — **fail-closed** — that the id is
+absent from every reachable surface and that content + vector material are
+actually cleared and the tombstone is present. Outcomes: `pass`, `fail`,
+`skipped`, `not_supported`. A reachable id, intact material, a missing tombstone,
+or an error in the verification path itself all yield `fail` — never a silent pass.
+
+### Audit events (content-free)
+
+`deletion_compaction_started/completed/failed/skipped`, `memory_content_compacted`,
+`memory_vector_purge_attempted/verified/failed`, `memory_purge_tombstone_preserved`.
+
+### Repository surface (additive only)
+
+`list_deleted_for_compaction` (deleted rows; excludes already-compacted →
+idempotent) and `compact_deleted_memory` (no-op-returns-`None` for any row whose
+status is not `deleted`). No destructive hard delete; row identity is preserved.
+
+## Honest scope (what this is NOT)
+
+- **Not crypto-shred.** No per-tenant key destruction.
+- **Not guaranteed physical disk/page erasure.** Clearing a column does not
+  guarantee the database overwrote the underlying pages; that is engine-dependent.
+- **Not pgvector reindex/`VACUUM` orchestration.** We clear the vector value; ANN
+  index storage reclamation is a separate DBA operation.
+- **Not a cross-tenant scheduler.** Scope enumeration stays the orchestrator's job
+  (ADR-010).
+
+The accurate claim is *auditable content/vector compaction + retrieval-exclusion
+verification with tombstone preservation* — application-level and
+repository-level, documented precisely in `docs/vector-purge-verification.md`.
+
+## Alternatives considered
+
+- **Hard `DELETE` of the row.** Rejected: destroys governance evidence (who/when/
+  why it was deleted) and the deletion verification trail. Compaction keeps the
+  tombstone; a later milestone can stage true hard purge / crypto-shred.
+- **Compact on the deletion request path.** Rejected: adds latency to a governed
+  action and removes the retention window; compaction belongs off-path with the
+  other lifecycle workers.
+- **Trust the soft-delete column flip without verification.** Rejected: the whole
+  point of v0.7 is *evidence*. Verification is fail-closed.
+
+## Consequences
+
+- Stronger, precise public deletion story; no change to the chat path.
+- The runner gains a `deletion_compaction` job; `all` runs it before deletion
+  verification so verification observes the compacted state.
+- Future work: governed hard purge / crypto-shred, pgvector index compaction
+  automation, and fleet-wide scheduling (v0.8 — Railway worker runtime).

--- a/scripts/pr_invariant_gate.py
+++ b/scripts/pr_invariant_gate.py
@@ -259,7 +259,8 @@ RULES: list[Rule] = [
         "worker-tests",
         r"^services/api/app/workers/",
         r"^services/api/tests/test_(lifecycle_worker|decay_worker|archive_worker"
-        r"|deletion_verification_worker|conflict_scan_worker|worker_idempotency)\.py$",
+        r"|deletion_verification_worker|deletion_compaction_worker|conflict_scan_worker"
+        r"|worker_idempotency)\.py$",
         "Background worker code changed without worker tests (tests/test_*_worker.py "
         "or test_worker_idempotency.py).",
     ),
@@ -298,8 +299,61 @@ RULES: list[Rule] = [
         "worker-runner-evidence",
         r"^services/api/app/workers/runner\.py$",
         r"^(docs/phase-gates/phase-12-background-lifecycle-workers\.md$"
-        r"|infra/adr/ADR-010-background-memory-lifecycle-workers\.md$)",
-        "Background worker runner changed without phase-gate or ADR-010 evidence.",
+        r"|infra/adr/ADR-010-background-memory-lifecycle-workers\.md$"
+        r"|docs/phase-gates/phase-13-deletion-compaction-vector-purge\.md$"
+        r"|infra/adr/ADR-011-physical-deletion-compaction-vector-purge\.md$)",
+        "Background worker runner changed without phase-gate or ADR evidence.",
+    ),
+    # ── v0.7 Physical deletion compaction + vector purge verification (ADR-011) ─
+    Rule(
+        "Security",
+        "deletion-compaction-tests",
+        r"^services/api/app/workers/deletion_compaction\.py$",
+        r"^services/api/tests/test_deletion_compaction_worker\.py$",
+        "Deletion compaction worker changed without deletion-compaction worker tests.",
+    ),
+    Rule(
+        "Security",
+        "vector-purge-verification-tests",
+        r"^services/api/app/workers/vector_purge\.py$",
+        r"^services/api/tests/test_vector_purge_verification\.py$",
+        "Vector purge verification changed without vector-purge verification tests.",
+    ),
+    Rule(
+        "Security",
+        "compaction-repo-security-docs",
+        r"^services/api/app/db/(repository|memory_repo|postgres_repo|entities)\.py$",
+        r"^(docs/security\.md$|docs/governance\.md$|SECURITY\.md$)",
+        "Repository deletion/compaction methods changed without updating security or "
+        "governance docs.",
+    ),
+    Rule(
+        "Security",
+        "deletion-compaction-security-docs",
+        r"^services/api/app/workers/deletion_compaction\.py$|^services/api/app/workers/vector_purge\.py$",
+        r"^(docs/deletion-compaction\.md$|docs/vector-purge-verification\.md$"
+        r"|docs/security\.md$|docs/deletion-verification\.md$)",
+        "Deletion compaction / vector purge changed without updating deletion/security docs.",
+    ),
+    Rule(
+        "Docs/ADR",
+        "deletion-compaction-adr",
+        r"^services/api/app/workers/deletion_compaction\.py$|^services/api/app/workers/vector_purge\.py$",
+        r"^(infra/adr/ADR-011-physical-deletion-compaction-vector-purge\.md$"
+        r"|docs/phase-gates/phase-13-deletion-compaction-vector-purge\.md$)",
+        "Physical deletion compaction semantics changed without ADR-011 or phase-13 gate "
+        "evidence.",
+    ),
+    Rule(
+        "Docs/ADR",
+        "compaction-audit-governance-docs",
+        r"^services/api/app/workers/schemas\.py$",
+        r"^(docs/background-lifecycle-workers\.md$|docs/governance\.md$"
+        r"|docs/deletion-compaction\.md$|docs/security\.md$"
+        r"|infra/adr/ADR-010-background-memory-lifecycle-workers\.md$"
+        r"|infra/adr/ADR-011-physical-deletion-compaction-vector-purge\.md$)",
+        "Worker audit/event schema changed without updating lifecycle/governance/security "
+        "or deletion-compaction docs / an ADR.",
     ),
 ]
 

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -75,6 +75,12 @@ class Settings(BaseSettings):
     workers_reflection_enabled: bool = False
     workers_reflection_min_cluster_size: int = 5
     workers_reflection_max_importance: int = 3
+    # Deletion compaction (v0.7, ADR-011). Only already soft-deleted memory is
+    # eligible, and only after it has been deleted for at least this many days
+    # (a retention/grace window before retrievable content + vector material are
+    # cleared). Default 0 = eligible as soon as it is deleted. Compaction never
+    # touches active/archived rows and never resurrects deleted memory.
+    workers_compaction_min_age_days: int = 0
 
     # Reliability knobs (used by core.reliability).
     llm_timeout_seconds: float = 8.0

--- a/services/api/app/db/entities.py
+++ b/services/api/app/db/entities.py
@@ -63,6 +63,51 @@ class StoredMemory:
         )
 
 
+# ── Deletion compaction (v0.7, ADR-011) ──────────────────────────────────────
+# Where the content-free compaction tombstone lives on a memory's metadata.
+COMPACTION_META_KEY = "compaction"
+
+
+def is_compacted(memory: StoredMemory) -> bool:
+    """True once a deleted memory's content + vector material have been cleared."""
+    meta = memory.metadata.get(COMPACTION_META_KEY)
+    return bool(isinstance(meta, dict) and meta.get("compacted"))
+
+
+def apply_compaction(
+    memory: StoredMemory,
+    *,
+    reason: str,
+    now: datetime,
+    vector_supported: bool = True,
+) -> None:
+    """Compact a *soft-deleted* memory in place (callers must check status first).
+
+    Clears the retrievable/sensitive payload — content, normalized content, the
+    embedding/vector material, and the provenance excerpt — while preserving the
+    governance tombstone: id, tenant/user, status (``deleted``), ``deleted_at``,
+    ``created_at``, and ``source.kind``. The audit trail lives separately and is
+    never touched. Idempotent: re-running clears already-clear fields and rewrites
+    the same marker. See ADR-011.
+    """
+    memory.content = ""
+    memory.normalized_content = ""
+    memory.embedding = []
+    # source.excerpt carries a content excerpt → cleared; kind preserved so
+    # provenance (invariant #3) survives compaction.
+    memory.source = Source(kind=memory.source.kind)
+    memory.metadata = dict(memory.metadata)
+    memory.metadata[COMPACTION_META_KEY] = {
+        "compacted": True,
+        "compacted_at": now.isoformat(),
+        "reason": reason,
+        "content_compacted": True,
+        "vector_purged": vector_supported,
+        "purge_status": "purged" if vector_supported else "not_supported",
+    }
+    memory.updated_at = now
+
+
 @dataclass
 class StoredAudit:
     tenant_id: str

--- a/services/api/app/db/memory_repo.py
+++ b/services/api/app/db/memory_repo.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 
 from ..loops.metrics import summarize_loop_runs
 from ..loops.types import LoopEvent, LoopRun
-from .entities import StoredAudit, StoredMemory, StoredSettings
+from .entities import StoredAudit, StoredMemory, StoredSettings, apply_compaction, is_compacted
 from .repository import Repository
 
 _ACTIVE = "active"
@@ -82,6 +82,31 @@ class InMemoryRepository(Repository):
         m.status = Status.deleted
         m.deleted_at = datetime.now(UTC)
         m.updated_at = m.deleted_at
+        return m
+
+    def list_deleted_for_compaction(
+        self, tenant_id: str, user_id: str, *, include_compacted: bool = False
+    ) -> list[StoredMemory]:
+        rows = [m for m in self._scoped(tenant_id, user_id) if m.status.value == _DELETED]
+        if not include_compacted:
+            rows = [m for m in rows if not is_compacted(m)]
+        return sorted(rows, key=lambda m: m.deleted_at or m.created_at, reverse=True)
+
+    def compact_deleted_memory(
+        self,
+        tenant_id: str,
+        user_id: str,
+        memory_id: str,
+        *,
+        reason: str,
+        now: datetime | None = None,
+    ) -> StoredMemory | None:
+        m = self.get_memory(tenant_id, user_id, memory_id)
+        # Only deleted rows are ever compacted (never resurrect, never touch active).
+        if not m or m.status.value != _DELETED:
+            return None
+        apply_compaction(m, reason=reason, now=now or datetime.now(UTC))
+        self._memories[m.id] = m
         return m
 
     def find_similar_active(

--- a/services/api/app/db/postgres_repo.py
+++ b/services/api/app/db/postgres_repo.py
@@ -25,7 +25,7 @@ from ..models.sqlalchemy_models import (
     SettingsORM,
 )
 from ..schemas.memory import MemoryType, Sensitivity, Source, Status
-from .entities import StoredAudit, StoredMemory, StoredSettings
+from .entities import StoredAudit, StoredMemory, StoredSettings, apply_compaction, is_compacted
 from .repository import Repository
 
 _DELETED = "deleted"
@@ -202,6 +202,55 @@ class PostgresRepository(Repository):
             now = datetime.now(UTC)
             row.deleted_at = now
             row.updated_at = now
+            s.commit()
+            return _to_stored(row)
+
+    def list_deleted_for_compaction(
+        self, tenant_id: str, user_id: str, *, include_compacted: bool = False
+    ) -> list[StoredMemory]:
+        with self._scoped(tenant_id, user_id) as s:
+            stmt = (
+                select(MemoryRecordORM)
+                .where(
+                    MemoryRecordORM.tenant_id == tenant_id,
+                    MemoryRecordORM.user_id == user_id,
+                    MemoryRecordORM.status == _DELETED,
+                )
+                .order_by(MemoryRecordORM.deleted_at.desc())
+            )
+            rows = [_to_stored(r) for r in s.scalars(stmt)]
+        if not include_compacted:
+            rows = [m for m in rows if not is_compacted(m)]
+        return rows
+
+    def compact_deleted_memory(
+        self,
+        tenant_id: str,
+        user_id: str,
+        memory_id: str,
+        *,
+        reason: str,
+        now: datetime | None = None,
+    ) -> StoredMemory | None:
+        with self._scoped(tenant_id, user_id) as s:
+            row = s.get(MemoryRecordORM, memory_id)
+            if (
+                not row
+                or row.tenant_id != tenant_id
+                or row.user_id != user_id
+                or row.status != _DELETED
+            ):
+                return None
+            stored = _to_stored(row)
+            apply_compaction(stored, reason=reason, now=now or datetime.now(UTC))
+            # Clear retrievable content + vector material; tombstone columns
+            # (id, tenant_id, user_id, status, deleted_at, created_at) untouched.
+            row.content = stored.content
+            row.normalized_content = stored.normalized_content
+            row.embedding = None  # vector column → NULL (material removed)
+            row.source = stored.source.model_dump()
+            row.extra_metadata = stored.metadata
+            row.updated_at = stored.updated_at
             s.commit()
             return _to_stored(row)
 

--- a/services/api/app/db/repository.py
+++ b/services/api/app/db/repository.py
@@ -8,6 +8,7 @@ isolation and deletion guarantees are enforced for all callers.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 
 from ..loops.types import LoopEvent, LoopRun
 from .entities import StoredAudit, StoredMemory, StoredSettings
@@ -37,6 +38,37 @@ class Repository(ABC):
 
     @abstractmethod
     def soft_delete(self, tenant_id: str, user_id: str, memory_id: str) -> StoredMemory | None: ...
+
+    # ── deletion compaction (v0.7, ADR-011) ───────────────────────────────────
+    @abstractmethod
+    def list_deleted_for_compaction(
+        self, tenant_id: str, user_id: str, *, include_compacted: bool = False
+    ) -> list[StoredMemory]:
+        """Soft-deleted rows in scope, for the compaction worker only.
+
+        Returns ``status='deleted'`` rows (the only rows ever eligible for
+        compaction). Already-compacted rows are excluded unless
+        ``include_compacted`` is set, which keeps the worker idempotent.
+        """
+        ...
+
+    @abstractmethod
+    def compact_deleted_memory(
+        self,
+        tenant_id: str,
+        user_id: str,
+        memory_id: str,
+        *,
+        reason: str,
+        now: datetime | None = None,
+    ) -> StoredMemory | None:
+        """Clear a soft-deleted memory's content + vector material in place.
+
+        No-op-returns-``None`` for a missing row or any row whose status is not
+        ``deleted`` (active/archived memory is never compacted, deleted memory is
+        never resurrected). Preserves the governance tombstone + audit trail.
+        """
+        ...
 
     @abstractmethod
     def find_similar_active(

--- a/services/api/app/workers/__init__.py
+++ b/services/api/app/workers/__init__.py
@@ -19,24 +19,30 @@ from __future__ import annotations
 from .archive import ArchiveWorker
 from .conflict_scan import ConflictScanWorker
 from .decay import DecayWorker
+from .deletion_compaction import DeletionCompactionWorker
 from .deletion_verification import DeletionVerificationWorker
 from .lifecycle import LifecycleWorker, WorkerContext
-from .metrics import summarize_worker_results
+from .metrics import summarize_compaction_results, summarize_worker_results
 from .reflection import ReflectionWorker
 from .runner import run_jobs
 from .schemas import (
+    PurgeVerification,
     WorkerJob,
     WorkerJobResult,
     WorkerRunReport,
     WorkerRunStatus,
 )
+from .vector_purge import PurgeCheck, verify_purged
 
 __all__ = [
     "ArchiveWorker",
     "ConflictScanWorker",
     "DecayWorker",
+    "DeletionCompactionWorker",
     "DeletionVerificationWorker",
     "LifecycleWorker",
+    "PurgeCheck",
+    "PurgeVerification",
     "ReflectionWorker",
     "WorkerContext",
     "WorkerJob",
@@ -44,5 +50,7 @@ __all__ = [
     "WorkerRunReport",
     "WorkerRunStatus",
     "run_jobs",
+    "summarize_compaction_results",
     "summarize_worker_results",
+    "verify_purged",
 ]

--- a/services/api/app/workers/deletion_compaction.py
+++ b/services/api/app/workers/deletion_compaction.py
@@ -1,0 +1,244 @@
+"""Deletion compaction worker (v0.7, ADR-011).
+
+The next layer after deletion *verification*. v0.6 proves soft-deleted memory is
+unreachable (logical deletion). This worker goes further: for soft-deleted memory
+that has passed its retention/grace window it **clears the retrievable content and
+vector material**, preserves the governance tombstone + audit trail, and then
+**verifies** the purge — recording audit evidence for every step.
+
+Safety rails (enforced here + in the repository + in tests):
+  * only ``status='deleted'`` rows are ever eligible — active/archived memory is
+    never compacted, deleted memory is never resurrected (invariants #1, #2);
+  * eligibility also requires the memory to have been deleted for at least
+    ``workers_compaction_min_age_days`` (a retention window);
+  * idempotent — already-compacted rows are filtered out by the repository, so a
+    re-run does no further destructive work and does not corrupt the tombstone;
+  * tenant scoped — all reads/writes go through the repository's scoped methods;
+  * fail-safe — a per-memory purge that does not verify is recorded as a finding
+    (``completed_with_findings``), never silently passed; the worker never raises
+    into the chat path.
+
+What is cleared: ``content``, normalized content, embedding/vector material, and
+the provenance excerpt. What is preserved: memory id, tenant/user, ``status``
+(stays ``deleted``), ``deleted_at``, ``created_at``, ``source.kind``, and the full
+audit trail. Audit metadata stays content-free — ids, counts, flags only.
+
+This is **not** crypto-shred and does not claim database-page / ANN-index physical
+byte reclamation — see docs/deletion-compaction.md and ADR-011.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from ..core.config import get_settings
+from ..db.entities import StoredMemory
+from ..db.repository import Repository
+from ..services.audit import AuditService
+from .lifecycle import LifecycleWorker, WorkerContext
+from .schemas import (
+    DELETION_COMPACTION_COMPLETED,
+    DELETION_COMPACTION_FAILED,
+    DELETION_COMPACTION_SKIPPED,
+    DELETION_COMPACTION_STARTED,
+    MEMORY_CONTENT_COMPACTED,
+    MEMORY_PURGE_TOMBSTONE_PRESERVED,
+    MEMORY_VECTOR_PURGE_ATTEMPTED,
+    MEMORY_VECTOR_PURGE_FAILED,
+    MEMORY_VECTOR_PURGE_VERIFIED,
+    WorkerJob,
+    WorkerJobResult,
+    WorkerRunStatus,
+)
+from .vector_purge import verify_purged
+
+_DELETED = "deleted"
+_COMPACTION_REASON = "soft-deleted memory past retention window; content + vector material cleared"
+
+
+class DeletionCompactionWorker(LifecycleWorker):
+    job = WorkerJob.deletion_compaction
+
+    def __init__(
+        self,
+        repo: Repository,
+        audit: AuditService | None = None,
+        *,
+        min_age_days: int | None = None,
+    ) -> None:
+        super().__init__(repo, audit)
+        s = get_settings()
+        self._min_age_days = (
+            min_age_days if min_age_days is not None else s.workers_compaction_min_age_days
+        )
+
+    @staticmethod
+    def _deleted_age_days(memory: StoredMemory, now: datetime) -> int:
+        ts = memory.deleted_at or memory.updated_at
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        return max(0, (now - ts).days)
+
+    def _execute(self, ctx: WorkerContext, result: WorkerJobResult) -> None:
+        started = self._audit.record(
+            tenant_id=ctx.tenant_id,
+            user_id=ctx.user_id,
+            action=DELETION_COMPACTION_STARTED,
+            reason="deletion compaction scan started",
+            trace_id=ctx.trace_id,
+            metadata={"dry_run": ctx.dry_run, "min_age_days": self._min_age_days},
+        )
+        result.audit_event_ids.append(started.id)
+
+        eligible = compacted = verified = failed = tombstones = 0
+        # Repository excludes already-compacted rows → idempotent, retry-safe.
+        for memory in self._repo.list_deleted_for_compaction(ctx.tenant_id, ctx.user_id):
+            result.scanned_count += 1
+            # Defense in depth: only deleted rows, never resurrect/touch active.
+            if memory.status.value != _DELETED:
+                result.skipped_count += 1
+                continue
+            if self._deleted_age_days(memory, ctx.now) < self._min_age_days:
+                result.skipped_count += 1  # within retention window; not yet eligible
+                continue
+
+            eligible += 1
+            if ctx.dry_run:
+                result.changed_count += 1  # candidate only; nothing cleared
+                continue
+
+            row = self._repo.compact_deleted_memory(
+                ctx.tenant_id,
+                ctx.user_id,
+                memory.id,
+                reason=_COMPACTION_REASON,
+                now=ctx.now,
+            )
+            if row is None:
+                # Lost a race (no longer deleted): skip rather than force.
+                result.skipped_count += 1
+                continue
+
+            compacted += 1
+            result.changed_count += 1
+            result.audit_event_ids.append(
+                self._audit.record(
+                    tenant_id=ctx.tenant_id,
+                    user_id=ctx.user_id,
+                    action=MEMORY_CONTENT_COMPACTED,
+                    reason="retrievable content cleared for soft-deleted memory",
+                    memory_id=memory.id,
+                    trace_id=ctx.trace_id,
+                    metadata={"deleted_age_days": self._deleted_age_days(memory, ctx.now)},
+                ).id
+            )
+            result.audit_event_ids.append(
+                self._audit.record(
+                    tenant_id=ctx.tenant_id,
+                    user_id=ctx.user_id,
+                    action=MEMORY_VECTOR_PURGE_ATTEMPTED,
+                    reason="vector material cleared; verifying exclusion",
+                    memory_id=memory.id,
+                    trace_id=ctx.trace_id,
+                ).id
+            )
+
+            check = verify_purged(
+                self._repo,
+                tenant_id=ctx.tenant_id,
+                user_id=ctx.user_id,
+                memory_id=memory.id,
+            )
+            if check.passed:
+                verified += 1
+                result.audit_event_ids.append(
+                    self._audit.record(
+                        tenant_id=ctx.tenant_id,
+                        user_id=ctx.user_id,
+                        action=MEMORY_VECTOR_PURGE_VERIFIED,
+                        reason="compacted memory unreachable; content + vector cleared",
+                        memory_id=memory.id,
+                        trace_id=ctx.trace_id,
+                        metadata={"verification_result": check.result},
+                    ).id
+                )
+                if check.tombstone_present:
+                    tombstones += 1
+                    result.audit_event_ids.append(
+                        self._audit.record(
+                            tenant_id=ctx.tenant_id,
+                            user_id=ctx.user_id,
+                            action=MEMORY_PURGE_TOMBSTONE_PRESERVED,
+                            reason="governance tombstone + audit trail preserved",
+                            memory_id=memory.id,
+                            trace_id=ctx.trace_id,
+                        ).id
+                    )
+            else:
+                failed += 1
+                result.error_count += 1
+                result.audit_event_ids.append(
+                    self._audit.record(
+                        tenant_id=ctx.tenant_id,
+                        user_id=ctx.user_id,
+                        action=MEMORY_VECTOR_PURGE_FAILED,
+                        reason="purge verification failed (fail-closed)",
+                        memory_id=memory.id,
+                        trace_id=ctx.trace_id,
+                        metadata={
+                            "verification_result": check.result,
+                            "reachable_surfaces": check.reachable_surfaces,
+                            "detail": check.reason,
+                        },
+                    ).id
+                )
+
+        result.details = {
+            "deleted_scanned": result.scanned_count,
+            "eligible_count": eligible,
+            "compacted_count": compacted,
+            "verified_count": verified,
+            "failed_count": failed,
+            "skipped_count": result.skipped_count,
+            "tombstone_preserved_count": tombstones,
+            "dry_run": ctx.dry_run,
+        }
+
+        if eligible == 0:
+            result.audit_event_ids.append(
+                self._audit.record(
+                    tenant_id=ctx.tenant_id,
+                    user_id=ctx.user_id,
+                    action=DELETION_COMPACTION_SKIPPED,
+                    reason="no soft-deleted memory eligible for compaction",
+                    trace_id=ctx.trace_id,
+                    metadata={"scanned": result.scanned_count},
+                ).id
+            )
+
+        if failed:
+            result.status = WorkerRunStatus.completed_with_findings.value
+            result.audit_event_ids.append(
+                self._audit.record(
+                    tenant_id=ctx.tenant_id,
+                    user_id=ctx.user_id,
+                    action=DELETION_COMPACTION_FAILED,
+                    reason=f"deletion compaction completed with {failed} purge finding(s)",
+                    trace_id=ctx.trace_id,
+                    metadata=dict(result.details),
+                ).id
+            )
+        else:
+            result.audit_event_ids.append(
+                self._audit.record(
+                    tenant_id=ctx.tenant_id,
+                    user_id=ctx.user_id,
+                    action=DELETION_COMPACTION_COMPLETED,
+                    reason=(
+                        f"deletion compaction completed: compacted={compacted} "
+                        f"verified={verified}"
+                    ),
+                    trace_id=ctx.trace_id,
+                    metadata=dict(result.details),
+                ).id
+            )

--- a/services/api/app/workers/metrics.py
+++ b/services/api/app/workers/metrics.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Iterable
 
-from .schemas import WorkerJobResult, WorkerRunStatus
+from .schemas import WorkerJob, WorkerJobResult, WorkerRunStatus
 
 
 def summarize_worker_results(results: Iterable[WorkerJobResult]) -> dict:
@@ -26,4 +26,28 @@ def summarize_worker_results(results: Iterable[WorkerJobResult]) -> dict:
         "errors": sum(r.error_count for r in results),
         "failed": by_status.get(WorkerRunStatus.failed.value, 0),
         "with_findings": by_status.get(WorkerRunStatus.completed_with_findings.value, 0),
+    }
+
+
+def summarize_compaction_results(results: Iterable[WorkerJobResult]) -> dict:
+    """Roll up deletion-compaction lifecycle metrics (v0.7). Content-free counts.
+
+    Sums the per-run ``details`` the compaction worker records so an operator/
+    metrics surface can show purge progress without re-reading audit events.
+    """
+    compaction = [r for r in results if r.job == WorkerJob.deletion_compaction.value]
+
+    def _sum(key: str) -> int:
+        return sum(int(r.details.get(key, 0)) for r in compaction)
+
+    return {
+        "deletion_compaction_runs": len(compaction),
+        "deletion_compaction_scanned_count": _sum("deleted_scanned"),
+        "deletion_compaction_eligible_count": _sum("eligible_count"),
+        "deletion_compaction_success_count": _sum("compacted_count"),
+        "deletion_compaction_failure_count": _sum("failed_count"),
+        "vector_purge_verified_count": _sum("verified_count"),
+        "vector_purge_failed_count": _sum("failed_count"),
+        "tombstone_preserved_count": _sum("tombstone_preserved_count"),
+        "skipped_not_eligible_count": _sum("skipped_count"),
     }

--- a/services/api/app/workers/runner.py
+++ b/services/api/app/workers/runner.py
@@ -10,6 +10,7 @@ scope here — see docs/background-lifecycle-workers.md.
 Usage (local):
     python -m app.workers.runner --tenant t1 --user u1 --job all
     python -m app.workers.runner --tenant t1 --user u1 --job decay --job archive
+    python -m app.workers.runner --tenant t1 --user u1 --job deletion_compaction
     python -m app.workers.runner --tenant t1 --user u1 --job deletion_verification --dry-run
 """
 
@@ -25,6 +26,7 @@ from ..services.audit import AuditService
 from .archive import ArchiveWorker
 from .conflict_scan import ConflictScanWorker
 from .decay import DecayWorker
+from .deletion_compaction import DeletionCompactionWorker
 from .deletion_verification import DeletionVerificationWorker
 from .lifecycle import LifecycleWorker, WorkerContext
 from .reflection import ReflectionWorker
@@ -34,6 +36,7 @@ from .schemas import DEFAULT_JOB_ORDER, WorkerJob, WorkerRunReport
 _WORKERS: dict[WorkerJob, type[LifecycleWorker]] = {
     WorkerJob.decay: DecayWorker,
     WorkerJob.archive: ArchiveWorker,
+    WorkerJob.deletion_compaction: DeletionCompactionWorker,
     WorkerJob.deletion_verification: DeletionVerificationWorker,
     WorkerJob.conflict_scan: ConflictScanWorker,
     WorkerJob.reflection: ReflectionWorker,

--- a/services/api/app/workers/schemas.py
+++ b/services/api/app/workers/schemas.py
@@ -18,20 +18,35 @@ from enum import Enum
 class WorkerJob(str, Enum):
     decay = "decay"
     archive = "archive"
+    deletion_compaction = "deletion_compaction"
     deletion_verification = "deletion_verification"
     conflict_scan = "conflict_scan"
     reflection = "reflection"
 
 
 # Jobs the runner executes for the "all" selector, in a deliberate order:
-# read-only verification last so it observes the state the mutating jobs left.
+# mutating jobs first, then compaction of already-deleted memory, and read-only
+# verification last so it observes the state the mutating + compaction jobs left.
 DEFAULT_JOB_ORDER: tuple[WorkerJob, ...] = (
     WorkerJob.decay,
     WorkerJob.archive,
     WorkerJob.conflict_scan,
     WorkerJob.reflection,
+    WorkerJob.deletion_compaction,
     WorkerJob.deletion_verification,
 )
+
+
+# ── Vector / content purge verification outcomes (v0.7) ────────────────────────
+# Honest result space. ``not_supported`` is reserved for a backend that genuinely
+# cannot clear vector material; both shipped backends DO clear it, so a real
+# deleted memory that is still reachable or whose material is intact is a ``fail``
+# (fail-closed), never a silent pass.
+class PurgeVerification(str, Enum):
+    passed = "pass"
+    failed = "fail"
+    skipped = "skipped"
+    not_supported = "not_supported"
 
 
 # ── Run status ────────────────────────────────────────────────────────────────
@@ -57,6 +72,17 @@ DELETION_VERIFICATION_PASSED = "deletion_verification_passed"
 DELETION_VERIFICATION_FAILED = "deletion_verification_failed"
 CONFLICT_CANDIDATE_DETECTED = "conflict_candidate_detected"
 REFLECTION_CANDIDATE_DETECTED = "reflection_candidate_detected"
+# v0.7 — physical deletion compaction + vector purge verification (ADR-011).
+# These describe *what was cleared/verified*, never the cleared content itself.
+DELETION_COMPACTION_STARTED = "deletion_compaction_started"
+DELETION_COMPACTION_COMPLETED = "deletion_compaction_completed"
+DELETION_COMPACTION_FAILED = "deletion_compaction_failed"
+DELETION_COMPACTION_SKIPPED = "deletion_compaction_skipped"
+MEMORY_CONTENT_COMPACTED = "memory_content_compacted"
+MEMORY_VECTOR_PURGE_ATTEMPTED = "memory_vector_purge_attempted"
+MEMORY_VECTOR_PURGE_VERIFIED = "memory_vector_purge_verified"
+MEMORY_VECTOR_PURGE_FAILED = "memory_vector_purge_failed"
+MEMORY_PURGE_TOMBSTONE_PRESERVED = "memory_purge_tombstone_preserved"
 
 WORKER_AUDIT_ACTIONS: frozenset[str] = frozenset(
     {
@@ -70,6 +96,15 @@ WORKER_AUDIT_ACTIONS: frozenset[str] = frozenset(
         DELETION_VERIFICATION_FAILED,
         CONFLICT_CANDIDATE_DETECTED,
         REFLECTION_CANDIDATE_DETECTED,
+        DELETION_COMPACTION_STARTED,
+        DELETION_COMPACTION_COMPLETED,
+        DELETION_COMPACTION_FAILED,
+        DELETION_COMPACTION_SKIPPED,
+        MEMORY_CONTENT_COMPACTED,
+        MEMORY_VECTOR_PURGE_ATTEMPTED,
+        MEMORY_VECTOR_PURGE_VERIFIED,
+        MEMORY_VECTOR_PURGE_FAILED,
+        MEMORY_PURGE_TOMBSTONE_PRESERVED,
     }
 )
 

--- a/services/api/app/workers/vector_purge.py
+++ b/services/api/app/workers/vector_purge.py
@@ -1,0 +1,122 @@
+"""Vector / content purge verification (v0.7, ADR-011).
+
+After a soft-deleted memory is compacted, this module proves — at the access paths
+a caller could actually reach — that the memory is gone *and* that its retrievable
+content + vector material were really cleared. It is the evidence half of the
+compaction story: compaction does the clearing, verification confirms it.
+
+Honest scope: this verifies **application-level retrieval exclusion** and
+**repository-level content/vector material clearing**. It does not (and does not
+claim to) prove database-page or ANN-index physical byte reclamation — that is the
+storage engine's job and is documented separately (see docs/vector-purge-verification.md).
+
+The verifier is **fail-closed**: any reachable surface, any material left intact,
+a missing tombstone, or an error in the verification path itself all yield
+``fail`` — never a silent ``pass``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..db.repository import Repository
+from .schemas import PurgeVerification
+
+
+@dataclass
+class PurgeCheck:
+    """Content-free verification outcome for a single memory (ids/flags only)."""
+
+    memory_id: str
+    result: str  # PurgeVerification value
+    reachable_surfaces: list[str] = field(default_factory=list)
+    content_cleared: bool = False
+    vector_cleared: bool = False
+    tombstone_present: bool = False
+    reason: str = ""
+
+    @property
+    def passed(self) -> bool:
+        return self.result == PurgeVerification.passed.value
+
+
+# The reachable read surfaces a deleted/compacted id must never appear in. An
+# empty query embedding makes the vector path degrade to "active rows at
+# similarity 0" — exactly the set a purged id must stay out of.
+def _reachable_surfaces(
+    repo: Repository, tenant_id: str, user_id: str, memory_id: str
+) -> list[str]:
+    active_ids = {m.id for m in repo.retrieve_active(tenant_id, user_id)}
+    listed_ids = {m.id for m in repo.list_memories(tenant_id, user_id)}
+    candidate_ids = {m.id for m, _ in repo.search_candidates(tenant_id, user_id, [])}
+    return [
+        name
+        for name, ids in (
+            ("active_retrieval", active_ids),
+            ("listing", listed_ids),
+            ("vector_candidates", candidate_ids),
+        )
+        if memory_id in ids
+    ]
+
+
+def verify_purged(
+    repo: Repository,
+    *,
+    tenant_id: str,
+    user_id: str,
+    memory_id: str,
+    vector_supported: bool = True,
+) -> PurgeCheck:
+    """Verify a compacted memory is unreachable and its material was cleared.
+
+    Returns ``pass`` only when the id is absent from every reachable surface, the
+    governance tombstone is still present, content is cleared, and (when the
+    backend supports it) vector material is cleared. Anything else is ``fail``.
+    ``not_supported`` is reserved for a backend that cannot clear vector material
+    at all; both shipped backends can, so it is not returned in practice.
+    """
+    try:
+        surfaces = _reachable_surfaces(repo, tenant_id, user_id, memory_id)
+        # get_memory returns the row regardless of status, so we can inspect the
+        # tombstone and confirm the payload is actually empty.
+        row = repo.get_memory(tenant_id, user_id, memory_id)
+        tombstone_present = row is not None
+        content_cleared = bool(row) and not (row.content or "").strip()
+        vector_cleared = bool(row) and not row.embedding
+
+        check = PurgeCheck(
+            memory_id=memory_id,
+            result=PurgeVerification.failed.value,
+            reachable_surfaces=surfaces,
+            content_cleared=content_cleared,
+            vector_cleared=vector_cleared,
+            tombstone_present=tombstone_present,
+        )
+
+        if surfaces:
+            check.reason = "compacted memory still reachable in a retrieval surface"
+            return check
+        if not tombstone_present:
+            check.reason = "governance tombstone missing after compaction"
+            return check
+        if not content_cleared:
+            check.reason = "retrievable content not cleared"
+            return check
+        if not vector_supported:
+            check.result = PurgeVerification.not_supported.value
+            check.reason = "backend does not support vector material clearing"
+            return check
+        if not vector_cleared:
+            check.reason = "vector material not cleared"
+            return check
+
+        check.result = PurgeVerification.passed.value
+        check.reason = "unreachable; content + vector material cleared; tombstone preserved"
+        return check
+    except Exception as exc:  # noqa: BLE001 — fail closed, never pass on error
+        return PurgeCheck(
+            memory_id=memory_id,
+            result=PurgeVerification.failed.value,
+            reason=f"verification path error: {type(exc).__name__}",
+        )

--- a/services/api/tests/test_deletion.py
+++ b/services/api/tests/test_deletion.py
@@ -59,6 +59,32 @@ def test_control_plane_detail_marks_deleted_never_active(gateway, repo):
     assert mem.id not in {m.id for m in repo.list_memories("t1", "u1")}
 
 
+def test_compacted_deleted_memory_stays_unreachable(gateway, repo):
+    # v0.7: after the repository compacts a soft-deleted memory (clears content +
+    # vector material), the deletion guarantee must still hold and the tombstone
+    # must remain (status stays deleted, never resurrected).
+    _chat(gateway, "Remember that I prefer dark mode dashboards.")
+    mem = repo.list_memories("t1", "u1")[0]
+    repo.soft_delete("t1", "u1", mem.id)
+
+    compacted = repo.compact_deleted_memory("t1", "u1", mem.id, reason="test")
+    assert compacted is not None
+    assert compacted.status == Status.deleted  # tombstone, never reactivated
+    assert compacted.content == "" and compacted.embedding == []
+
+    assert mem.id not in {m.id for m in repo.retrieve_active("t1", "u1")}
+    assert mem.id not in {m.id for m in repo.list_memories("t1", "u1")}
+    assert all(m.id != mem.id for m, _ in repo.search_candidates("t1", "u1", []))
+
+
+def test_compaction_rejects_active_memory(gateway, repo):
+    # Active memory is never eligible for compaction (only deleted rows are).
+    _chat(gateway, "Remember that I prefer dark mode dashboards.")
+    mem = repo.list_memories("t1", "u1")[0]
+    assert repo.compact_deleted_memory("t1", "u1", mem.id, reason="x") is None
+    assert repo.get_memory("t1", "u1", mem.id).content != ""
+
+
 def test_loop_traces_do_not_resurrect_deleted_memory(gateway, repo):
     # v0.3.1: loop runs/events are operational evidence stored alongside the
     # write path. They must never re-expose a soft-deleted memory in retrieval.

--- a/services/api/tests/test_deletion_compaction_worker.py
+++ b/services/api/tests/test_deletion_compaction_worker.py
@@ -1,0 +1,305 @@
+"""Deletion compaction worker (v0.7, ADR-011).
+
+Proves the compaction layer above logical deletion: soft-deleted memory past its
+retention window has its content + vector material cleared, the governance
+tombstone + audit trail are preserved, the purge is verified, and active/archived
+memory is never touched. Tenant-scoped, idempotent, fail-closed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.db.entities import COMPACTION_META_KEY, is_compacted
+from app.schemas.memory import Status
+from app.workers.deletion_compaction import DeletionCompactionWorker
+from app.workers.lifecycle import WorkerContext
+from app.workers.metrics import summarize_compaction_results
+from app.workers.runner import run_jobs
+from app.workers.schemas import (
+    DELETION_COMPACTION_COMPLETED,
+    DELETION_COMPACTION_FAILED,
+    DELETION_COMPACTION_SKIPPED,
+    DELETION_COMPACTION_STARTED,
+    MEMORY_CONTENT_COMPACTED,
+    MEMORY_PURGE_TOMBSTONE_PRESERVED,
+    MEMORY_VECTOR_PURGE_ATTEMPTED,
+    MEMORY_VECTOR_PURGE_FAILED,
+    MEMORY_VECTOR_PURGE_VERIFIED,
+    WorkerRunStatus,
+)
+
+from ._worker_helpers import NOW, seed_memory
+
+
+def _ctx(**kw) -> WorkerContext:
+    kw.setdefault("tenant_id", "t1")
+    kw.setdefault("user_id", "u1")
+    kw.setdefault("now", NOW)
+    return WorkerContext(**kw)
+
+
+def _seed_deleted(repo, *, content="secret note", embedding=(0.1, 0.2, 0.3), **kw):
+    mem = seed_memory(repo, content=content, status=Status.deleted, **kw)
+    mem.embedding = list(embedding)  # give it real vector material to clear
+    return mem
+
+
+def _actions(repo, tenant="t1"):
+    return [e.action for e in repo.list_audit(tenant, "u1")]
+
+
+# ── core compaction ────────────────────────────────────────────────────────────
+def test_soft_deleted_memory_is_compacted(repo) -> None:
+    mem = _seed_deleted(repo)
+    result = DeletionCompactionWorker(repo).run(_ctx())
+
+    assert result.status == WorkerRunStatus.completed.value
+    assert result.details["compacted_count"] == 1
+    assert result.details["verified_count"] == 1
+    assert is_compacted(repo.get_memory("t1", "u1", mem.id))
+
+
+def test_active_memory_is_never_compacted(repo) -> None:
+    active = seed_memory(repo, content="keep me", status=Status.active)
+    DeletionCompactionWorker(repo).run(_ctx())
+
+    row = repo.get_memory("t1", "u1", active.id)
+    assert row.status == Status.active
+    assert row.content == "keep me"
+    assert not is_compacted(row)
+
+
+def test_archived_memory_is_not_compacted_unless_deleted(repo) -> None:
+    archived = seed_memory(repo, content="archived note", status=Status.archived)
+    result = DeletionCompactionWorker(repo).run(_ctx())
+
+    assert result.details["eligible_count"] == 0
+    row = repo.get_memory("t1", "u1", archived.id)
+    assert row.content == "archived note"
+    assert not is_compacted(row)
+
+
+def test_compaction_clears_retrievable_content_and_vector(repo) -> None:
+    mem = _seed_deleted(repo, content="my home address is 42 Privet Drive")
+    DeletionCompactionWorker(repo).run(_ctx())
+
+    row = repo.get_memory("t1", "u1", mem.id)
+    assert row.content == ""
+    assert row.normalized_content == ""
+    assert row.embedding == []
+    assert row.source.excerpt == ""  # sensitive provenance excerpt cleared
+
+
+def test_compaction_preserves_tombstone(repo) -> None:
+    mem = _seed_deleted(repo)
+    DeletionCompactionWorker(repo).run(_ctx())
+
+    row = repo.get_memory("t1", "u1", mem.id)
+    # Identity + deletion metadata + provenance kind survive; status stays deleted.
+    assert row.id == mem.id
+    assert row.tenant_id == "t1" and row.user_id == "u1"
+    assert row.status == Status.deleted
+    assert row.deleted_at is not None
+    assert row.source.kind == "chat"
+    marker = row.metadata[COMPACTION_META_KEY]
+    assert marker["compacted"] is True
+    assert marker["purge_status"] == "purged"
+    assert marker["compacted_at"]
+
+
+def test_compaction_records_audit_evidence(repo) -> None:
+    _seed_deleted(repo)
+    DeletionCompactionWorker(repo).run(_ctx())
+
+    actions = set(_actions(repo))
+    assert DELETION_COMPACTION_STARTED in actions
+    assert MEMORY_CONTENT_COMPACTED in actions
+    assert MEMORY_VECTOR_PURGE_ATTEMPTED in actions
+    assert MEMORY_VECTOR_PURGE_VERIFIED in actions
+    assert MEMORY_PURGE_TOMBSTONE_PRESERVED in actions
+    assert DELETION_COMPACTION_COMPLETED in actions
+
+
+def test_audit_metadata_is_content_free(repo) -> None:
+    _seed_deleted(repo, content="topsecret value xyz")
+    DeletionCompactionWorker(repo).run(_ctx())
+    for e in repo.list_audit("t1", "u1"):
+        assert "topsecret" not in (e.reason or "")
+        assert "topsecret" not in str(e.metadata)
+
+
+def test_skipped_event_when_nothing_eligible(repo) -> None:
+    seed_memory(repo, status=Status.active)
+    result = DeletionCompactionWorker(repo).run(_ctx())
+    assert result.details["eligible_count"] == 0
+    assert DELETION_COMPACTION_SKIPPED in set(_actions(repo))
+
+
+def test_retention_window_blocks_compaction(repo) -> None:
+    _seed_deleted(repo)  # deleted_at == NOW → age 0 days
+    result = DeletionCompactionWorker(repo, min_age_days=1).run(_ctx())
+    assert result.details["eligible_count"] == 0
+    assert result.details["skipped_count"] == 1
+
+
+def test_dry_run_compacts_nothing(repo) -> None:
+    mem = _seed_deleted(repo)
+    result = DeletionCompactionWorker(repo).run(_ctx(dry_run=True))
+
+    assert result.details["eligible_count"] == 1
+    assert result.details["compacted_count"] == 0
+    row = repo.get_memory("t1", "u1", mem.id)
+    assert row.content != ""  # untouched
+    assert not is_compacted(row)
+
+
+# ── retrieval safety ─────────────────────────────────────────────────────────
+def test_compacted_memory_is_unreachable(repo) -> None:
+    mem = _seed_deleted(repo)
+    DeletionCompactionWorker(repo).run(_ctx())
+
+    assert mem.id not in {m.id for m in repo.retrieve_active("t1", "u1")}
+    assert mem.id not in {m.id for m in repo.list_memories("t1", "u1")}
+    assert mem.id not in {m.id for m, _ in repo.search_candidates("t1", "u1", [])}
+
+
+def test_verification_fails_when_compacted_memory_leaks_into_candidates(repo) -> None:
+    mem = _seed_deleted(repo)
+
+    class _LeakyCandidates:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        def search_candidates(self, t, u, emb, **kw):
+            leaked = self._inner.get_memory(t, u, mem.id)
+            base = list(self._inner.search_candidates(t, u, emb, **kw))
+            if leaked and all(x.id != leaked.id for x, _ in base):
+                base.append((leaked, 0.0))
+            return base
+
+    result = DeletionCompactionWorker(_LeakyCandidates(repo)).run(_ctx())
+
+    assert result.status == WorkerRunStatus.completed_with_findings.value
+    assert result.details["failed_count"] == 1
+    actions = set(_actions(repo))
+    assert MEMORY_VECTOR_PURGE_FAILED in actions
+    assert DELETION_COMPACTION_FAILED in actions
+    # Still compacted (content cleared) and never resurrected.
+    row = repo.get_memory("t1", "u1", mem.id)
+    assert row.status == Status.deleted
+
+
+def test_verification_fails_closed_when_path_errors(repo) -> None:
+    _seed_deleted(repo)
+
+    class _BrokenVerify:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        def retrieve_active(self, t, u):  # used only inside verify_purged
+            raise RuntimeError("retrieval path down")
+
+    result = DeletionCompactionWorker(_BrokenVerify(repo)).run(_ctx())
+    assert result.status == WorkerRunStatus.completed_with_findings.value
+    assert result.details["failed_count"] == 1
+    assert MEMORY_VECTOR_PURGE_FAILED in set(_actions(repo))
+
+
+# ── tenant isolation ─────────────────────────────────────────────────────────
+def test_compaction_is_tenant_scoped(repo) -> None:
+    a = _seed_deleted(repo, tenant_id="t1")
+    b = _seed_deleted(repo, tenant_id="t2")
+    DeletionCompactionWorker(repo).run(_ctx(tenant_id="t1"))
+
+    assert is_compacted(repo.get_memory("t1", "u1", a.id))
+    # tenant B untouched
+    b_row = repo.get_memory("t2", "u1", b.id)
+    assert not is_compacted(b_row)
+    assert b_row.content != ""
+
+
+def test_audit_events_are_tenant_scoped(repo) -> None:
+    _seed_deleted(repo, tenant_id="t1")
+    _seed_deleted(repo, tenant_id="t2")
+    DeletionCompactionWorker(repo).run(_ctx(tenant_id="t1"))
+
+    assert MEMORY_CONTENT_COMPACTED in set(_actions(repo, "t1"))
+    assert MEMORY_CONTENT_COMPACTED not in set(_actions(repo, "t2"))
+
+
+# ── idempotency ──────────────────────────────────────────────────────────────
+def test_running_twice_does_no_further_destructive_work(repo) -> None:
+    mem = _seed_deleted(repo)
+    DeletionCompactionWorker(repo).run(_ctx())
+    second = DeletionCompactionWorker(repo).run(_ctx())
+
+    assert second.details["eligible_count"] == 0  # already compacted, filtered out
+    assert second.details["compacted_count"] == 0
+    # Tombstone unchanged and still deleted.
+    row = repo.get_memory("t1", "u1", mem.id)
+    assert row.status == Status.deleted
+    assert is_compacted(row)
+
+
+def test_retry_after_failure_completes_safely(repo) -> None:
+    mem = _seed_deleted(repo)
+
+    class _FlakyCompact:
+        def __init__(self, inner):
+            self._inner = inner
+            self.calls = 0
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        def compact_deleted_memory(self, *a, **kw):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("transient store error")
+            return self._inner.compact_deleted_memory(*a, **kw)
+
+    flaky = _FlakyCompact(repo)
+    first = DeletionCompactionWorker(flaky).run(_ctx())
+    assert first.status == WorkerRunStatus.failed.value  # caught, never raised
+
+    second = DeletionCompactionWorker(flaky).run(_ctx())
+    assert second.details["compacted_count"] == 1
+    assert is_compacted(repo.get_memory("t1", "u1", mem.id))
+
+
+# ── policy / deletion safety ─────────────────────────────────────────────────
+def test_worker_never_resurrects_or_reactivates(repo) -> None:
+    mem = _seed_deleted(repo)
+    DeletionCompactionWorker(repo).run(_ctx())
+    row = repo.get_memory("t1", "u1", mem.id)
+    assert row.status == Status.deleted  # never moved back to active/archived
+
+
+# ── runner + metrics integration ─────────────────────────────────────────────
+def test_runner_invokes_deletion_compaction(repo) -> None:
+    mem = _seed_deleted(repo)
+    report = run_jobs(repo, tenant_id="t1", user_id="u1", jobs=["deletion_compaction"])
+    assert report.ok
+    assert is_compacted(repo.get_memory("t1", "u1", mem.id))
+
+
+def test_compaction_metrics_summary(repo) -> None:
+    _seed_deleted(repo)
+    report = run_jobs(repo, tenant_id="t1", user_id="u1", jobs=["deletion_compaction"])
+    metrics = summarize_compaction_results(report.results)
+    assert metrics["deletion_compaction_success_count"] == 1
+    assert metrics["vector_purge_verified_count"] == 1
+    assert metrics["tombstone_preserved_count"] == 1
+
+
+@pytest.mark.parametrize("status", [Status.active, Status.archived, Status.pending])
+def test_repo_compact_rejects_non_deleted(repo, status) -> None:
+    mem = seed_memory(repo, status=status)
+    assert repo.compact_deleted_memory("t1", "u1", mem.id, reason="x") is None

--- a/services/api/tests/test_tenant_isolation.py
+++ b/services/api/tests/test_tenant_isolation.py
@@ -52,6 +52,22 @@ def test_loop_runs_are_tenant_and_user_scoped(gateway, repo):
     assert repo.list_loop_runs(tenant_id="tenant_acme", user_id="other_user") == []
 
 
+def test_compaction_listing_is_tenant_scoped(gateway, repo):
+    # v0.7: the compaction worker's source query (list_deleted_for_compaction)
+    # and the compaction mutation must stay within the (tenant, user) scope.
+    _chat(gateway, "tenant_acme", "user_acme", "Remember Acme's roadmap is confidential.")
+    mem = repo.list_memories("tenant_acme", "user_acme")[0]
+    repo.soft_delete("tenant_acme", "user_acme", mem.id)
+
+    # Another tenant sees no deleted-for-compaction rows and cannot compact it.
+    assert repo.list_deleted_for_compaction("tenant_demo", "user_demo") == []
+    assert repo.compact_deleted_memory("tenant_demo", "user_demo", mem.id, reason="x") is None
+    # Wrong user in the same tenant also cannot reach it.
+    assert repo.compact_deleted_memory("tenant_acme", "other_user", mem.id, reason="x") is None
+    # The correct scope sees exactly its one deleted row.
+    assert [m.id for m in repo.list_deleted_for_compaction("tenant_acme", "user_acme")] == [mem.id]
+
+
 def test_audit_listing_is_tenant_and_memory_scoped(gateway, repo):
     # v0.5: the control plane's per-memory audit filter must stay tenant-scoped
     # and must not surface another memory's events.

--- a/services/api/tests/test_vector_purge_verification.py
+++ b/services/api/tests/test_vector_purge_verification.py
@@ -1,0 +1,97 @@
+"""Vector / content purge verification (v0.7, ADR-011).
+
+Unit-level proof that ``verify_purged`` is fail-closed: it passes only when a
+compacted memory is unreachable on every surface, the tombstone is present, and
+content + vector material are cleared. Anything else — reachable, material intact,
+missing tombstone, or an error in the verification path — is ``fail``.
+"""
+
+from __future__ import annotations
+
+from app.schemas.memory import Status
+from app.workers.schemas import PurgeVerification
+from app.workers.vector_purge import verify_purged
+
+from ._worker_helpers import seed_memory
+
+
+def _compact(repo, mem):
+    return repo.compact_deleted_memory("t1", "u1", mem.id, reason="test")
+
+
+def test_passes_for_compacted_deleted_memory(repo) -> None:
+    mem = seed_memory(repo, content="gone now", status=Status.deleted)
+    mem.embedding = [0.1, 0.2]
+    _compact(repo, mem)
+
+    check = verify_purged(repo, tenant_id="t1", user_id="u1", memory_id=mem.id)
+    assert check.passed
+    assert check.result == PurgeVerification.passed.value
+    assert check.content_cleared and check.vector_cleared and check.tombstone_present
+    assert check.reachable_surfaces == []
+
+
+def test_fails_when_content_not_cleared(repo) -> None:
+    # Deleted but NOT compacted: content still present → fail-closed.
+    mem = seed_memory(repo, content="still here", status=Status.deleted)
+    check = verify_purged(repo, tenant_id="t1", user_id="u1", memory_id=mem.id)
+    assert not check.passed
+    assert check.result == PurgeVerification.failed.value
+    assert not check.content_cleared
+
+
+def test_fails_when_reachable_in_a_surface(repo) -> None:
+    mem = seed_memory(repo, content="gone", status=Status.deleted)
+    _compact(repo, mem)
+
+    class _Leaky:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        def retrieve_active(self, t, u):
+            return [self._inner.get_memory(t, u, mem.id)]
+
+    check = verify_purged(_Leaky(repo), tenant_id="t1", user_id="u1", memory_id=mem.id)
+    assert not check.passed
+    assert "active_retrieval" in check.reachable_surfaces
+
+
+def test_fails_when_tombstone_missing(repo) -> None:
+    mem = seed_memory(repo, content="gone", status=Status.deleted)
+    _compact(repo, mem)
+
+    class _NoTombstone:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        def get_memory(self, t, u, mid):
+            return None  # tombstone vanished
+
+    check = verify_purged(_NoTombstone(repo), tenant_id="t1", user_id="u1", memory_id=mem.id)
+    assert not check.passed
+    assert not check.tombstone_present
+
+
+def test_fails_closed_on_verification_error(repo) -> None:
+    mem = seed_memory(repo, content="gone", status=Status.deleted)
+    _compact(repo, mem)
+
+    class _Broken:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        def search_candidates(self, *a, **kw):
+            raise RuntimeError("index unavailable")
+
+    check = verify_purged(_Broken(repo), tenant_id="t1", user_id="u1", memory_id=mem.id)
+    assert check.result == PurgeVerification.failed.value
+    assert "verification path error" in check.reason


### PR DESCRIPTION
## v0.7 — Physical Deletion Compaction + Vector-Index Purge Verification

Moves MemoryOps from **logical** deletion verification (v0.6) to **auditable content/vector compaction with fail-closed purge verification**. Deleted memory is now provably unreachable *and* its payload is provably cleared, while the governance tombstone + audit trail are preserved.

### What landed
- **`deletion_compaction` worker** — clears a soft-deleted memory's `content`, normalized content, embedding/vector material, and provenance excerpt after a retention window; preserves the tombstone (id, tenant/user, `status='deleted'`, `deleted_at`, `source.kind`) and the full audit trail.
- **Vector/content purge verification** (`verify_purged`) — fail-closed: a still-reachable id, intact material, a missing tombstone, or a verification-path error all record evidence and flag the run; never a silent pass.
- **Additive repository methods** — `list_deleted_for_compaction`, `compact_deleted_memory` (in-memory + Postgres); `apply_compaction` helper. Only `status='deleted'` rows are eligible; never resurrect/reactivate.
- **Content-free audit events** — `deletion_compaction_started/completed/failed/skipped`, `memory_content_compacted`, `memory_vector_purge_attempted/verified/failed`, `memory_purge_tombstone_preserved`.
- **Runner / metrics / config** — `deletion_compaction` job (runs before verification in `all`), `summarize_compaction_results`, `workers_compaction_min_age_days`.
- **PR invariant gate** — new deletion-compaction / vector-purge evidence rules; extended `worker-tests`.
- **Docs** — new `deletion-compaction.md`, `vector-purge-verification.md`, ADR-011, phase-13 gate; updated security/governance/architecture/rollout/README/AGENTS/CLAUDE/deletion-verification/background-lifecycle-workers.

### Validation
- pytest: **183 passed, 1 skipped**
- ruff: **all checks passed**
- evals: **PASS** (all invariants hold, pass rate ≥ 80%)
- PR invariant gate: **PASS** (12 armed rules satisfied)

### Honest scope (stated in docs + ADR-011)
Not crypto-shred · no guaranteed physical disk/page byte erasure · no pgvector reindex/`VACUUM` orchestration · no cross-tenant scheduler · tombstone deliberately retained (no destructive hard `DELETE`).

The accurate claim: **application-level retrieval exclusion + repository-level content/vector clearing, verified, with tombstone preservation and audit evidence.**

Closes #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)