### PR TITLE
feat: v0.8 worker runtime + scheduled lifecycle orchestration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,11 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
   service (scope enumeration is the orchestrator's job). See ADR-010, ADR-011,
   `docs/background-lifecycle-workers.md`, `docs/deletion-compaction.md`,
   `docs/vector-purge-verification.md`, `docs/deletion-verification.md`.
+  v0.8 worker runtime (`orchestrator.py`/`scheduler.py`/`locks.py`/`retry.py`):
+  the `worker` service runs the scheduler over explicit `MEMORYOPS_WORKER_SCOPES`,
+  leased (duplicate runs prevented), retried with backoff, dead-lettered on
+  exhausted retries, with persisted run history (`worker_runs`, migration 006) and
+  worker health at `GET /healthz/workers`. See ADR-012, `docs/worker-runtime.md`.
 - `services/api/app/db` — repository abstraction. `MEMORYOPS_STORAGE=memory|postgres`. Vector
   retrieval goes through `Repository.search_candidates` (pgvector on Postgres, cosine in memory).
 - `infra/db/migrations` — SQL schema (Postgres + pgvector). RLS is **enforced** in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,12 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
   crypto-shred / no physical disk reclamation claim). See ADR-010, ADR-011,
   `docs/background-lifecycle-workers.md`, `docs/deletion-compaction.md`,
   `docs/vector-purge-verification.md`.
+  - v0.8 worker runtime: `orchestrator.py` + `scheduler.py` + `locks.py` (leases) +
+    `retry.py` make the jobs operable — leased (duplicate runs prevented), retried
+    with backoff, dead-lettered on exhausted retries, with persisted run history
+    (`worker_runs`, migration 006) and a `GET /healthz/workers` view. Scopes are
+    explicit (`worker_scopes`). `services/worker/main.py` runs the scheduler.
+    See ADR-012 and `docs/worker-runtime.md`.
 - `services/api/app/db` — repository abstraction. `MEMORYOPS_STORAGE=memory|postgres`. Vector
   retrieval goes through `Repository.search_candidates` (pgvector on Postgres, cosine in memory).
 - `infra/db/migrations` — SQL schema (Postgres + pgvector). RLS is **enforced** in

--- a/README.md
+++ b/README.md
@@ -355,20 +355,36 @@ MemoryOps integrates it via an adapter and does not vendor its source.
   [docs/vector-purge-verification.md](docs/vector-purge-verification.md), and
   [ADR-011](infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md).
 
+## What works as of v0.8 (worker runtime + scheduled orchestration)
+
+- The lifecycle jobs are now **operable**, not just callable: a **lease/lock**
+  prevents duplicate concurrent runs of a scope, a **retry/backoff** policy
+  absorbs transient faults, exhausted retries become **dead-letter** records, and
+  every run is persisted as content-free **run history**.
+- A thin **scheduler** drives the orchestrator over explicit `"tenant:user"`
+  scopes; `services/worker/main.py` now runs the real lifecycle workers.
+- **Worker health is visible** at `GET /healthz/workers` (recent runs, dead-letter
+  / failure counts, last run per scope). New migration `006_worker_runtime.sql`.
+- Leases expire, so a crashed worker never deadlocks a scope; multiple replicas
+  are safe (the lease arbitrates). No queue/broker added.
+- See [docs/worker-runtime.md](docs/worker-runtime.md) and
+  [ADR-012](infra/adr/ADR-012-worker-runtime-orchestration.md).
+
 ## Roadmap
 
 - **v0.7** — physical deletion compaction + vector purge verification ✅
-- **v0.8** — Railway worker runtime + scheduled lifecycle orchestration
+- **v0.8** — worker runtime + scheduled lifecycle orchestration ✅
 - **v0.9** — retention policies + legal hold + consent-aware memory
 - **v0.10** — assistant SDK + example apps
 - **v1.0** — production-ready governed memory runtime
 
-## What remains (v0.8+)
+## What remains (v0.9+)
 
-- Scheduled worker runtime with locks/leases, retries, and run history (v0.8).
+- Retention windows, legal hold, consent-aware capture (v0.9).
 - Hard purge / crypto-shred and pgvector index reclamation (beyond v0.7's
   auditable compaction).
-- Governed reflection write path; cross-tenant scope enumeration for fleet scheduling.
+- Optional queue/cron backend behind the orchestrator interface; auto-discovered
+  scope enumeration.
 - Observability + economics, AI PR review runtime, deployment hardening.
 
 See [docs/rollout.md](docs/rollout.md) and the build phases in [CLAUDE.md](CLAUDE.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -351,10 +351,19 @@ resurrect deleted memory and none bypass the policy broker (it stays
 authoritative — workers demote/flag/propose only). A worker failure is caught and
 recorded (`lifecycle_worker_failed`), never raised into a caller, so it cannot
 block chat. Workers add no HTTP route; they run via
-`python -m app.workers.runner` (hosted by the Railway `worker` service). See
+`python -m app.workers.runner` (hosted by the Railway `worker` service).
+
+As of **v0.8** these jobs run inside an operable **worker runtime**
+(`app/workers/{orchestrator,scheduler,locks,retry}.py`): a per-scope lease prevents
+duplicate concurrent runs, a retry/backoff policy absorbs transient faults,
+exhausted retries dead-letter, run history persists (`worker_runs`, migration
+`006`), and `GET /healthz/workers` exposes health. `services/worker/main.py` runs
+the scheduler over explicit `worker_scopes`. See
 [ADR-010](../infra/adr/ADR-010-background-memory-lifecycle-workers.md),
 [ADR-011](../infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md),
-[background-lifecycle-workers.md](background-lifecycle-workers.md), and
+[ADR-012](../infra/adr/ADR-012-worker-runtime-orchestration.md),
+[background-lifecycle-workers.md](background-lifecycle-workers.md),
+[worker-runtime.md](worker-runtime.md), and
 [deletion-compaction.md](deletion-compaction.md).
 
 ## Failure modes considered

--- a/docs/background-lifecycle-workers.md
+++ b/docs/background-lifecycle-workers.md
@@ -107,15 +107,24 @@ Thresholds are `Settings.workers_*` (see `app/core/config.py`):
 
 `MEMORYOPS_WORKERS_REFLECTION=1` is the public toggle for reflection.
 
+## Scheduled runtime (v0.8)
+
+As of v0.8 these jobs are driven by an operable **worker runtime** — leased so
+duplicate concurrent runs are prevented, retried with backoff, and recorded as
+run history / dead-letter evidence, with a `GET /healthz/workers` health view.
+`run_jobs(...)` is still the single-scope unit of work; the runtime adds
+scheduling, locking, retries, and durable history around it. See
+[worker-runtime.md](worker-runtime.md) and
+[ADR-012](../infra/adr/ADR-012-worker-runtime-orchestration.md).
+
 ## How this fits the Railway worker service
 
 Deployment is Railway-only (one project, five services: web/api/worker + Postgres
 + Redis — see [deployment/railway.md](deployment/railway.md)). The `worker`
-service is the natural host for a scheduled loop that, for each active tenant/user
-scope, calls `run_jobs(...)`. **Scope enumeration and scheduling live in the
-orchestrator**, not in the workers — workers are deliberately single-scope so
-tenant isolation is structural. No new infrastructure or live deployment is
-introduced by v0.6.
+service runs the v0.8 scheduler (`services/worker/main.py`), which calls the
+orchestrator once per interval for each configured `"tenant:user"` scope.
+**Scope enumeration stays explicit** (`worker_scopes`), and workers are
+deliberately single-scope so tenant isolation is structural.
 
 ## Limitations / future work
 

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -63,14 +63,20 @@ config files is resolved relative to the service **Root Directory**.
 - **Config File:** `railway/worker.railway.json`
 - **Dockerfile path:** `services/worker/Dockerfile` (relative to repo root)
 - **Start command:** `python main.py` (from config)
-- **No HTTP health check** — it is an interval scheduler, not a web server.
+- **No HTTP health check on the worker itself** — it is an interval scheduler, not
+  a web server. As of v0.8 it runs the orchestrator + scheduler over the real
+  lifecycle workers (leased, retried, dead-lettered); set
+  `MEMORYOPS_WORKER_SCOPES="tenant:user,…"` and optionally
+  `MEMORYOPS_WORKER_INTERVAL_SECONDS`. **Worker health is observable via the API**
+  at `GET /healthz/workers` (run history, dead-letter / failure counts, last run
+  per scope). See [worker-runtime.md](../worker-runtime.md).
 
 ## Deployment order
 
 Provision and deploy in this order so dependencies are ready:
 
 1. **Postgres** plugin — then run migrations from `infra/db/migrations` (apply
-   `001…005` in order; `005_loop_engineering.sql` is the latest).
+   `001…006` in order; `006_worker_runtime.sql` is the latest).
 2. **Redis** plugin.
 3. **`memoryops-api`** — set `MEMORYOPS_STORAGE=postgres`, `DATABASE_URL`,
    `REDIS_URL`. Wait for `/readyz` to report `ready: true`.
@@ -107,7 +113,8 @@ After all five are up, run the smoke test
   `HEALTHCHECK` is cosmetic in production.
 - `NEXT_PUBLIC_API_URL` is build-time; changing the API domain requires a **web
   rebuild**, not just a restart.
-- The worker is a single-replica interval scheduler (no Celery/Temporal yet);
-  it is intentionally simple and idempotent per tick.
+- The worker is an interval scheduler (no Celery/Temporal yet); it is idempotent
+  per tick and lease-arbitrated, so running more than one replica is safe (the
+  lease prevents duplicate runs) but there is no central schedule coordinator.
 - Postgres RLS is enforced in `004_rls_policies.sql`; verify with
   `scripts/check_rls_policies.py` against the Railway database.

--- a/docs/phase-gates/phase-14-worker-runtime-orchestration.md
+++ b/docs/phase-gates/phase-14-worker-runtime-orchestration.md
@@ -1,0 +1,50 @@
+# Phase 14 (addendum) — Worker Runtime + Scheduled Lifecycle Orchestration
+
+> Companion to [phase-12-background-lifecycle-workers.md](phase-12-background-lifecycle-workers.md),
+> [phase-12-reliability.md](phase-12-reliability.md), and
+> [phase-13-infrastructure.md](phase-13-infrastructure.md). v0.8 turns the
+> lifecycle workers from callable functions into an operable runtime. Decision
+> record: [ADR-012](../../infra/adr/ADR-012-worker-runtime-orchestration.md).
+
+**Question:** How are the v0.6/v0.7 lifecycle jobs *operated* — scheduled, run
+without duplication across replicas, retried on transient faults, and recorded
+(including failures) — without adding queue infrastructure?
+
+## MemoryOps mapping
+A worker runtime in `services/api/app/workers/` composed of a lease/lock
+(`locks.py`), a retry/backoff policy (`retry.py`), an orchestrator
+(`orchestrator.py`), and a thin scheduler (`scheduler.py`). For each explicit
+`(tenant, user)` scope it acquires a lease, runs the lifecycle jobs under retry,
+persists a content-free run-history record (or a dead-letter record on exhausted
+retries), and always releases the lease. Leases + run history persist via
+`006_worker_runtime.sql`; `GET /healthz/workers` surfaces health. `services/worker/
+main.py` drives the real lifecycle workers (superseding the legacy `jobs.py`).
+See [worker-runtime.md](../worker-runtime.md).
+
+## Gate (must be true to pass)
+- Duplicate concurrent runs of a scope are prevented by a lease; an expired lease
+  is reclaimable so a crashed worker never deadlocks a scope.
+- A retry/backoff policy absorbs transient faults; exhausted retries become a
+  dead-letter record — never silently lost.
+- Run history + dead-letter records are persisted and queryable; worker health is
+  visible via an endpoint.
+- Scopes are explicit (no unbounded cross-tenant scan); run records are tenant
+  scoped and content-free.
+- One scope's failure never blocks another; a bad scheduler tick never crashes the
+  worker process; the runtime stays off the chat path.
+
+## Evidence
+- `services/api/app/workers/{locks,retry,orchestrator,scheduler}.py`
+- `services/api/app/db/{repository,memory_repo,postgres_repo,entities}.py`
+  (`try_acquire_lease`/`renew_lease`/`release_lease`/`get_lease`,
+  `add_worker_run`/`list_worker_runs`, `WorkerLease`/`WorkerRunRecord`)
+- `infra/db/migrations/006_worker_runtime.sql`,
+  `services/api/app/models/sqlalchemy_models.py` (`WorkerLeaseORM`/`WorkerRunORM`)
+- `services/api/app/routes/health.py` (`GET /healthz/workers`)
+- `services/worker/main.py` (scheduler entrypoint)
+- `services/api/tests/test_worker_retry.py`, `test_worker_locks.py`,
+  `test_worker_orchestrator.py`, `test_worker_health.py`,
+  `test_tenant_isolation.py`, `test_deletion.py`
+- `scripts/pr_invariant_gate.py` (worker-runtime evidence rules)
+
+## Status: ✅ Implemented (v0.8)

--- a/docs/rollout.md
+++ b/docs/rollout.md
@@ -66,13 +66,24 @@ See [deletion-compaction.md](deletion-compaction.md),
 [phase-gates/phase-13-deletion-compaction-vector-purge.md](phase-gates/phase-13-deletion-compaction-vector-purge.md),
 [ADR-011](../infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md).
 
+## Phase 5 (cont.) — Worker runtime + scheduled orchestration ✅ (v0.8)
+The lifecycle jobs become operable: a lease/lock prevents duplicate concurrent
+runs, a retry/backoff policy absorbs transient faults, exhausted retries
+dead-letter, run history is persisted, and `GET /healthz/workers` exposes health.
+A thin scheduler drives the orchestrator over explicit `"tenant:user"` scopes;
+`services/worker/main.py` now runs the real lifecycle workers (superseding the
+legacy `jobs.py`). New migration `006_worker_runtime.sql`. See
+[worker-runtime.md](worker-runtime.md),
+[phase-gates/phase-14-worker-runtime-orchestration.md](phase-gates/phase-14-worker-runtime-orchestration.md),
+[ADR-012](../infra/adr/ADR-012-worker-runtime-orchestration.md).
+
 ## Public roadmap
 
 | Version | Scope | Status |
 |---------|-------|--------|
 | v0.7 | Physical deletion compaction + vector purge verification | ✅ Done |
-| v0.8 | Railway worker runtime + scheduled lifecycle orchestration | ⏳ Next |
-| v0.9 | Retention policies + legal hold + consent-aware memory | ⏳ Planned |
+| v0.8 | Worker runtime + scheduled lifecycle orchestration | ✅ Done |
+| v0.9 | Retention policies + legal hold + consent-aware memory | ⏳ Next |
 | v0.10 | Assistant SDK + example apps | ⏳ Planned |
 | v1.0 | Production-ready governed memory runtime | ⏳ Planned |
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -127,6 +127,24 @@ The most dangerous failures for an AI memory system are:
   [vector-purge-verification.md](vector-purge-verification.md), and
   [ADR-011](../infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md).
 
+### Worker runtime (v0.8)
+- The scheduled worker runtime persists two new operational artifacts —
+  **leases** (`worker_leases`) and **run history** (`worker_runs`, migration
+  `006`). Both are **content-free**: run records carry ids, counts, status,
+  attempts, and owner only — never memory content (`test_deletion.py::
+  test_worker_runtime_preserves_deletion_guarantee`).
+- Run history is **tenant scoped** at the repository (`list_worker_runs`
+  filters by `tenant_id`/`user_id`; `test_tenant_isolation.py::
+  test_worker_runs_are_tenant_scoped`). Lease keys are scope identifiers
+  (`"tenant:user"`), not data.
+- A **lease prevents duplicate concurrent runs** of a scope across replicas and
+  **expires**, so a crashed worker never deadlocks a scope. Exhausted retries are
+  **dead-lettered** (never silently lost) and surfaced at `GET /healthz/workers`.
+- The runtime stays **off the chat path** and never resurrects deleted memory —
+  running it over a scope preserves the deletion guarantee. See
+  [worker-runtime.md](worker-runtime.md) and
+  [ADR-012](../infra/adr/ADR-012-worker-runtime-orchestration.md).
+
 ## Production hardening roadmap
 
 - Encryption at rest (pgcrypto / disk) + field-level encryption for high-sensitivity content.

--- a/docs/worker-runtime.md
+++ b/docs/worker-runtime.md
@@ -1,0 +1,92 @@
+# Worker Runtime + Scheduled Lifecycle Orchestration (v0.8)
+
+> Decision record: [ADR-012](../infra/adr/ADR-012-worker-runtime-orchestration.md).
+> Builds on [background-lifecycle-workers.md](background-lifecycle-workers.md)
+> (the jobs) and [deletion-compaction.md](deletion-compaction.md). Deployment:
+> [deployment/railway.md](deployment/railway.md).
+
+v0.6/v0.7 gave MemoryOps the lifecycle **jobs**. v0.8 makes them **operable**: run
+them on a schedule, prevent duplicate runs, retry transient faults, and record
+what ran (and what failed) — without a queue or new infrastructure.
+
+## The pieces
+
+| Piece | File | Responsibility |
+|-------|------|----------------|
+| Lease / lock | `app/workers/locks.py` | TTL'd mutual exclusion per `"tenant:user"` scope |
+| Retry / backoff | `app/workers/retry.py` | deterministic exponential backoff with a ceiling |
+| Orchestrator | `app/workers/orchestrator.py` | lease → run jobs (retried) → record history / dead-letter → release |
+| Scheduler | `app/workers/scheduler.py` | interval loop running one pass over the configured scopes |
+| Worker process | `services/worker/main.py` | wires the scheduler to the real lifecycle workers |
+| Health | `GET /healthz/workers` | recent runs, dead-letter/failure counts, last run per scope |
+
+## How one scope is processed
+
+```
+acquire lease(tenant:user)                     # locks.py — duplicate runs prevented
+  └─ if held by another owner → record locked_skip, do nothing
+run_jobs(...) under retry/backoff              # retry.py absorbs transient store faults
+  ├─ success            → record run history (completed / completed_with_findings / failed)
+  └─ retries exhausted  → record dead_letter (never silently lost)
+release lease                                  # always, even on failure → never deadlocked
+```
+
+A lease **expires** after `worker_lease_ttl_seconds`, so a crashed worker never
+deadlocks a scope — the lease is reclaimable.
+
+## Run history & dead-letter
+
+Every orchestrated run appends a content-free `WorkerRunRecord` (ids/counts/status
+only — never memory content): `tenant_id`, `user_id`, `status`, `jobs`, `attempts`,
+scanned/changed/skipped/error counts, `owner`, `trace_id`. Statuses:
+
+- `completed` / `completed_with_findings` / `failed` — mirror the job report;
+- `locked_skip` — another replica held the lease (duplicate prevented);
+- `dead_letter` — retries exhausted on a transient fault.
+
+Stored via `worker_runs` (migration `006_worker_runtime.sql`); query with
+`Repository.list_worker_runs(...)`.
+
+## Configuration
+
+| Setting | Default | Meaning |
+|---------|---------|---------|
+| `worker_interval_seconds` (`MEMORYOPS_WORKER_INTERVAL_SECONDS`) | 60 | seconds between scheduler passes |
+| `worker_scopes` (`MEMORYOPS_WORKER_SCOPES`) | `tenant_demo:user_demo` | explicit `"tenant:user,…"` scopes to run |
+| `worker_lease_ttl_seconds` | 300 | lease TTL (reclaimable after this) |
+| `worker_max_attempts` | 3 | retry attempts per scope |
+| `worker_backoff_base_seconds` | 1.0 | base backoff delay |
+| `worker_backoff_factor` | 2.0 | backoff multiplier |
+| `worker_backoff_max_seconds` | 30.0 | backoff ceiling |
+| `worker_run_history_limit` | 500 | rows scanned for the health view |
+
+## Running
+
+```bash
+# the worker process (interval scheduler over configured scopes)
+cd services/worker && python main.py
+
+# one pass, programmatically
+from app.workers import WorkerScheduler, Scope
+WorkerScheduler(repo, scopes=[Scope("t1", "u1")]).tick()
+
+# worker health
+curl localhost:8000/healthz/workers
+```
+
+## Guarantees (enforced in code + tests)
+
+- **Duplicate runs prevented** by the lease; **never deadlocked** (leases expire).
+- **Tenant scoped** — explicit scopes only; no unbounded cross-tenant scan.
+- **Failures durable, not fatal** — retry → dead-letter; a bad tick never crashes
+  the scheduler; one scope's failure never blocks another.
+- **Content-free** run history + health.
+- **Off the chat path** — maintenance only.
+
+## Limitations (kept honest)
+
+- Single-process interval scheduler — not a distributed cron; multiple replicas are
+  safe (the lease arbitrates) but there is no central schedule coordinator.
+- No external queue/broker (Celery/Temporal). The orchestrator interface is
+  queue-shaped so one can be added later without touching the lifecycle workers.
+- Scope enumeration is explicit (operator-configured), not auto-discovered.

--- a/infra/adr/ADR-012-worker-runtime-orchestration.md
+++ b/infra/adr/ADR-012-worker-runtime-orchestration.md
@@ -1,0 +1,84 @@
+# ADR-012 — Worker Runtime + Scheduled Lifecycle Orchestration
+
+- Status: Accepted (v0.8)
+- Date: 2026-06-22
+- Supersedes: none
+- Related: ADR-001 (storage), ADR-004 (observability), ADR-010 (background
+  lifecycle workers), ADR-011 (deletion compaction)
+
+## Context
+
+v0.6 and v0.7 gave MemoryOps real lifecycle workers (decay, archive, conflict
+scan, reflection, deletion compaction, deletion verification) and a tenant-scoped
+`runner`. But they were still *callable functions*: something external had to
+decide when to run them, nothing prevented two replicas from running the same
+scope at once, a transient store fault just failed the run, and there was no
+durable record of what ran or what failed. That is library code, not operable
+infrastructure.
+
+The product brief's `services/worker` was still the Phase-5 scaffold (`jobs.py`)
+with its own ad-hoc decay/archive logic, disconnected from the v0.6/v0.7
+lifecycle workers.
+
+## Decision
+
+Add a production-style **worker runtime** in `services/api/app/workers/` and point
+the `services/worker` process at it. Four small, composable pieces:
+
+1. **Lease/lock** (`locks.py` + `Repository.try_acquire_lease`) — a TTL'd
+   mutual-exclusion token keyed by `"tenant:user"`. Only the holder processes a
+   scope; a second worker that fails to acquire skips it. Leases expire, so a
+   crashed worker never deadlocks a scope. Atomicity lives in the repository
+   (in-memory live-owner check; Postgres `INSERT … ON CONFLICT … WHERE expired/own`).
+2. **Retry/backoff** (`retry.py`) — deterministic exponential backoff with a
+   ceiling, wrapping the per-scope work to absorb transient faults. Exhausted
+   retries are dead-lettered, never silently lost.
+3. **Orchestrator** (`orchestrator.py`) — for each explicit scope: acquire lease
+   → `run_jobs` under retry → persist a content-free **run-history** record (or a
+   **dead-letter** record) → always release the lease. One scope failing never
+   blocks another.
+4. **Scheduler** (`scheduler.py`) — a thin interval loop that runs one
+   orchestration pass per tick over the configured scopes; `max_ticks` /
+   `run_once` make it testable and scriptable.
+
+Run history + leases are persisted via additive repository methods and a new
+migration (`006_worker_runtime.sql`: `worker_leases`, `worker_runs`). A
+`GET /healthz/workers` endpoint surfaces recent runs, dead-letter / failure
+counts, and the last run per scope.
+
+### Design constraints
+
+- **Tenant isolation preserved.** Scope enumeration stays explicit — the
+  scheduler is handed `"tenant:user"` scopes (`worker_scopes`); there is no
+  unbounded cross-tenant scan (consistent with ADR-010).
+- **Duplicate runs prevented** by the lease; **never deadlocked** because leases
+  expire.
+- **Failures are durable, not fatal.** Transient faults retry; exhausted retries
+  dead-letter; a bad tick never crashes the scheduler.
+- **Content-free.** Run records and health carry ids/counts/status only — never
+  memory content (invariant #7 spirit; aligns with worker audit metadata).
+- **Off the chat path.** Unchanged from ADR-010 — the runtime is maintenance only.
+
+## Alternatives considered
+
+- **Celery / Temporal / a real queue.** Rejected for v0.8: adds infra and a
+  broker dependency for a single-scope, low-frequency maintenance workload. The
+  lease + retry + dead-letter primitives cover the need and keep the repository as
+  the only backing store. The orchestrator interface is queue-shaped, so this can
+  be swapped later without touching the lifecycle workers.
+- **Advisory `pg_advisory_lock`.** Rejected: ties locking to a live DB session and
+  is invisible/untestable for the in-memory backend. A lease row works on both
+  backends and is inspectable (`/healthz/workers`, `get_lease`).
+- **Cross-tenant scope auto-discovery.** Deferred (as in ADR-010): scope
+  enumeration stays explicit to keep isolation structural.
+
+## Consequences
+
+- `services/worker/main.py` now drives the real lifecycle workers via the
+  scheduler; the legacy `jobs.py` scaffold is superseded on the maintenance path.
+- New operable surface: leased runs, retry/backoff, durable run history,
+  dead-letter records, and a worker health endpoint.
+- New migration `006_worker_runtime.sql`; additive repository methods only.
+- Future work (v0.9+): governed retention/legal-hold inputs to the workers;
+  optional queue/cron backend behind the same orchestrator interface; per-scope
+  scheduling cadence.

--- a/infra/db/migrations/006_worker_runtime.sql
+++ b/infra/db/migrations/006_worker_runtime.sql
@@ -1,0 +1,44 @@
+-- 006_worker_runtime.sql — worker runtime: leases + run history (v0.8, ADR-012)
+--
+-- The worker orchestrator runs lifecycle jobs on a schedule for explicit scopes.
+-- A lease prevents duplicate concurrent runs of the same scope; run history is
+-- content-free operational evidence (ids/counts/status only — never memory
+-- content). A dead-letter run is just a run row with status='dead_letter'.
+
+create table if not exists worker_leases (
+  key text primary key,
+  owner text not null,
+  acquired_at timestamptz not null default now(),
+  expires_at timestamptz not null
+);
+
+create index if not exists idx_worker_leases_expires_at
+on worker_leases(expires_at);
+
+create table if not exists worker_runs (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id text not null,
+  user_id text not null,
+  status text not null,
+  jobs jsonb default '[]'::jsonb,
+  attempts integer not null default 0,
+  scanned_count integer not null default 0,
+  changed_count integer not null default 0,
+  skipped_count integer not null default 0,
+  error_count integer not null default 0,
+  owner text not null default '',
+  trace_id text,
+  error text,
+  metadata jsonb default '{}'::jsonb,
+  started_at timestamptz not null default now(),
+  completed_at timestamptz
+);
+
+create index if not exists idx_worker_runs_tenant_user
+on worker_runs(tenant_id, user_id);
+
+create index if not exists idx_worker_runs_status
+on worker_runs(status);
+
+create index if not exists idx_worker_runs_started_at
+on worker_runs(started_at desc);

--- a/scripts/pr_invariant_gate.py
+++ b/scripts/pr_invariant_gate.py
@@ -260,9 +260,10 @@ RULES: list[Rule] = [
         r"^services/api/app/workers/",
         r"^services/api/tests/test_(lifecycle_worker|decay_worker|archive_worker"
         r"|deletion_verification_worker|deletion_compaction_worker|conflict_scan_worker"
-        r"|worker_idempotency)\.py$",
+        r"|worker_idempotency|worker_orchestrator|worker_locks|worker_retry"
+        r"|worker_health)\.py$",
         "Background worker code changed without worker tests (tests/test_*_worker.py "
-        "or test_worker_idempotency.py).",
+        "or test_worker_*.py).",
     ),
     Rule(
         "Security",
@@ -354,6 +355,51 @@ RULES: list[Rule] = [
         r"|infra/adr/ADR-011-physical-deletion-compaction-vector-purge\.md$)",
         "Worker audit/event schema changed without updating lifecycle/governance/security "
         "or deletion-compaction docs / an ADR.",
+    ),
+    # ── v0.8 Worker runtime + scheduled lifecycle orchestration (ADR-012) ───────
+    Rule(
+        "Reliability",
+        "worker-runtime-tests",
+        r"^services/api/app/workers/(orchestrator|scheduler|locks|retry)\.py$",
+        r"^services/api/tests/test_worker_(orchestrator|locks|retry|health)\.py$",
+        "Worker runtime (orchestrator/scheduler/locks/retry) changed without runtime tests "
+        "(test_worker_orchestrator/locks/retry/health).",
+    ),
+    Rule(
+        "Reliability",
+        "worker-lease-isolation-tests",
+        r"^services/api/app/workers/(orchestrator|locks)\.py$",
+        r"^services/api/tests/test_worker_locks\.py$",
+        "Lease / duplicate-run prevention changed without lock tests (test_worker_locks).",
+    ),
+    Rule(
+        "Reliability",
+        "worker-runtime-persistence-tests",
+        r"^services/api/app/db/(repository|memory_repo|postgres_repo|entities)\.py$",
+        r"^services/api/tests/test_worker_(orchestrator|locks|health)\.py$"
+        r"|^services/api/tests/test_tenant_isolation\.py$",
+        "Worker lease / run-history persistence changed without runtime or tenant-isolation "
+        "tests.",
+    ),
+    Rule(
+        "Docs/ADR",
+        "worker-runtime-docs",
+        r"^services/api/app/workers/(orchestrator|scheduler|locks|retry)\.py$|^services/worker/",
+        r"^(docs/worker-runtime\.md$|docs/background-lifecycle-workers\.md$"
+        r"|docs/deployment/railway\.md$"
+        r"|infra/adr/ADR-012-worker-runtime-orchestration\.md$"
+        r"|docs/phase-gates/phase-14-worker-runtime-orchestration\.md$)",
+        "Worker runtime / worker process changed without updating worker-runtime, "
+        "lifecycle-worker, or deployment docs / ADR-012 / phase-14 gate.",
+    ),
+    Rule(
+        "Docs/ADR",
+        "worker-runtime-adr",
+        r"^services/api/app/workers/(orchestrator|scheduler)\.py$",
+        r"^(infra/adr/ADR-012-worker-runtime-orchestration\.md$"
+        r"|docs/phase-gates/phase-14-worker-runtime-orchestration\.md$)",
+        "Worker orchestration/scheduling semantics changed without ADR-012 or phase-14 "
+        "gate evidence.",
     ),
 ]
 

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -82,6 +82,21 @@ class Settings(BaseSettings):
     # touches active/archived rows and never resurrects deleted memory.
     workers_compaction_min_age_days: int = 0
 
+    # Worker runtime / scheduled lifecycle orchestration (v0.8, ADR-012). The
+    # orchestrator runs lifecycle jobs on a schedule for explicit scopes, with a
+    # lease (lock) to prevent duplicate concurrent runs, a retry/backoff policy,
+    # persisted run history, and dead-letter records for exhausted retries.
+    worker_interval_seconds: int = 60
+    worker_lease_ttl_seconds: int = 300
+    worker_max_attempts: int = 3
+    worker_backoff_base_seconds: float = 1.0
+    worker_backoff_factor: float = 2.0
+    worker_backoff_max_seconds: float = 30.0
+    # Explicit scopes the scheduler runs, "tenant:user" comma-separated. Scope
+    # enumeration stays explicit (no unbounded cross-tenant scan) — see ADR-010/012.
+    worker_scopes: str = "tenant_demo:user_demo"
+    worker_run_history_limit: int = 500
+
     # Reliability knobs (used by core.reliability).
     llm_timeout_seconds: float = 8.0
     retrieval_timeout_seconds: float = 3.0
@@ -123,4 +138,10 @@ def get_settings() -> Settings:
     # documented toggle; other thresholds are configured via their field names.
     if (val := os.getenv("MEMORYOPS_WORKERS_REFLECTION")) is not None:
         overrides["workers_reflection_enabled"] = val.lower() not in ("0", "false", "no")
+    # v0.8 worker runtime knobs (ADR-012). Operator-facing public toggles.
+    if (val := os.getenv("MEMORYOPS_WORKER_INTERVAL_SECONDS")) is not None:
+        with contextlib.suppress(ValueError):
+            overrides["worker_interval_seconds"] = int(val)
+    if (val := os.getenv("MEMORYOPS_WORKER_SCOPES")) is not None:
+        overrides["worker_scopes"] = val
     return Settings(**overrides)

--- a/services/api/app/db/entities.py
+++ b/services/api/app/db/entities.py
@@ -121,6 +121,49 @@ class StoredAudit:
     created_at: datetime = field(default_factory=_now)
 
 
+# ── Worker runtime (v0.8, ADR-012) ───────────────────────────────────────────
+@dataclass
+class WorkerLease:
+    """A mutual-exclusion lease that prevents duplicate concurrent worker runs.
+
+    ``key`` identifies the scope being processed (e.g. ``"tenant:user"``). A lease
+    is held by one ``owner`` until ``expires_at``; an expired lease is reclaimable
+    so a crashed worker never deadlocks the scope.
+    """
+
+    key: str
+    owner: str
+    acquired_at: datetime
+    expires_at: datetime
+
+
+@dataclass
+class WorkerRunRecord:
+    """Persisted history of one orchestrated worker run for a single scope.
+
+    Content-free operational evidence (ids/counts/status only). A run that
+    exhausts its retries is recorded with ``status='dead_letter'``; a run skipped
+    because another worker holds the lease is ``status='locked_skip'``.
+    """
+
+    tenant_id: str
+    user_id: str
+    status: str
+    jobs: list[str] = field(default_factory=list)
+    attempts: int = 0
+    scanned_count: int = 0
+    changed_count: int = 0
+    skipped_count: int = 0
+    error_count: int = 0
+    owner: str = ""
+    trace_id: str | None = None
+    error: str | None = None
+    details: dict = field(default_factory=dict)
+    id: str = field(default_factory=new_id)
+    started_at: datetime = field(default_factory=_now)
+    completed_at: datetime | None = None
+
+
 @dataclass
 class StoredSettings:
     tenant_id: str

--- a/services/api/app/db/memory_repo.py
+++ b/services/api/app/db/memory_repo.py
@@ -10,7 +10,15 @@ from datetime import UTC, datetime
 
 from ..loops.metrics import summarize_loop_runs
 from ..loops.types import LoopEvent, LoopRun
-from .entities import StoredAudit, StoredMemory, StoredSettings, apply_compaction, is_compacted
+from .entities import (
+    StoredAudit,
+    StoredMemory,
+    StoredSettings,
+    WorkerLease,
+    WorkerRunRecord,
+    apply_compaction,
+    is_compacted,
+)
 from .repository import Repository
 
 _ACTIVE = "active"
@@ -28,6 +36,8 @@ class InMemoryRepository(Repository):
         self._settings: dict[tuple[str, str], StoredSettings] = {}
         self._loop_runs: dict[str, LoopRun] = {}
         self._loop_events: list[LoopEvent] = []
+        self._leases: dict[str, WorkerLease] = {}
+        self._worker_runs: list[WorkerRunRecord] = []
 
     # ── memory ───────────────────────────────────────────────────────────────
     def create_memory(self, memory: StoredMemory) -> StoredMemory:
@@ -159,6 +169,54 @@ class InMemoryRepository(Repository):
         if memory_id:
             rows = [e for e in rows if e.memory_id == memory_id]
         return sorted(rows, key=lambda e: e.created_at, reverse=True)[:limit]
+
+    # ── worker runtime (v0.8) ──────────────────────────────────────────────────
+    def try_acquire_lease(
+        self, key: str, owner: str, *, now: datetime, expires_at: datetime
+    ) -> bool:
+        existing = self._leases.get(key)
+        if existing and existing.expires_at > now and existing.owner != owner:
+            return False  # another owner holds a live lease → duplicate prevented
+        self._leases[key] = WorkerLease(
+            key=key, owner=owner, acquired_at=now, expires_at=expires_at
+        )
+        return True
+
+    def renew_lease(self, key: str, owner: str, *, expires_at: datetime) -> bool:
+        existing = self._leases.get(key)
+        if not existing or existing.owner != owner:
+            return False
+        existing.expires_at = expires_at
+        return True
+
+    def release_lease(self, key: str, owner: str) -> None:
+        existing = self._leases.get(key)
+        if existing and existing.owner == owner:
+            del self._leases[key]
+
+    def get_lease(self, key: str) -> WorkerLease | None:
+        return self._leases.get(key)
+
+    def add_worker_run(self, record: WorkerRunRecord) -> WorkerRunRecord:
+        self._worker_runs.append(record)
+        return record
+
+    def list_worker_runs(
+        self,
+        *,
+        tenant_id: str | None = None,
+        user_id: str | None = None,
+        status: str | None = None,
+        limit: int = 200,
+    ) -> list[WorkerRunRecord]:
+        rows = list(self._worker_runs)
+        if tenant_id:
+            rows = [r for r in rows if r.tenant_id == tenant_id]
+        if user_id:
+            rows = [r for r in rows if r.user_id == user_id]
+        if status:
+            rows = [r for r in rows if r.status == status]
+        return sorted(rows, key=lambda r: r.started_at, reverse=True)[:limit]
 
     # ── settings ─────────────────────────────────────────────────────────────
     def get_settings(self, tenant_id: str, user_id: str) -> StoredSettings:

--- a/services/api/app/db/postgres_repo.py
+++ b/services/api/app/db/postgres_repo.py
@@ -23,9 +23,19 @@ from ..models.sqlalchemy_models import (
     LoopRunORM,
     MemoryRecordORM,
     SettingsORM,
+    WorkerLeaseORM,
+    WorkerRunORM,
 )
 from ..schemas.memory import MemoryType, Sensitivity, Source, Status
-from .entities import StoredAudit, StoredMemory, StoredSettings, apply_compaction, is_compacted
+from .entities import (
+    StoredAudit,
+    StoredMemory,
+    StoredSettings,
+    WorkerLease,
+    WorkerRunRecord,
+    apply_compaction,
+    is_compacted,
+)
 from .repository import Repository
 
 _DELETED = "deleted"
@@ -345,6 +355,123 @@ class PostgresRepository(Repository):
                     trace_id=r.trace_id,
                     metadata=r.extra_metadata or {},
                     created_at=r.created_at,
+                )
+                for r in s.scalars(stmt)
+            ]
+
+    # ── worker runtime (v0.8) ──────────────────────────────────────────────────
+    def try_acquire_lease(
+        self, key: str, owner: str, *, now: datetime, expires_at: datetime
+    ) -> bool:
+        # Atomic acquire: insert, or take over only if the prior lease expired or
+        # is ours. RETURNING owner tells us whether we now hold it.
+        sql = text(
+            """
+            INSERT INTO worker_leases (key, owner, acquired_at, expires_at)
+            VALUES (:key, :owner, :now, :exp)
+            ON CONFLICT (key) DO UPDATE
+              SET owner = excluded.owner,
+                  acquired_at = excluded.acquired_at,
+                  expires_at = excluded.expires_at
+              WHERE worker_leases.expires_at <= :now OR worker_leases.owner = :owner
+            RETURNING owner
+            """
+        )
+        with self._Session() as s:
+            row = s.execute(
+                sql, {"key": key, "owner": owner, "now": now, "exp": expires_at}
+            ).first()
+            s.commit()
+            return bool(row and row[0] == owner)
+
+    def renew_lease(self, key: str, owner: str, *, expires_at: datetime) -> bool:
+        with self._Session() as s:
+            row = s.get(WorkerLeaseORM, key)
+            if not row or row.owner != owner:
+                return False
+            row.expires_at = expires_at
+            s.commit()
+            return True
+
+    def release_lease(self, key: str, owner: str) -> None:
+        with self._Session() as s:
+            row = s.get(WorkerLeaseORM, key)
+            if row and row.owner == owner:
+                s.delete(row)
+                s.commit()
+
+    def get_lease(self, key: str) -> WorkerLease | None:
+        with self._Session() as s:
+            row = s.get(WorkerLeaseORM, key)
+            if not row:
+                return None
+            return WorkerLease(
+                key=row.key,
+                owner=row.owner,
+                acquired_at=row.acquired_at,
+                expires_at=row.expires_at,
+            )
+
+    def add_worker_run(self, record: WorkerRunRecord) -> WorkerRunRecord:
+        with self._Session() as s:
+            s.add(
+                WorkerRunORM(
+                    id=record.id,
+                    tenant_id=record.tenant_id,
+                    user_id=record.user_id,
+                    status=record.status,
+                    jobs=list(record.jobs),
+                    attempts=record.attempts,
+                    scanned_count=record.scanned_count,
+                    changed_count=record.changed_count,
+                    skipped_count=record.skipped_count,
+                    error_count=record.error_count,
+                    owner=record.owner,
+                    trace_id=record.trace_id,
+                    error=record.error,
+                    extra_metadata=record.details,
+                    started_at=record.started_at,
+                    completed_at=record.completed_at,
+                )
+            )
+            s.commit()
+            return record
+
+    def list_worker_runs(
+        self,
+        *,
+        tenant_id: str | None = None,
+        user_id: str | None = None,
+        status: str | None = None,
+        limit: int = 200,
+    ) -> list[WorkerRunRecord]:
+        with self._Session() as s:
+            stmt = select(WorkerRunORM)
+            if tenant_id:
+                stmt = stmt.where(WorkerRunORM.tenant_id == tenant_id)
+            if user_id:
+                stmt = stmt.where(WorkerRunORM.user_id == user_id)
+            if status:
+                stmt = stmt.where(WorkerRunORM.status == status)
+            stmt = stmt.order_by(WorkerRunORM.started_at.desc()).limit(limit)
+            return [
+                WorkerRunRecord(
+                    id=r.id,
+                    tenant_id=r.tenant_id,
+                    user_id=r.user_id,
+                    status=r.status,
+                    jobs=list(r.jobs or []),
+                    attempts=r.attempts,
+                    scanned_count=r.scanned_count,
+                    changed_count=r.changed_count,
+                    skipped_count=r.skipped_count,
+                    error_count=r.error_count,
+                    owner=r.owner,
+                    trace_id=r.trace_id,
+                    error=r.error,
+                    details=r.extra_metadata or {},
+                    started_at=r.started_at,
+                    completed_at=r.completed_at,
                 )
                 for r in s.scalars(stmt)
             ]

--- a/services/api/app/db/repository.py
+++ b/services/api/app/db/repository.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 
 from ..loops.types import LoopEvent, LoopRun
-from .entities import StoredAudit, StoredMemory, StoredSettings
+from .entities import StoredAudit, StoredMemory, StoredSettings, WorkerLease, WorkerRunRecord
 
 
 class Repository(ABC):
@@ -110,6 +110,47 @@ class Repository(ABC):
         memory_id: str | None = None,
         limit: int = 200,
     ) -> list[StoredAudit]: ...
+
+    # ── worker runtime (v0.8, ADR-012) ────────────────────────────────────────
+    @abstractmethod
+    def try_acquire_lease(
+        self, key: str, owner: str, *, now: datetime, expires_at: datetime
+    ) -> bool:
+        """Atomically acquire the lease ``key`` for ``owner``.
+
+        Returns ``True`` if acquired (no live lease existed, or the prior one was
+        expired and is reclaimed). Returns ``False`` if another owner holds a
+        non-expired lease — this is how duplicate concurrent runs are prevented.
+        """
+        ...
+
+    @abstractmethod
+    def renew_lease(self, key: str, owner: str, *, expires_at: datetime) -> bool:
+        """Extend the lease expiry; only the current owner can renew."""
+        ...
+
+    @abstractmethod
+    def release_lease(self, key: str, owner: str) -> None:
+        """Release the lease; a no-op if held by a different owner (or absent)."""
+        ...
+
+    @abstractmethod
+    def get_lease(self, key: str) -> WorkerLease | None: ...
+
+    @abstractmethod
+    def add_worker_run(self, record: WorkerRunRecord) -> WorkerRunRecord:
+        """Append a worker run record to history (append-only operational log)."""
+        ...
+
+    @abstractmethod
+    def list_worker_runs(
+        self,
+        *,
+        tenant_id: str | None = None,
+        user_id: str | None = None,
+        status: str | None = None,
+        limit: int = 200,
+    ) -> list[WorkerRunRecord]: ...
 
     # ── settings ─────────────────────────────────────────────────────────────
     @abstractmethod

--- a/services/api/app/models/sqlalchemy_models.py
+++ b/services/api/app/models/sqlalchemy_models.py
@@ -103,6 +103,36 @@ class LoopEventORM(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
 
 
+class WorkerLeaseORM(Base):
+    __tablename__ = "worker_leases"
+
+    key: Mapped[str] = mapped_column(String, primary_key=True)
+    owner: Mapped[str] = mapped_column(String)
+    acquired_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
+
+
+class WorkerRunORM(Base):
+    __tablename__ = "worker_runs"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=_uuid)
+    tenant_id: Mapped[str] = mapped_column(String, index=True)
+    user_id: Mapped[str] = mapped_column(String, index=True)
+    status: Mapped[str] = mapped_column(String, index=True)
+    jobs: Mapped[dict] = mapped_column(JSON, default=list)
+    attempts: Mapped[int] = mapped_column(Integer, default=0)
+    scanned_count: Mapped[int] = mapped_column(Integer, default=0)
+    changed_count: Mapped[int] = mapped_column(Integer, default=0)
+    skipped_count: Mapped[int] = mapped_column(Integer, default=0)
+    error_count: Mapped[int] = mapped_column(Integer, default=0)
+    owner: Mapped[str] = mapped_column(String, default="")
+    trace_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    error: Mapped[str | None] = mapped_column(String, nullable=True)
+    extra_metadata: Mapped[dict] = mapped_column("metadata", JSON, default=dict)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now, index=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
 class SettingsORM(Base):
     __tablename__ = "memory_settings"
 

--- a/services/api/app/routes/health.py
+++ b/services/api/app/routes/health.py
@@ -16,6 +16,23 @@ def healthz() -> dict:
     return {"status": "ok", "version": __version__}
 
 
+@router.get("/healthz/workers")
+def workers_health() -> dict:
+    """Worker runtime health (v0.8): recent run history, dead-letter + failure
+    counts, and the last run per scope. Content-free operational evidence."""
+    from ..workers.orchestrator import summarize_runtime_health
+
+    settings = get_settings()
+    try:
+        summary = summarize_runtime_health(
+            get_repository(), limit=settings.worker_run_history_limit
+        )
+        healthy = summary["dead_letter_count"] == 0 and summary["failed_count"] == 0
+        return {"healthy": healthy, **summary}
+    except Exception as exc:  # noqa: BLE001 — health must not raise
+        return {"healthy": False, "detail": f"unavailable: {type(exc).__name__}"}
+
+
 @router.get("/readyz")
 def readyz() -> dict:
     settings = get_settings()

--- a/services/api/app/workers/__init__.py
+++ b/services/api/app/workers/__init__.py
@@ -22,9 +22,18 @@ from .decay import DecayWorker
 from .deletion_compaction import DeletionCompactionWorker
 from .deletion_verification import DeletionVerificationWorker
 from .lifecycle import LifecycleWorker, WorkerContext
+from .locks import WorkerLeaseManager, scope_key
 from .metrics import summarize_compaction_results, summarize_worker_results
+from .orchestrator import (
+    Scope,
+    WorkerOrchestrator,
+    parse_scopes,
+    summarize_runtime_health,
+)
 from .reflection import ReflectionWorker
+from .retry import RetryOutcome, RetryPolicy, run_with_retry
 from .runner import run_jobs
+from .scheduler import WorkerScheduler
 from .schemas import (
     PurgeVerification,
     WorkerJob,
@@ -44,13 +53,23 @@ __all__ = [
     "PurgeCheck",
     "PurgeVerification",
     "ReflectionWorker",
+    "RetryOutcome",
+    "RetryPolicy",
+    "Scope",
     "WorkerContext",
     "WorkerJob",
     "WorkerJobResult",
+    "WorkerLeaseManager",
+    "WorkerOrchestrator",
     "WorkerRunReport",
     "WorkerRunStatus",
+    "WorkerScheduler",
+    "parse_scopes",
     "run_jobs",
+    "run_with_retry",
+    "scope_key",
     "summarize_compaction_results",
+    "summarize_runtime_health",
     "summarize_worker_results",
     "verify_purged",
 ]

--- a/services/api/app/workers/locks.py
+++ b/services/api/app/workers/locks.py
@@ -1,0 +1,46 @@
+"""Worker leases (locks) for the scheduled runtime (v0.8, ADR-012).
+
+A lease is a TTL'd mutual-exclusion token keyed by the scope being processed
+(``"tenant:user"``). It prevents *duplicate concurrent runs* of the same scope
+across replicas: only the worker that holds a live lease processes that scope; a
+second worker that fails to acquire skips it. Because leases expire, a crashed
+worker never deadlocks a scope — the lease is reclaimable after its TTL.
+
+The atomicity lives in the repository (`try_acquire_lease`): in-memory checks the
+live owner; Postgres uses `INSERT … ON CONFLICT … WHERE expired/own`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from ..db.repository import Repository
+
+
+def scope_key(tenant_id: str, user_id: str) -> str:
+    """Canonical lease key for a (tenant, user) scope."""
+    return f"{tenant_id}:{user_id}"
+
+
+class WorkerLeaseManager:
+    def __init__(self, repo: Repository, *, ttl_seconds: int, owner: str) -> None:
+        self._repo = repo
+        self._ttl = timedelta(seconds=ttl_seconds)
+        self._owner = owner
+
+    @property
+    def owner(self) -> str:
+        return self._owner
+
+    def acquire(self, key: str, *, now: datetime | None = None) -> bool:
+        now = now or datetime.now(UTC)
+        return self._repo.try_acquire_lease(
+            key, self._owner, now=now, expires_at=now + self._ttl
+        )
+
+    def renew(self, key: str, *, now: datetime | None = None) -> bool:
+        now = now or datetime.now(UTC)
+        return self._repo.renew_lease(key, self._owner, expires_at=now + self._ttl)
+
+    def release(self, key: str) -> None:
+        self._repo.release_lease(key, self._owner)

--- a/services/api/app/workers/orchestrator.py
+++ b/services/api/app/workers/orchestrator.py
@@ -1,0 +1,226 @@
+"""Worker runtime orchestration (v0.8, ADR-012).
+
+Turns the v0.6/v0.7 lifecycle workers from callable functions into an operable,
+scheduled runtime. For each explicit ``(tenant, user)`` scope the orchestrator:
+
+  1. acquires a **lease** so duplicate concurrent runs are prevented (locks.py);
+  2. runs the lifecycle jobs (`run_jobs`) under a **retry/backoff** policy that
+     absorbs transient store faults (retry.py);
+  3. persists a content-free **run-history** record (and a **dead-letter** record
+     if retries are exhausted);
+  4. always **releases** the lease, even on failure.
+
+Tenant isolation is preserved: each scope is processed independently through the
+repository's scoped methods, and one scope failing never blocks another. Scope
+enumeration stays explicit (no unbounded cross-tenant scan) — see ADR-010/012.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from ..core.config import get_settings
+from ..core.logging import get_logger
+from ..db.entities import WorkerRunRecord
+from ..db.repository import Repository
+from ..services.audit import AuditService
+from .locks import WorkerLeaseManager, scope_key
+from .retry import RetryPolicy, run_with_retry
+from .runner import run_jobs
+from .schemas import WorkerRunReport, WorkerRunStatus
+
+logger = get_logger("memoryops.workers.orchestrator")
+
+# Run-history statuses (superset of WorkerRunStatus: adds runtime-level outcomes).
+RUN_COMPLETED = WorkerRunStatus.completed.value
+RUN_WITH_FINDINGS = WorkerRunStatus.completed_with_findings.value
+RUN_FAILED = WorkerRunStatus.failed.value
+RUN_LOCKED_SKIP = "locked_skip"
+RUN_DEAD_LETTER = "dead_letter"
+
+
+@dataclass(frozen=True)
+class Scope:
+    tenant_id: str
+    user_id: str
+    jobs: tuple[str, ...] = ("all",)
+
+
+def parse_scopes(raw: str) -> list[Scope]:
+    """Parse ``"tenant:user,tenant2:user2"`` into scopes (jobs default to all)."""
+    scopes: list[Scope] = []
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        tenant, _, user = chunk.partition(":")
+        if tenant and user:
+            scopes.append(Scope(tenant_id=tenant.strip(), user_id=user.strip()))
+    return scopes
+
+
+def default_owner() -> str:
+    """Stable-enough identity for a worker replica: host:pid:rand."""
+    return f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex[:8]}"
+
+
+def _report_status(report: WorkerRunReport) -> str:
+    statuses = {r.status for r in report.results}
+    if RUN_FAILED in statuses:
+        return RUN_FAILED
+    if RUN_WITH_FINDINGS in statuses:
+        return RUN_WITH_FINDINGS
+    return RUN_COMPLETED
+
+
+@dataclass
+class WorkerOrchestrator:
+    repo: Repository
+    owner: str = field(default_factory=default_owner)
+    lease_ttl_seconds: int | None = None
+    retry_policy: RetryPolicy | None = None
+    audit: AuditService | None = None
+    sleep: Callable[[float], None] | None = None
+
+    def __post_init__(self) -> None:
+        s = get_settings()
+        self._leases = WorkerLeaseManager(
+            self.repo,
+            ttl_seconds=self.lease_ttl_seconds or s.worker_lease_ttl_seconds,
+            owner=self.owner,
+        )
+        self._policy = self.retry_policy or RetryPolicy(
+            max_attempts=s.worker_max_attempts,
+            base_delay_seconds=s.worker_backoff_base_seconds,
+            backoff_factor=s.worker_backoff_factor,
+            max_delay_seconds=s.worker_backoff_max_seconds,
+        )
+        self._audit = self.audit or AuditService(self.repo)
+
+    def run_scope(
+        self, scope: Scope, *, now: datetime | None = None, trace_id: str | None = None
+    ) -> WorkerRunRecord:
+        now = now or datetime.now(UTC)
+        key = scope_key(scope.tenant_id, scope.user_id)
+        jobs = list(scope.jobs)
+
+        if not self._leases.acquire(key, now=now):
+            # Another replica holds the lease → skip; record the duplicate-prevented
+            # outcome so it is observable, but do no work.
+            return self._record(
+                scope, jobs, status=RUN_LOCKED_SKIP, attempts=0, now=now,
+                trace_id=trace_id, details={"reason": "lease_held_by_other"},
+            )
+
+        try:
+            outcome = run_with_retry(
+                lambda: run_jobs(
+                    self.repo,
+                    tenant_id=scope.tenant_id,
+                    user_id=scope.user_id,
+                    jobs=jobs,
+                    trace_id=trace_id,
+                    now=now,
+                    audit=self._audit,
+                ),
+                self._policy,
+                sleep=self.sleep or time.sleep,
+            )
+            if outcome.ok and outcome.value is not None:
+                report = outcome.value
+                return self._record(
+                    scope, jobs, status=_report_status(report),
+                    attempts=outcome.attempts, now=now, trace_id=trace_id,
+                    report=report,
+                    details={"jobs": {r.job: r.status for r in report.results}},
+                )
+            # Retries exhausted on a transient fault → dead-letter, never lost.
+            logger.warning(
+                "worker scope dead-lettered",
+                extra={"event": "worker_dead_letter", "status": "failed",
+                       "attempts": outcome.attempts},
+            )
+            return self._record(
+                scope, jobs, status=RUN_DEAD_LETTER, attempts=outcome.attempts,
+                now=now, trace_id=trace_id, error=outcome.error,
+                details={"reason": "retries_exhausted"},
+            )
+        finally:
+            self._leases.release(key)
+
+    def run_once(
+        self,
+        scopes: list[Scope],
+        *,
+        now: datetime | None = None,
+        trace_id: str | None = None,
+    ) -> list[WorkerRunRecord]:
+        """One scheduling pass over all scopes. Scopes are independent."""
+        records: list[WorkerRunRecord] = []
+        for scope in scopes:
+            records.append(self.run_scope(scope, now=now, trace_id=trace_id))
+        return records
+
+    # ── helpers ────────────────────────────────────────────────────────────────
+    def _record(
+        self,
+        scope: Scope,
+        jobs: list[str],
+        *,
+        status: str,
+        attempts: int,
+        now: datetime,
+        trace_id: str | None,
+        report: WorkerRunReport | None = None,
+        error: str | None = None,
+        details: dict | None = None,
+    ) -> WorkerRunRecord:
+        record = WorkerRunRecord(
+            tenant_id=scope.tenant_id,
+            user_id=scope.user_id,
+            status=status,
+            jobs=jobs,
+            attempts=attempts,
+            scanned_count=report.scanned_count if report else 0,
+            changed_count=report.changed_count if report else 0,
+            skipped_count=report.skipped_count if report else 0,
+            error_count=report.error_count if report else 0,
+            owner=self.owner,
+            trace_id=trace_id,
+            error=error,
+            details=details or {},
+            started_at=now,
+            completed_at=datetime.now(UTC),
+        )
+        return self.repo.add_worker_run(record)
+
+
+def summarize_runtime_health(repo: Repository, *, limit: int = 200) -> dict:
+    """Content-free operational health view over recent worker runs (v0.8)."""
+    runs = repo.list_worker_runs(limit=limit)
+    by_status: dict[str, int] = {}
+    last_per_scope: dict[str, dict] = {}
+    for r in runs:
+        by_status[r.status] = by_status.get(r.status, 0) + 1
+        key = f"{r.tenant_id}:{r.user_id}"
+        if key not in last_per_scope:  # runs are newest-first
+            last_per_scope[key] = {
+                "status": r.status,
+                "attempts": r.attempts,
+                "started_at": r.started_at.isoformat(),
+            }
+    return {
+        "runs_observed": len(runs),
+        "by_status": by_status,
+        "dead_letter_count": by_status.get(RUN_DEAD_LETTER, 0),
+        "failed_count": by_status.get(RUN_FAILED, 0),
+        "with_findings_count": by_status.get(RUN_WITH_FINDINGS, 0),
+        "locked_skip_count": by_status.get(RUN_LOCKED_SKIP, 0),
+        "last_run_per_scope": last_per_scope,
+    }

--- a/services/api/app/workers/retry.py
+++ b/services/api/app/workers/retry.py
@@ -1,0 +1,71 @@
+"""Retry / backoff policy for the worker runtime (v0.8, ADR-012).
+
+A small, deterministic, dependency-free retry helper used by the orchestrator to
+absorb *transient* infrastructure faults (e.g. a brief store/lease hiccup) around
+a scope's work. It is intentionally not a queue: exhausted retries surface as a
+dead-letter record, never a silent loss.
+
+Note: lifecycle workers themselves never raise (they catch and record), so retry
+here wraps the orchestration around them — the parts that touch the store.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Exponential backoff with a ceiling. Deterministic (no jitter) for tests."""
+
+    max_attempts: int = 3
+    base_delay_seconds: float = 1.0
+    backoff_factor: float = 2.0
+    max_delay_seconds: float = 30.0
+
+    def delay_for(self, attempt: int) -> float:
+        """Seconds to wait *before* retry ``attempt`` (1-based: the wait after the
+        first failed try is ``delay_for(1)``)."""
+        if attempt < 1:
+            return 0.0
+        delay = self.base_delay_seconds * (self.backoff_factor ** (attempt - 1))
+        return min(delay, self.max_delay_seconds)
+
+
+@dataclass
+class RetryOutcome(Generic[T]):
+    ok: bool
+    attempts: int
+    value: T | None = None
+    error: str | None = None
+
+
+def run_with_retry(
+    fn: Callable[[], T],
+    policy: RetryPolicy,
+    *,
+    sleep: Callable[[float], None] = time.sleep,
+) -> RetryOutcome[T]:
+    """Call ``fn`` up to ``policy.max_attempts`` times, backing off between tries.
+
+    Returns a ``RetryOutcome``: ``ok=True`` with the value on success, or
+    ``ok=False`` with the last error type name after retries are exhausted. Never
+    re-raises — the caller decides what to do with an exhausted outcome
+    (dead-letter it).
+    """
+    attempts = 0
+    last_error: str | None = None
+    while attempts < policy.max_attempts:
+        attempts += 1
+        try:
+            return RetryOutcome(ok=True, attempts=attempts, value=fn())
+        except Exception as exc:  # noqa: BLE001 — transient faults are retried/dead-lettered
+            last_error = type(exc).__name__
+            if attempts < policy.max_attempts:
+                sleep(policy.delay_for(attempts))
+    return RetryOutcome(ok=False, attempts=attempts, error=last_error)

--- a/services/api/app/workers/scheduler.py
+++ b/services/api/app/workers/scheduler.py
@@ -1,0 +1,81 @@
+"""Scheduler loop for the worker runtime (v0.8, ADR-012).
+
+A deliberately thin interval scheduler: every ``interval_seconds`` it runs one
+orchestration pass (`WorkerOrchestrator.run_once`) over the configured scopes. The
+heavy lifting — leasing, retries, run history, dead-letter — lives in the
+orchestrator; this just paces it. Production-grade scheduling (cron/queue) can
+replace the loop without touching the orchestrator. ``max_ticks`` makes the loop
+testable; ``run_once`` makes a single pass scriptable.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Callable
+
+from ..core.config import get_settings
+from ..core.logging import get_logger
+from ..db.entities import WorkerRunRecord
+from ..db.repository import Repository
+from .orchestrator import Scope, WorkerOrchestrator, parse_scopes
+
+logger = get_logger("memoryops.workers.scheduler")
+
+
+class WorkerScheduler:
+    def __init__(
+        self,
+        repo: Repository,
+        *,
+        scopes: list[Scope] | None = None,
+        interval_seconds: int | None = None,
+        orchestrator: WorkerOrchestrator | None = None,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        s = get_settings()
+        self._repo = repo
+        self._scopes = scopes if scopes is not None else parse_scopes(s.worker_scopes)
+        self._interval = interval_seconds or s.worker_interval_seconds
+        self._orchestrator = orchestrator or WorkerOrchestrator(repo)
+        self._sleep = sleep
+
+    @property
+    def scopes(self) -> list[Scope]:
+        return self._scopes
+
+    def tick(self, *, trace_id: str | None = None) -> list[WorkerRunRecord]:
+        trace_id = trace_id or f"worker-{uuid.uuid4().hex[:12]}"
+        records = self._orchestrator.run_once(self._scopes, trace_id=trace_id)
+        logger.info(
+            "worker scheduler tick",
+            extra={
+                "event": "worker_tick",
+                "status": "done",
+                "scopes": len(self._scopes),
+                "runs": len(records),
+            },
+        )
+        return records
+
+    def run_forever(self, *, max_ticks: int | None = None) -> int:
+        """Loop ``tick`` every interval. ``max_ticks`` bounds it for tests.
+
+        A tick never raises into the loop: the orchestrator records per-scope
+        failures, and any unexpected error is caught here so the scheduler keeps
+        running (the worker process must not crash on a single bad pass).
+        """
+        ticks = 0
+        while max_ticks is None or ticks < max_ticks:
+            try:
+                self.tick()
+            except Exception as exc:  # noqa: BLE001 — scheduler must survive a bad tick
+                logger.warning(
+                    "worker scheduler tick failed",
+                    extra={"event": "worker_tick_error", "status": "failed",
+                           "error": type(exc).__name__},
+                )
+            ticks += 1
+            if max_ticks is None or ticks < max_ticks:
+                self._sleep(self._interval)
+        return ticks

--- a/services/api/tests/test_deletion.py
+++ b/services/api/tests/test_deletion.py
@@ -85,6 +85,29 @@ def test_compaction_rejects_active_memory(gateway, repo):
     assert repo.get_memory("t1", "u1", mem.id).content != ""
 
 
+def test_worker_runtime_preserves_deletion_guarantee(gateway, repo):
+    # v0.8: running the scheduled worker runtime over a scope that has a deleted
+    # memory must keep the deletion guarantee (the run record is content-free and
+    # the deleted row stays unreachable / never resurrected).
+    from app.workers.orchestrator import Scope, WorkerOrchestrator
+    from app.workers.retry import RetryPolicy
+
+    _chat(gateway, "Remember that I prefer dark mode dashboards.")
+    mem = repo.list_memories("t1", "u1")[0]
+    repo.soft_delete("t1", "u1", mem.id)
+
+    orch = WorkerOrchestrator(
+        repo, owner="t", retry_policy=RetryPolicy(max_attempts=1), sleep=lambda _s: None
+    )
+    rec = orch.run_scope(Scope("t1", "u1"))
+
+    assert mem.id not in {m.id for m in repo.retrieve_active("t1", "u1")}
+    assert mem.id not in {m.id for m in repo.list_memories("t1", "u1")}
+    assert repo.get_memory("t1", "u1", mem.id).status == Status.deleted
+    # Run record carries no memory content (ids/counts/status only).
+    assert "dark mode" not in str(rec.details)
+
+
 def test_loop_traces_do_not_resurrect_deleted_memory(gateway, repo):
     # v0.3.1: loop runs/events are operational evidence stored alongside the
     # write path. They must never re-expose a soft-deleted memory in retrieval.

--- a/services/api/tests/test_tenant_isolation.py
+++ b/services/api/tests/test_tenant_isolation.py
@@ -68,6 +68,19 @@ def test_compaction_listing_is_tenant_scoped(gateway, repo):
     assert [m.id for m in repo.list_deleted_for_compaction("tenant_acme", "user_acme")] == [mem.id]
 
 
+def test_worker_runs_are_tenant_scoped(repo):
+    # v0.8: worker run history is operational evidence tagged by tenant/user and
+    # must filter to a single scope (no cross-tenant leakage of run records).
+    from app.db.entities import WorkerRunRecord
+
+    repo.add_worker_run(WorkerRunRecord(tenant_id="tenant_acme", user_id="u1", status="completed"))
+    repo.add_worker_run(WorkerRunRecord(tenant_id="tenant_demo", user_id="u1", status="completed"))
+
+    acme = repo.list_worker_runs(tenant_id="tenant_acme")
+    assert [r.tenant_id for r in acme] == ["tenant_acme"]
+    assert repo.list_worker_runs(tenant_id="tenant_demo", user_id="other") == []
+
+
 def test_audit_listing_is_tenant_and_memory_scoped(gateway, repo):
     # v0.5: the control plane's per-memory audit filter must stay tenant-scoped
     # and must not surface another memory's events.

--- a/services/api/tests/test_worker_health.py
+++ b/services/api/tests/test_worker_health.py
@@ -1,0 +1,31 @@
+"""Worker runtime health endpoint (v0.8, ADR-012)."""
+
+from __future__ import annotations
+
+from app.db.entities import WorkerRunRecord
+from app.workers.orchestrator import RUN_COMPLETED, RUN_DEAD_LETTER
+
+
+def test_workers_health_empty_is_healthy(api_client) -> None:
+    client, _repo = api_client
+    resp = client.get("/healthz/workers")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["healthy"] is True
+    assert body["runs_observed"] == 0
+
+
+def test_workers_health_reflects_dead_letter(api_client) -> None:
+    client, repo = api_client
+    repo.add_worker_run(
+        WorkerRunRecord(tenant_id="t1", user_id="u1", status=RUN_COMPLETED)
+    )
+    assert client.get("/healthz/workers").json()["healthy"] is True
+
+    repo.add_worker_run(
+        WorkerRunRecord(tenant_id="t2", user_id="u2", status=RUN_DEAD_LETTER)
+    )
+    body = client.get("/healthz/workers").json()
+    assert body["healthy"] is False
+    assert body["dead_letter_count"] == 1
+    assert body["runs_observed"] == 2

--- a/services/api/tests/test_worker_locks.py
+++ b/services/api/tests/test_worker_locks.py
@@ -1,0 +1,65 @@
+"""Worker leases / locks (v0.8, ADR-012) — duplicate-run prevention."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from app.workers.locks import WorkerLeaseManager, scope_key
+
+NOW = datetime(2026, 6, 22, tzinfo=UTC)
+
+
+def _mgr(repo, owner, ttl=300):
+    return WorkerLeaseManager(repo, ttl_seconds=ttl, owner=owner)
+
+
+def test_scope_key_is_tenant_user() -> None:
+    assert scope_key("t1", "u1") == "t1:u1"
+
+
+def test_second_owner_cannot_acquire_live_lease(repo) -> None:
+    a = _mgr(repo, "worker-a")
+    b = _mgr(repo, "worker-b")
+    assert a.acquire("t1:u1", now=NOW) is True
+    # Duplicate concurrent run prevented: b cannot take a live lease.
+    assert b.acquire("t1:u1", now=NOW) is False
+
+
+def test_same_owner_reacquire_is_ok(repo) -> None:
+    a = _mgr(repo, "worker-a")
+    assert a.acquire("t1:u1", now=NOW) is True
+    assert a.acquire("t1:u1", now=NOW) is True  # idempotent for the holder
+
+
+def test_release_allows_reacquire(repo) -> None:
+    a = _mgr(repo, "worker-a")
+    b = _mgr(repo, "worker-b")
+    a.acquire("t1:u1", now=NOW)
+    a.release("t1:u1")
+    assert b.acquire("t1:u1", now=NOW) is True
+
+
+def test_expired_lease_is_reclaimable(repo) -> None:
+    a = _mgr(repo, "worker-a", ttl=60)
+    b = _mgr(repo, "worker-b", ttl=60)
+    a.acquire("t1:u1", now=NOW)
+    later = NOW + timedelta(seconds=120)  # past the 60s TTL
+    assert b.acquire("t1:u1", now=later) is True  # crashed worker never deadlocks
+
+
+def test_wrong_owner_release_is_noop(repo) -> None:
+    a = _mgr(repo, "worker-a")
+    b = _mgr(repo, "worker-b")
+    a.acquire("t1:u1", now=NOW)
+    b.release("t1:u1")  # not the holder → no effect
+    assert b.acquire("t1:u1", now=NOW) is False
+    assert repo.get_lease("t1:u1").owner == "worker-a"
+
+
+def test_renew_only_by_owner(repo) -> None:
+    a = _mgr(repo, "worker-a", ttl=60)
+    b = _mgr(repo, "worker-b", ttl=60)
+    a.acquire("t1:u1", now=NOW)
+    assert b.renew("t1:u1", now=NOW) is False
+    assert a.renew("t1:u1", now=NOW + timedelta(seconds=30)) is True
+    assert repo.get_lease("t1:u1").expires_at == NOW + timedelta(seconds=90)

--- a/services/api/tests/test_worker_orchestrator.py
+++ b/services/api/tests/test_worker_orchestrator.py
@@ -1,0 +1,130 @@
+"""Worker orchestration runtime (v0.8, ADR-012).
+
+Proves the scheduled runtime: leased (duplicate runs prevented), retried,
+recorded as run history, and dead-lettered on exhausted retries — all tenant
+scoped, with one scope's failure never blocking another.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.schemas.memory import Status
+from app.workers.locks import scope_key
+from app.workers.orchestrator import (
+    RUN_COMPLETED,
+    RUN_DEAD_LETTER,
+    RUN_LOCKED_SKIP,
+    Scope,
+    WorkerOrchestrator,
+    parse_scopes,
+    summarize_runtime_health,
+)
+from app.workers.retry import RetryPolicy
+from app.workers.scheduler import WorkerScheduler
+
+from ._worker_helpers import seed_memory
+
+NOW = datetime(2026, 6, 22, tzinfo=UTC)
+
+
+def _orch(repo, owner="worker-test", **kw):
+    kw.setdefault("retry_policy", RetryPolicy(max_attempts=2, base_delay_seconds=0.0))
+    kw.setdefault("sleep", lambda _s: None)
+    return WorkerOrchestrator(repo, owner=owner, **kw)
+
+
+def test_parse_scopes() -> None:
+    scopes = parse_scopes("t1:u1, t2:u2 ,bad,:nouser,tenant:")
+    assert scopes == [Scope("t1", "u1"), Scope("t2", "u2")]
+
+
+def test_run_scope_records_history(repo) -> None:
+    seed_memory(repo, content="dark mode", status=Status.active)
+    rec = _orch(repo).run_scope(Scope("t1", "u1"), now=NOW, trace_id="x")
+
+    assert rec.status == RUN_COMPLETED
+    assert rec.attempts == 1
+    assert rec.owner == "worker-test"
+    history = repo.list_worker_runs(tenant_id="t1", user_id="u1")
+    assert [r.id for r in history] == [rec.id]
+    # Lease is released after the run so the next pass can acquire it.
+    assert repo.get_lease(scope_key("t1", "u1")) is None
+
+
+def test_duplicate_run_prevented_by_lease(repo) -> None:
+    # Another owner holds a live lease → orchestrator skips, records locked_skip.
+    repo.try_acquire_lease(
+        scope_key("t1", "u1"), "other-worker",
+        now=NOW, expires_at=NOW.replace(year=2027),
+    )
+    rec = _orch(repo).run_scope(Scope("t1", "u1"), now=NOW)
+    assert rec.status == RUN_LOCKED_SKIP
+    assert rec.attempts == 0
+    # The other owner's lease is untouched (we never released someone else's lease).
+    assert repo.get_lease(scope_key("t1", "u1")).owner == "other-worker"
+
+
+def test_exhausted_retries_become_dead_letter(repo, monkeypatch) -> None:
+    def _boom(*a, **kw):
+        raise RuntimeError("store down")
+
+    monkeypatch.setattr("app.workers.orchestrator.run_jobs", _boom)
+    rec = _orch(repo).run_scope(Scope("t1", "u1"), now=NOW)
+
+    assert rec.status == RUN_DEAD_LETTER
+    assert rec.attempts == 2
+    assert rec.error == "RuntimeError"
+    # Lease released even though the work failed → scope not deadlocked.
+    assert repo.get_lease(scope_key("t1", "u1")) is None
+    dead = repo.list_worker_runs(status=RUN_DEAD_LETTER)
+    assert len(dead) == 1
+
+
+def test_run_once_is_tenant_scoped_and_independent(repo) -> None:
+    seed_memory(repo, tenant_id="t1", status=Status.active)
+    seed_memory(repo, tenant_id="t2", status=Status.active)
+    recs = _orch(repo).run_once([Scope("t1", "u1"), Scope("t2", "u1")], now=NOW)
+
+    assert {r.tenant_id for r in recs} == {"t1", "t2"}
+    assert repo.list_worker_runs(tenant_id="t1") and repo.list_worker_runs(tenant_id="t2")
+
+
+def test_second_pass_is_idempotent(repo) -> None:
+    seed_memory(repo, status=Status.active)
+    orch = _orch(repo)
+    orch.run_once([Scope("t1", "u1")], now=NOW)
+    orch.run_once([Scope("t1", "u1")], now=NOW)
+    runs = repo.list_worker_runs(tenant_id="t1", user_id="u1")
+    assert len(runs) == 2  # both passes recorded
+    assert all(r.status == RUN_COMPLETED for r in runs)
+
+
+def test_runtime_health_summary(repo, monkeypatch) -> None:
+    seed_memory(repo, status=Status.active)
+    orch = _orch(repo)
+    orch.run_scope(Scope("t1", "u1"), now=NOW)  # completed
+    # Force a dead-letter for a second scope.
+    monkeypatch.setattr(
+        "app.workers.orchestrator.run_jobs", lambda *a, **kw: (_ for _ in ()).throw(OSError())
+    )
+    orch.run_scope(Scope("t2", "u2"), now=NOW)
+
+    health = summarize_runtime_health(repo)
+    assert health["runs_observed"] == 2
+    assert health["dead_letter_count"] == 1
+    assert "t1:u1" in health["last_run_per_scope"]
+
+
+def test_scheduler_run_forever_bounded_by_max_ticks(repo) -> None:
+    seed_memory(repo, status=Status.active)
+    slept: list[float] = []
+    sched = WorkerScheduler(
+        repo, scopes=[Scope("t1", "u1")], interval_seconds=5,
+        orchestrator=_orch(repo), sleep=slept.append,
+    )
+    ticks = sched.run_forever(max_ticks=3)
+    assert ticks == 3
+    # Sleeps only between ticks, not after the last one.
+    assert slept == [5, 5]
+    assert len(repo.list_worker_runs(tenant_id="t1", user_id="u1")) == 3

--- a/services/api/tests/test_worker_retry.py
+++ b/services/api/tests/test_worker_retry.py
@@ -1,0 +1,52 @@
+"""Worker retry / backoff policy (v0.8, ADR-012)."""
+
+from __future__ import annotations
+
+from app.workers.retry import RetryPolicy, run_with_retry
+
+
+def test_delay_for_is_exponential_with_ceiling() -> None:
+    p = RetryPolicy(base_delay_seconds=1.0, backoff_factor=2.0, max_delay_seconds=3.0)
+    assert p.delay_for(1) == 1.0
+    assert p.delay_for(2) == 2.0
+    assert p.delay_for(3) == 3.0  # min(4, 3) — ceiling applied
+    assert p.delay_for(0) == 0.0
+
+
+def test_success_on_first_try_does_not_sleep() -> None:
+    slept: list[float] = []
+    out = run_with_retry(lambda: 42, RetryPolicy(max_attempts=3), sleep=slept.append)
+    assert out.ok and out.value == 42 and out.attempts == 1
+    assert slept == []
+
+
+def test_retries_then_succeeds() -> None:
+    calls = {"n": 0}
+    slept: list[float] = []
+
+    def fn() -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise RuntimeError("transient")
+        return "ok"
+
+    out = run_with_retry(
+        fn,
+        RetryPolicy(max_attempts=3, base_delay_seconds=1.0, backoff_factor=2.0),
+        sleep=slept.append,
+    )
+    assert out.ok and out.value == "ok" and out.attempts == 3
+    assert slept == [1.0, 2.0]  # one wait after each of the first two failures
+
+
+def test_exhausts_and_reports_last_error() -> None:
+    slept: list[float] = []
+
+    def fn() -> None:
+        raise ValueError("always")
+
+    out = run_with_retry(fn, RetryPolicy(max_attempts=2), sleep=slept.append)
+    assert not out.ok
+    assert out.attempts == 2
+    assert out.error == "ValueError"
+    assert len(slept) == 1  # no sleep after the final attempt

--- a/services/worker/README.md
+++ b/services/worker/README.md
@@ -1,12 +1,28 @@
 # MemoryOps AI — Worker
 
-Background intelligence (Phase 5 scaffold): decay, archival, conflict detection,
-and reflection/compression. Jobs run against the same repository interface as the
-API, so they can later move to Celery/Temporal with retries + DLQs.
+Scheduled lifecycle runtime (v0.8, ADR-012). Drives the real v0.6/v0.7 lifecycle
+workers — decay, archive, deletion_compaction, deletion_verification,
+conflict_scan, reflection — through the orchestrator + scheduler in
+`app/workers/`: leased so duplicate concurrent runs are prevented, retried with
+backoff, and recorded as run history / dead-letter evidence. It shares the API's
+repository (added to `PYTHONPATH`), so it works on the same in-memory or Postgres
+backend.
 
 ```bash
 # from services/worker, with the API venv active:
-python main.py          # interval loop (WORKER_INTERVAL_SECONDS, default 60)
+python main.py
 ```
 
-In Docker Compose the worker shares the Postgres backend with the API.
+Configuration (via the API `Settings`):
+
+- `MEMORYOPS_WORKER_INTERVAL_SECONDS` — seconds between passes (default 60)
+- `MEMORYOPS_WORKER_SCOPES` — `"tenant:user,tenant2:user2"` scopes to run
+- `worker_lease_ttl_seconds`, `worker_max_attempts`, backoff knobs (see config)
+
+Worker health is observable via the **API** at `GET /healthz/workers` (run
+history, dead-letter / failure counts, last run per scope). See
+[docs/worker-runtime.md](../../docs/worker-runtime.md).
+
+> `jobs.py` is the legacy Phase-5 scaffold (its own ad-hoc decay/archive). It is
+> superseded by the lifecycle workers + runtime on the maintenance path and kept
+> only for reference.

--- a/services/worker/main.py
+++ b/services/worker/main.py
@@ -1,36 +1,52 @@
-"""Worker entrypoint.
+"""Worker entrypoint (v0.8, ADR-012) — production-style scheduled lifecycle runtime.
 
-A simple interval scheduler for the demo. In production this becomes Celery beat
-or Temporal schedules (see docs/rollout.md). Import order matters: ``jobs`` puts
-the API package on sys.path, after which ``app.db.factory`` resolves to the API.
+Drives the real v0.6/v0.7 lifecycle workers (decay, archive, deletion_compaction,
+deletion_verification, conflict_scan, reflection) through the orchestrator +
+scheduler: leased so duplicate concurrent runs are prevented, retried with backoff,
+and recorded as run history / dead-letter evidence. Replaces the legacy Phase-5
+``jobs.py`` scaffold on the chat-independent maintenance path.
+
+Configuration (via the API ``Settings``):
+  * ``MEMORYOPS_WORKER_INTERVAL_SECONDS`` — seconds between passes (default 60)
+  * ``MEMORYOPS_WORKER_SCOPES`` — ``"tenant:user,tenant2:user2"`` scopes to run
+  * ``worker_lease_ttl_seconds`` / ``worker_max_attempts`` / backoff knobs
+
+The API package is shared by adding ``services/api`` to ``sys.path`` (the worker
+image copies it alongside; PYTHONPATH=/srv/api in the Dockerfile).
 """
 
 from __future__ import annotations
 
-import os
-import time
+import sys
+from pathlib import Path
 
-from jobs import run_all  # adds services/api to sys.path as a side effect
+# Reuse the API's repository, config, and workers without packaging the API.
+_API = Path(__file__).resolve().parents[1] / "api"
+if str(_API) not in sys.path:
+    sys.path.insert(0, str(_API))
 
-from app.db.factory import get_repository  # noqa: E402  (resolved via jobs import)
-
-INTERVAL_SECONDS = int(os.getenv("WORKER_INTERVAL_SECONDS", "60"))
-
-
-def tick() -> None:
-    repo = get_repository()
-    summary = run_all(repo, tenant_id="tenant_demo", user_id="user_demo")
-    print({"event": "worker_tick", **summary}, flush=True)
+from app.core.config import get_settings  # noqa: E402
+from app.core.logging import get_logger, setup_logging  # noqa: E402
+from app.db.factory import get_repository  # noqa: E402
+from app.workers.scheduler import WorkerScheduler  # noqa: E402
 
 
 def main() -> None:
-    print({"event": "worker_start", "interval_s": INTERVAL_SECONDS}, flush=True)
-    while True:
-        try:
-            tick()
-        except Exception as exc:  # noqa: BLE001
-            print({"event": "worker_error", "error": str(exc)}, flush=True)
-        time.sleep(INTERVAL_SECONDS)
+    settings = get_settings()
+    setup_logging(settings.log_level)
+    logger = get_logger("memoryops.worker")
+    scheduler = WorkerScheduler(get_repository())
+    logger.info(
+        "worker runtime starting",
+        extra={
+            "event": "worker_start",
+            "status": "ok",
+            "interval_s": settings.worker_interval_seconds,
+            "scopes": len(scheduler.scopes),
+            "storage": settings.storage,
+        },
+    )
+    scheduler.run_forever()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## v0.8 — Worker Runtime + Scheduled Lifecycle Orchestration

Turns the v0.6/v0.7 lifecycle workers from **callable functions** into an **operable runtime** — scheduled, leased, retried, and recorded — without adding a queue/broker.

> Builds on `feat/v0.7-deletion-compaction` (#6). Until that merges, this PR's diff also contains the v0.7 commit; review v0.8 via commit `feat: v0.8 worker runtime…` or merge #6 first.

### What landed
- **Lease/lock** (`app/workers/locks.py` + `Repository.try_acquire_lease`) — TTL'd mutual exclusion per `"tenant:user"` scope prevents duplicate concurrent runs; expired leases are reclaimable so a crashed worker never deadlocks a scope.
- **Retry/backoff** (`app/workers/retry.py`) — deterministic exponential backoff with a ceiling; exhausted retries **dead-letter**, never silently lost.
- **Orchestrator** (`app/workers/orchestrator.py`) — per scope: acquire lease → run jobs under retry → persist content-free run history (or dead-letter) → always release lease. One scope failing never blocks another.
- **Scheduler** (`app/workers/scheduler.py`) — thin interval loop; `max_ticks`/`run_once` make it testable.
- **Persistence** — `WorkerLease` + `WorkerRunRecord`; additive repo methods (in-memory + Postgres); migration `006_worker_runtime.sql` + ORM.
- **Worker health** — `GET /healthz/workers` (run history, dead-letter/failure counts, last run per scope).
- **Worker process** — `services/worker/main.py` now drives the real lifecycle workers via the scheduler (supersedes the legacy Phase-5 `jobs.py`).
- **Docs/gate** — `worker-runtime.md`, ADR-012, phase-14 gate; new PR-gate `Reliability` rules; updated background-lifecycle-workers/security/architecture/rollout/deployment/README/CLAUDE/AGENTS.

### Validation
- pytest: **206 passed, 1 skipped**
- ruff: **all checks passed**
- evals: **PASS** (all invariants hold, pass rate ≥ 80%)
- PR invariant gate: **PASS** (12 armed rules satisfied)

### Honest scope
Single-process interval scheduler (no Celery/Temporal); lease-arbitrated so multiple replicas are safe but there's no central schedule coordinator. Scope enumeration stays explicit (no unbounded cross-tenant scan). Runtime stays off the chat path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)