### PR TITLE
feat: v0.9 public results dashboard + evidence explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ enforced.
 ```text
 memoryops-ai/
   apps/web/            Next.js frontend (chat, memories, governance, audit, loops, admin, architecture)
+  apps/results-dashboard/ Public read-only Streamlit results/evidence dashboard (demo-only; v0.9)
   services/api/        FastAPI backend (gateway, extractor, policy broker, write/read path, audit)
   services/worker/     Background jobs (decay, reflection, conflict resolution, compression)
   packages/shared/     Shared types
@@ -370,17 +371,30 @@ MemoryOps integrates it via an adapter and does not vendor its source.
 - See [docs/worker-runtime.md](docs/worker-runtime.md) and
   [ADR-012](infra/adr/ADR-012-worker-runtime-orchestration.md).
 
+## What works as of v0.9 (public results dashboard + evidence explorer)
+
+- A **read-only public results dashboard** ([`apps/results-dashboard/`](apps/results-dashboard))
+  built with Streamlit makes MemoryOps understandable and inspectable: overview,
+  version timeline, memory lifecycle, **deletion compaction proof**, worker
+  runtime results, audit evidence, validation results, and honest limitations.
+- It is **demo/evidence UI only** — static demo JSON, no live DB, no secrets, no
+  auth, no writes. The Next.js app in `apps/web` remains the official product UI.
+- Run it with `cd apps/results-dashboard && pip install -r requirements.txt &&
+  streamlit run app.py`. See [docs/results-dashboard.md](docs/results-dashboard.md).
+
 ## Roadmap
 
 - **v0.7** — physical deletion compaction + vector purge verification ✅
 - **v0.8** — worker runtime + scheduled lifecycle orchestration ✅
-- **v0.9** — retention policies + legal hold + consent-aware memory
-- **v0.10** — assistant SDK + example apps
+- **v0.9** — public results dashboard + evidence explorer ✅
+- **v0.10** — retention policies + legal hold + consent-aware memory
+- **v0.11** — assistant SDK + integration examples
+- **v0.12** — hosted demo + public screenshots
 - **v1.0** — production-ready governed memory runtime
 
-## What remains (v0.9+)
+## What remains (v0.10+)
 
-- Retention windows, legal hold, consent-aware capture (v0.9).
+- Retention windows, legal hold, consent-aware capture (v0.10).
 - Hard purge / crypto-shred and pgvector index reclamation (beyond v0.7's
   auditable compaction).
 - Optional queue/cron backend behind the orchestrator interface; auto-discovered
@@ -424,5 +438,6 @@ system with release discipline, review gates, and operational safety. Overview:
 - [docs/security.md](docs/security.md) — tenant isolation, secret detection, deletion guarantee.
 - [docs/governance.md](docs/governance.md) — lifecycle, approvals, audit, retention.
 - [docs/rollout.md](docs/rollout.md) — phased delivery and production roadmap.
+- [docs/results-dashboard.md](docs/results-dashboard.md) — public read-only results/evidence dashboard (v0.9; demo-only, not production UI).
 - [docs/demo-script.md](docs/demo-script.md) — the 6-step demo.
 - [infra/adr/](infra/adr/) — storage, retrieval, policy broker, observability, deletion ADRs.

--- a/apps/results-dashboard/README.md
+++ b/apps/results-dashboard/README.md
@@ -1,0 +1,62 @@
+# MemoryOps AI — Public Results Dashboard + Evidence Explorer (v0.9)
+
+A **read-only public evidence/demo dashboard** built with Streamlit. It makes
+MemoryOps AI understandable and inspectable at a glance — for GitHub, Hacker
+News, Reddit, LinkedIn, recruiter, founder, and AI-infra audiences.
+
+> This is **demo/evidence UI only**. It is **not** the production UI.
+> The Next.js app in [`apps/web`](../web) remains the official product /
+> governance UI. This dashboard reads static JSON from [`data/`](data) — it has
+> **no live database, no secrets, no auth, and no write actions.**
+
+## What it shows
+
+| Page | Answers |
+|------|---------|
+| 1 · Overview | What is MemoryOps? Why does AI memory need governance? |
+| 2 · Version Timeline | What shipped in v0.1 → v0.8, and what's next |
+| 3 · Memory Lifecycle Flow | Capture → Evaluate → Store → Retrieve → Rank → Compose → Update → Forget → Audit |
+| 4 · Deletion Proof Explorer | Before/after deletion compaction, vector purge verification, tombstone preservation |
+| 5 · Worker Runtime Dashboard | Lifecycle job results + run history (leases, retries, dead-letter) |
+| 6 · Audit Evidence Viewer | The audit-event timeline that proves actions are recorded |
+| 7 · Validation Results | pytest / ruff / eval / PR-invariant-gate results |
+| 8 · Roadmap + Honest Limitations | What's next, and what the system deliberately does not claim |
+
+## Run it
+
+```bash
+cd apps/results-dashboard
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+Then open the URL Streamlit prints (default http://localhost:8501). No
+environment variables, database, or API keys are required.
+
+## How it's wired
+
+```text
+data/*.json  ──>  components/*.py  ──>  app.py (8 Streamlit pages)
+```
+
+- [`data/`](data) — static demo artifacts (releases, validation, lifecycle,
+  deletion compaction, worker runs, audit events, roadmap). Shapes mirror the
+  real backend (e.g. `worker_runs` from migration 006, real `AuditService`
+  event names) but contain **only demo data** — no real user content.
+- [`components/`](components) — presentation-only helpers (`cards`, `charts`,
+  `flowcharts`, `timelines`). They never touch the core API.
+- [`app.py`](app.py) — the page router.
+
+## Guardrails (by design)
+
+- Read-only. No writes, no admin controls, no auth.
+- No connection to production secrets or real user data.
+- No live DB required; everything renders from `data/*.json`.
+- Isolated from the core API — adds no risk to the production path.
+
+To refresh the demo numbers, edit the JSON files in [`data/`](data). Streamlit
+caches them with `@st.cache_data`; use the app's "Rerun" / "Clear cache" menu to
+pick up edits.
+
+See [`docs/results-dashboard.md`](../../docs/results-dashboard.md) for the
+project-level explanation of why this exists and how it fits the architecture.

--- a/apps/results-dashboard/app.py
+++ b/apps/results-dashboard/app.py
@@ -1,0 +1,309 @@
+"""MemoryOps AI — Public Results Dashboard + Evidence Explorer (v0.9).
+
+A READ-ONLY public evidence/demo surface. It explains MemoryOps and shows what
+the system proves: the memory lifecycle, deletion compaction + vector purge
+verification, worker runtime results, audit evidence, and validation results.
+
+This dashboard is demo/evidence UI ONLY:
+  - It reads static JSON from ./data — no live database, no secrets, no auth.
+  - It performs no writes and exposes no admin controls.
+  - The Next.js app in apps/web remains the official product / governance UI.
+
+Run:
+    cd apps/results-dashboard
+    pip install -r requirements.txt
+    streamlit run app.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import streamlit as st
+
+from components import cards, charts, flowcharts, timelines
+
+DATA_DIR = Path(__file__).parent / "data"
+
+
+@st.cache_data
+def load(name: str) -> dict:
+    """Load a static demo JSON artifact from ./data (read-only)."""
+    return json.loads((DATA_DIR / name).read_text(encoding="utf-8"))
+
+
+def demo_banner() -> None:
+    st.caption(
+        "📖 Read-only public evidence/demo dashboard · static demo data · "
+        "no live DB · no secrets · not the production UI"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Page 1 — Overview
+# --------------------------------------------------------------------------- #
+def page_overview() -> None:
+    rel = load("releases.json")
+    st.title("MemoryOps AI — governed memory infrastructure for AI assistants")
+    st.markdown(
+        "Typed capture, policy evaluation, hybrid retrieval, lifecycle workers, "
+        "deletion compaction, vector purge verification, tenant isolation, and "
+        "audit evidence."
+    )
+    demo_banner()
+    st.divider()
+
+    cards.metric_row([
+        ("Current version", rel["current_version"]),
+        ("Next milestone", rel["next_version"]),
+        ("Releases shipped", sum(1 for r in rel["releases"]
+                                 if r["status"] == "Released")),
+    ])
+
+    st.subheader("Core promise")
+    st.info(rel["core_promise"])
+
+    st.subheader("Why AI memory needs governance")
+    col1, col2 = st.columns(2)
+    with col1:
+        st.markdown("**Most AI 'memory' demos**")
+        st.code("chat message → vector database → retrieve later", language="text")
+    with col2:
+        st.markdown("**MemoryOps AI**")
+        st.code(
+            "Capture → Evaluate → Store → Retrieve → Rank →\n"
+            "Compose → Update → Forget → Audit",
+            language="text",
+        )
+
+    st.subheader("Architecture summary")
+    flowcharts.architecture_flow()
+    st.markdown(f"**Repository:** {rel['repo_url']}")
+
+
+# --------------------------------------------------------------------------- #
+# Page 2 — Version Timeline
+# --------------------------------------------------------------------------- #
+def page_timeline() -> None:
+    rel = load("releases.json")
+    st.title("Version Timeline")
+    st.caption("Progress from v0.1 through the current milestone.")
+    demo_banner()
+    st.divider()
+    timelines.version_timeline(rel["releases"])
+    st.divider()
+    st.subheader("Release detail")
+    for release in rel["releases"]:
+        cards.release_card(release)
+
+
+# --------------------------------------------------------------------------- #
+# Page 3 — Memory Lifecycle Flow
+# --------------------------------------------------------------------------- #
+def page_lifecycle() -> None:
+    demo = load("memory_lifecycle_demo.json")
+    st.title("Memory Lifecycle Flow")
+    st.caption("Capture → Evaluate → Store → Retrieve → Rank → Compose → "
+               "Update → Forget → Audit")
+    demo_banner()
+    st.divider()
+    flowcharts.lifecycle_flow()
+
+    st.subheader("What each stage does")
+    for stage in demo["stages"]:
+        st.markdown(f"**{stage['stage']}** — {stage['what']}")
+        st.caption(f"Invariant: {stage['invariant']}")
+
+    st.divider()
+    st.subheader("Example: a write")
+    w = demo["example_write"]
+    st.markdown(f"> {w['input_message']}")
+    st.dataframe(w["extracted_candidates"], use_container_width=True,
+                 hide_index=True)
+    cards.metric_row([
+        ("Stored", w["stored_count"]),
+        ("Dropped", w["dropped_count"]),
+        ("Blocked", w["blocked_count"]),
+    ])
+    st.caption("Audit events: " + ", ".join(f"`{e}`" for e in w["audit_events"]))
+
+    st.subheader("Example: a read")
+    r = demo["example_read"]
+    st.markdown(f"> {r['query']}")
+    st.dataframe(r["retrieved"], use_container_width=True, hide_index=True)
+    cards.metric_row([
+        ("Excluded (deleted)", r["excluded_deleted"]),
+        ("Composed context (chars)", r["composed_context_chars"]),
+    ])
+    st.caption("Audit events: " + ", ".join(f"`{e}`" for e in r["audit_events"]))
+
+
+# --------------------------------------------------------------------------- #
+# Page 4 — Deletion Proof Explorer
+# --------------------------------------------------------------------------- #
+def page_deletion() -> None:
+    demo = load("deletion_compaction_demo.json")
+    st.title("Deletion Proof Explorer")
+    st.caption("v0.7 — deletion compaction + vector purge verification. The "
+               "strongest evidence MemoryOps provides.")
+    demo_banner()
+    st.divider()
+
+    flowcharts.deletion_flow()
+
+    col1, col2 = st.columns(2)
+    with col1:
+        cards.kv_block("Before compaction", demo["before"])
+    with col2:
+        cards.kv_block("After compaction", demo["after"])
+
+    st.subheader("What happened")
+    cards.labelled_list(demo["labels"], key="phase", value="result",
+                        detail="detail")
+
+    st.divider()
+    st.warning("Scope: " + demo["scope_note"])
+
+
+# --------------------------------------------------------------------------- #
+# Page 5 — Worker Runtime Dashboard
+# --------------------------------------------------------------------------- #
+def page_workers() -> None:
+    data = load("worker_runs.json")
+    st.title("Worker Runtime Dashboard")
+    st.caption("v0.6 lifecycle workers + v0.8 operable runtime "
+               "(leases, retries, dead-letter, run history).")
+    demo_banner()
+    st.divider()
+
+    st.subheader("Lifecycle jobs")
+    st.dataframe(data["jobs"], use_container_width=True, hide_index=True)
+
+    st.subheader("Per-job results (last run)")
+    charts.job_results_bar(data["job_results"])
+    st.dataframe(data["job_results"], use_container_width=True, hide_index=True)
+
+    st.subheader("Audit events per job")
+    charts.audit_count_chart(data["job_results"])
+
+    st.subheader("Run history")
+    charts.runs_table(data["runs"])
+    st.caption("A `dead_letter` row is a run whose retries were exhausted — "
+               "kept for inspection, never silently dropped.")
+
+    st.subheader("Runtime features")
+    for feat in data["runtime_features"]:
+        st.markdown(f"- {feat}")
+
+
+# --------------------------------------------------------------------------- #
+# Page 6 — Audit Evidence Viewer
+# --------------------------------------------------------------------------- #
+def page_audit() -> None:
+    data = load("audit_events.json")
+    st.title("Audit Evidence Viewer")
+    st.caption("MemoryOps doesn't just act — it records content-safe evidence "
+               "of every lifecycle action.")
+    demo_banner()
+    st.divider()
+
+    st.subheader("Deletion + compaction audit timeline")
+    timelines.audit_timeline(data["deletion_compaction_timeline"])
+
+    st.divider()
+    st.subheader("Write-path audit timeline")
+    timelines.audit_timeline(data["write_path_timeline"])
+
+    st.divider()
+    st.subheader("Event glossary")
+    st.dataframe(data["event_glossary"], use_container_width=True,
+                 hide_index=True)
+    st.info(data["note"])
+
+
+# --------------------------------------------------------------------------- #
+# Page 7 — Validation Results
+# --------------------------------------------------------------------------- #
+def page_validation() -> None:
+    data = load("validation.json")
+    latest = data["latest"]
+    st.title("Validation Results")
+    st.caption("Build-quality evidence captured from local runs.")
+    demo_banner()
+    st.divider()
+
+    cards.metric_row([
+        ("pytest", latest["pytest"]),
+        ("ruff", latest["ruff"]),
+        ("evals", latest["evals"]),
+    ])
+    st.markdown(f"**PR invariant gate:** {latest['pr_invariant_gate']}")
+
+    st.subheader("Loop evidence")
+    st.dataframe(
+        [{"loop": k, "result": v} for k, v in latest["loop_evidence"].items()],
+        use_container_width=True, hide_index=True,
+    )
+
+    st.subheader("Version-by-version validation")
+    st.dataframe(data["history"], use_container_width=True, hide_index=True)
+    st.info(data["note"])
+
+
+# --------------------------------------------------------------------------- #
+# Page 8 — Roadmap + Honest Limitations
+# --------------------------------------------------------------------------- #
+def page_roadmap() -> None:
+    data = load("roadmap.json")
+    st.title("Roadmap + Honest Limitations")
+    st.caption("Where MemoryOps is going — and what it deliberately does not "
+               "claim.")
+    demo_banner()
+    st.divider()
+
+    st.subheader("Forward roadmap")
+    timelines.roadmap_timeline(data["milestones"])
+
+    st.divider()
+    st.subheader("Honest limitations")
+    for lim in data["limitations"]:
+        st.markdown(f"- {lim}")
+    st.success("Stating limitations plainly is part of what makes the system "
+               "trustworthy.")
+
+
+# --------------------------------------------------------------------------- #
+# Router
+# --------------------------------------------------------------------------- #
+PAGES = {
+    "1 · Overview": page_overview,
+    "2 · Version Timeline": page_timeline,
+    "3 · Memory Lifecycle Flow": page_lifecycle,
+    "4 · Deletion Proof Explorer": page_deletion,
+    "5 · Worker Runtime Dashboard": page_workers,
+    "6 · Audit Evidence Viewer": page_audit,
+    "7 · Validation Results": page_validation,
+    "8 · Roadmap + Limitations": page_roadmap,
+}
+
+
+def main() -> None:
+    st.set_page_config(
+        page_title="MemoryOps AI — Public Results Dashboard",
+        page_icon="🧠",
+        layout="wide",
+    )
+    st.sidebar.title("🧠 MemoryOps AI")
+    st.sidebar.caption("Public Results Dashboard + Evidence Explorer (v0.9)")
+    choice = st.sidebar.radio("Pages", list(PAGES.keys()), label_visibility="collapsed")
+    st.sidebar.divider()
+    st.sidebar.caption(
+        "Read-only · static demo data · no live DB · no secrets.\n\n"
+        "The Next.js app (apps/web) remains the official product UI."
+    )
+    PAGES[choice]()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/results-dashboard/components/__init__.py
+++ b/apps/results-dashboard/components/__init__.py
@@ -1,0 +1,5 @@
+"""Reusable Streamlit UI helpers for the MemoryOps public results dashboard.
+
+These components are presentation-only. They render static demo data and never
+touch the core API, a live database, or any secret. See app.py for usage.
+"""

--- a/apps/results-dashboard/components/cards.py
+++ b/apps/results-dashboard/components/cards.py
@@ -1,0 +1,59 @@
+"""Card-style renderers: metrics, release cards, labelled key/value blocks."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Sequence
+
+import streamlit as st
+
+_STATUS_ICON = {
+    "Released": "✅",
+    "In progress": "🚧",
+    "Planned": "⏳",
+}
+
+
+def metric_row(metrics: Sequence[tuple[str, object]]) -> None:
+    """Render a horizontal row of st.metric tiles from (label, value) pairs."""
+    cols = st.columns(len(metrics))
+    for col, (label, value) in zip(cols, metrics):
+        col.metric(label, value)
+
+
+def release_card(release: Mapping[str, object]) -> None:
+    """Render a single release as an expandable card."""
+    status = str(release.get("status", ""))
+    icon = _STATUS_ICON.get(status, "•")
+    version = release.get("version", "")
+    title = release.get("title", "")
+    with st.expander(f"{icon} {version} — {title}  ·  {status}"):
+        st.write(release.get("summary", ""))
+        for item in release.get("highlights", []) or []:
+            st.markdown(f"- {item}")
+
+
+def kv_block(title: str, data: Mapping[str, object]) -> None:
+    """Render a titled block of key/value rows (used for before/after states)."""
+    st.markdown(f"**{title}**")
+    rows = "\n".join(
+        f"| `{key}` | `{_fmt(value)}` |" for key, value in data.items()
+    )
+    st.markdown("| field | value |\n| --- | --- |\n" + rows)
+
+
+def labelled_list(items: Iterable[Mapping[str, str]], *, key: str, value: str,
+                  detail: str | None = None) -> None:
+    """Render labelled rows like 'Phase — result' with optional detail text."""
+    for item in items:
+        line = f"**{item.get(key, '')}** — {item.get(value, '')}"
+        st.markdown(line)
+        if detail and item.get(detail):
+            st.caption(item[detail])
+
+
+def _fmt(value: object) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)

--- a/apps/results-dashboard/components/charts.py
+++ b/apps/results-dashboard/components/charts.py
@@ -1,0 +1,32 @@
+"""Lightweight chart renderers built on Streamlit's native charting + pandas."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+import streamlit as st
+
+
+def job_results_bar(job_results: Sequence[dict]) -> None:
+    """Stacked bar of per-job scanned/changed/skipped/failed counts."""
+    df = pd.DataFrame(job_results).set_index("job")
+    cols = [c for c in ("scanned_count", "changed_count", "skipped_count",
+                        "failed_count") if c in df.columns]
+    pretty = df[cols].rename(columns=lambda c: c.replace("_count", "").title())
+    st.bar_chart(pretty)
+
+
+def runs_table(runs: Sequence[dict]) -> None:
+    """Render worker run history as a dataframe."""
+    df = pd.DataFrame(runs)
+    keep = [c for c in ("id", "status", "attempts", "scanned_count",
+                        "changed_count", "skipped_count", "error_count",
+                        "started_at", "completed_at") if c in df.columns]
+    st.dataframe(df[keep], use_container_width=True, hide_index=True)
+
+
+def audit_count_chart(job_results: Sequence[dict]) -> None:
+    """Bar of audit events emitted per job — evidence is recorded, not implied."""
+    df = pd.DataFrame(job_results).set_index("job")[["audit_events"]]
+    st.bar_chart(df.rename(columns={"audit_events": "Audit events"}))

--- a/apps/results-dashboard/components/flowcharts.py
+++ b/apps/results-dashboard/components/flowcharts.py
@@ -1,0 +1,54 @@
+"""Graphviz DOT flowcharts. DOT strings render via st.graphviz_chart without
+requiring the python graphviz package."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+_NODE = 'node [shape=box style="rounded,filled" fillcolor="#eef2ff" ' \
+        'fontname="Helvetica" color="#6366f1"];'
+
+
+def lifecycle_flow() -> None:
+    """Capture -> Evaluate -> ... -> Audit, the core memory lifecycle."""
+    stages = ["Capture", "Evaluate", "Store", "Retrieve", "Rank",
+              "Compose", "Update", "Forget", "Audit"]
+    edges = " -> ".join(f'"{s}"' for s in stages)
+    st.graphviz_chart(
+        f'digraph {{ rankdir=LR; {_NODE} {edges}; }}',
+        use_container_width=True,
+    )
+
+
+def architecture_flow() -> None:
+    """Backend -> evidence sources -> public dashboard -> audiences."""
+    dot = f"""
+    digraph {{
+        rankdir=LR; {_NODE}
+        "MemoryOps Backend" -> "Validation Artifacts";
+        "MemoryOps Backend" -> "Worker Run Reports";
+        "MemoryOps Backend" -> "Audit Events";
+        "MemoryOps Backend" -> "Demo Memory Fixtures";
+        "Validation Artifacts" -> "Public Results Dashboard";
+        "Worker Run Reports" -> "Public Results Dashboard";
+        "Audit Events" -> "Public Results Dashboard";
+        "Demo Memory Fixtures" -> "Public Results Dashboard";
+        "Public Results Dashboard" -> "Visitors / Recruiters / Builders";
+    }}
+    """
+    st.graphviz_chart(dot, use_container_width=True)
+
+
+def deletion_flow() -> None:
+    """Soft delete -> verify -> compact -> purge-verify -> tombstone preserved."""
+    dot = f"""
+    digraph {{
+        rankdir=LR; {_NODE}
+        "Soft delete\\n(status=deleted)" -> "Deletion\\nverification";
+        "Deletion\\nverification" -> "Retention\\nwindow elapses";
+        "Retention\\nwindow elapses" -> "Content +\\nvector compaction";
+        "Content +\\nvector compaction" -> "Vector purge\\nverification";
+        "Vector purge\\nverification" -> "Tombstone\\npreserved";
+    }}
+    """
+    st.graphviz_chart(dot, use_container_width=True)

--- a/apps/results-dashboard/components/timelines.py
+++ b/apps/results-dashboard/components/timelines.py
@@ -1,0 +1,45 @@
+"""Vertical timeline renderers for releases and audit-event sequences."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import streamlit as st
+
+_STATUS_ICON = {"Released": "✅", "In progress": "🚧", "Planned": "⏳"}
+
+
+def version_timeline(releases: Sequence[dict]) -> None:
+    """Render a vertical version timeline from release records."""
+    for rel in releases:
+        icon = _STATUS_ICON.get(str(rel.get("status", "")), "•")
+        st.markdown(
+            f"{icon} **{rel.get('version','')}** — {rel.get('title','')}  "
+            f"<span style='color:#888'>· {rel.get('status','')}</span>",
+            unsafe_allow_html=True,
+        )
+        if rel.get("summary"):
+            st.caption(rel["summary"])
+
+
+def audit_timeline(events: Sequence[dict]) -> None:
+    """Render an ordered audit-event sequence with detail captions."""
+    for ev in events:
+        seq = ev.get("seq")
+        prefix = f"`{seq}` " if seq is not None else ""
+        st.markdown(f"{prefix}**`{ev.get('event','')}`**")
+        if ev.get("detail"):
+            st.caption(ev["detail"])
+
+
+def roadmap_timeline(milestones: Sequence[dict]) -> None:
+    """Render forward roadmap milestones with goals."""
+    for m in milestones:
+        icon = _STATUS_ICON.get(str(m.get("status", "")), "•")
+        st.markdown(
+            f"{icon} **{m.get('version','')} — {m.get('title','')}**  "
+            f"<span style='color:#888'>· {m.get('status','')}</span>",
+            unsafe_allow_html=True,
+        )
+        if m.get("goal"):
+            st.caption(m["goal"])

--- a/apps/results-dashboard/data/audit_events.json
+++ b/apps/results-dashboard/data/audit_events.json
@@ -1,0 +1,32 @@
+{
+  "note": "Demo audit timeline. Event names match the real AuditService vocabulary. Audit events are content-safe (ids/counts/decisions only).",
+  "deletion_compaction_timeline": [
+    {"seq": 1, "event": "memory_deleted", "detail": "User requested deletion; memory soft-deleted (status='deleted')."},
+    {"seq": 2, "event": "deletion_verification_passed", "detail": "Confirmed the soft-deleted memory is not retrievable."},
+    {"seq": 3, "event": "deletion_compaction_started", "detail": "Retention window elapsed; compaction begins for eligible memory."},
+    {"seq": 4, "event": "memory_content_compacted", "detail": "Content payload cleared (set to null)."},
+    {"seq": 5, "event": "memory_vector_purge_attempted", "detail": "Vector material removal attempted."},
+    {"seq": 6, "event": "memory_vector_purge_verified", "detail": "Verified the memory cannot be returned from the candidate/search path."},
+    {"seq": 7, "event": "memory_purge_tombstone_preserved", "detail": "Governance tombstone retained for audit/idempotency."},
+    {"seq": 8, "event": "deletion_compaction_completed", "detail": "Compaction run finished; counts recorded."}
+  ],
+  "write_path_timeline": [
+    {"seq": 1, "event": "memory_extraction", "detail": "Extractor proposed typed candidates from the message."},
+    {"seq": 2, "event": "memory_evaluation", "detail": "Policy broker scored candidates (KEEP/DROP/BLOCK)."},
+    {"seq": 3, "event": "memory_created", "detail": "Approved memory written with tenant_id + user_id."},
+    {"seq": 4, "event": "memory_dropped", "detail": "Low-value candidate dropped before storage."}
+  ],
+  "event_glossary": [
+    {"event": "memory_created", "plane": "Store"},
+    {"event": "memory_retrieved", "plane": "Retrieve"},
+    {"event": "memory_updated", "plane": "Update"},
+    {"event": "memory_merged", "plane": "Update"},
+    {"event": "memory_decay_applied", "plane": "Forget"},
+    {"event": "memory_archived_by_worker", "plane": "Forget"},
+    {"event": "memory_deleted", "plane": "Forget"},
+    {"event": "deletion_verification_passed", "plane": "Forget"},
+    {"event": "memory_content_compacted", "plane": "Forget"},
+    {"event": "memory_vector_purge_verified", "plane": "Forget"},
+    {"event": "memory_purge_tombstone_preserved", "plane": "Audit"}
+  ]
+}

--- a/apps/results-dashboard/data/deletion_compaction_demo.json
+++ b/apps/results-dashboard/data/deletion_compaction_demo.json
@@ -1,0 +1,30 @@
+{
+  "memory_id": "11111111-2222-3333-4444-555555555555",
+  "tenant_id": "demo-tenant",
+  "user_id": "demo-user",
+  "retention_window_days": 30,
+  "before": {
+    "status": "deleted",
+    "content": "User prefers X",
+    "embedding_present": true,
+    "tombstone_present": true,
+    "compacted_at": null,
+    "purge_verification": null
+  },
+  "after": {
+    "status": "deleted",
+    "content": null,
+    "embedding_present": false,
+    "tombstone_present": true,
+    "compacted_at": "2026-06-21T11:20:42Z",
+    "purge_verification": "passed"
+  },
+  "labels": [
+    {"phase": "Logical deletion", "result": "unreachable", "detail": "status='deleted' rows are never retrieved."},
+    {"phase": "Compaction", "result": "payload cleared", "detail": "Content and vector material removed after the retention window."},
+    {"phase": "Vector purge verification", "result": "candidate path checked", "detail": "Verifies the memory cannot be returned from the candidate/search path. Fail-closed."},
+    {"phase": "Tombstone", "result": "preserved", "detail": "Governance tombstone retained for audit and idempotency."},
+    {"phase": "Audit", "result": "recorded", "detail": "Each step appends a content-safe audit event."}
+  ],
+  "scope_note": "Auditable content/vector compaction + retrieval-exclusion verification. NOT crypto-shred and NOT a guarantee of physical disk/page reclamation."
+}

--- a/apps/results-dashboard/data/memory_lifecycle_demo.json
+++ b/apps/results-dashboard/data/memory_lifecycle_demo.json
@@ -1,0 +1,35 @@
+{
+  "stages": [
+    {"stage": "Capture", "what": "A message arrives; the extractor proposes typed memory candidates.", "invariant": "Provenance: every candidate carries a non-null source."},
+    {"stage": "Evaluate", "what": "The policy broker scores each candidate and decides KEEP / DROP / BLOCK.", "invariant": "Policy-before-storage: the broker runs before any write."},
+    {"stage": "Store", "what": "Approved memories are written to typed stores with tenant_id + user_id.", "invariant": "Tenant isolation: every row is scoped to a tenant and user."},
+    {"stage": "Retrieve", "what": "Tenant-scoped hybrid retrieval pulls candidate memories for a query.", "invariant": "Deletion guarantee: status='deleted' rows are never retrieved."},
+    {"stage": "Rank", "what": "Candidates are ranked by relevance, recency, and importance.", "invariant": "Graceful degradation: retrieval failures never block responses."},
+    {"stage": "Compose", "what": "The context composer assembles the final memory context for the LLM.", "invariant": "Temporary chat: temporary_chat=true reads/writes nothing."},
+    {"stage": "Update", "what": "Conflicts are detected and superseding memories are merged or revised.", "invariant": "LLM output is advisory; the policy broker stays authoritative."},
+    {"stage": "Forget", "what": "Decay/archive/deletion move stale or removed memory out of the active set.", "invariant": "Workers never resurrect deleted memory."},
+    {"stage": "Audit", "what": "Every lifecycle action appends a content-safe audit event.", "invariant": "Auditability: every lifecycle action emits an audit event."}
+  ],
+  "example_write": {
+    "input_message": "By the way, I prefer metric units and dark mode.",
+    "extracted_candidates": [
+      {"content": "User prefers metric units", "memory_type": "preference", "source": "chat", "decision": "KEEP"},
+      {"content": "User prefers dark mode", "memory_type": "preference", "source": "chat", "decision": "KEEP"},
+      {"content": "It is raining today", "memory_type": "trivia", "source": "chat", "decision": "DROP"}
+    ],
+    "stored_count": 2,
+    "dropped_count": 1,
+    "blocked_count": 0,
+    "audit_events": ["memory_extraction", "memory_evaluation", "memory_created", "memory_created", "memory_dropped"]
+  },
+  "example_read": {
+    "query": "What units should I use in the summary?",
+    "retrieved": [
+      {"content": "User prefers metric units", "memory_type": "preference", "score": 0.91},
+      {"content": "User prefers dark mode", "memory_type": "preference", "score": 0.42}
+    ],
+    "excluded_deleted": 1,
+    "composed_context_chars": 184,
+    "audit_events": ["memory_read_loop", "memory_retrieved"]
+  }
+}

--- a/apps/results-dashboard/data/releases.json
+++ b/apps/results-dashboard/data/releases.json
@@ -1,0 +1,94 @@
+{
+  "project": "MemoryOps AI",
+  "tagline": "Governed memory infrastructure for AI assistants.",
+  "current_version": "v0.8",
+  "next_version": "v0.9",
+  "repo_url": "https://github.com/patibandlavenkatamanideep/MemoryOps-AI",
+  "core_promise": "Memory is not a database. Memory is a governed decision system that decides what information is valuable enough to carry into the future.",
+  "releases": [
+    {
+      "version": "v0.1",
+      "title": "Governed Memory Path",
+      "status": "Released",
+      "summary": "Capture, policy evaluation, typed storage, retrieval, and audit on the write/read path.",
+      "highlights": ["Write path: Extractor -> Policy Broker -> Write Service", "Read path: Retriever -> Ranker -> Composer", "Audit log on every lifecycle action"]
+    },
+    {
+      "version": "v0.2",
+      "title": "Agentic Governance Layer",
+      "status": "Released",
+      "summary": "Operator/developer skills and phase gates wrapping the core.",
+      "highlights": ["Hermes operator skills", "agentic-swe-kit phase gates", "PR invariant evidence gate"]
+    },
+    {
+      "version": "v0.2.1",
+      "title": "Context Compression",
+      "status": "Released",
+      "summary": "Optional context compression at the LLM boundary, after governance.",
+      "highlights": ["NoopCompressor default", "HeadroomCompressor optional + degrades to no-op", "Runs after policy/composition, never before policy broker"]
+    },
+    {
+      "version": "v0.3",
+      "title": "pgvector + Tenant Isolation",
+      "status": "Released",
+      "summary": "Vector retrieval on Postgres with enforced row-level security.",
+      "highlights": ["pgvector candidate search", "RLS FORCE + tenant policy", "scripts/check_rls_policies.py"]
+    },
+    {
+      "version": "v0.3.1",
+      "title": "Loop Engineering",
+      "status": "Released",
+      "summary": "Memory workflows modeled as Observe -> Decide -> Act -> Verify -> Audit -> Learn loops.",
+      "highlights": ["Six primary loops", "Validated state transitions", "/api/loops operational timelines"]
+    },
+    {
+      "version": "v0.3.2",
+      "title": "Railway Deployment Alignment",
+      "status": "Released",
+      "summary": "One Railway project, five services. No Vercel.",
+      "highlights": ["web/api/worker + Postgres + Redis", "Canonical docs/deployment/railway.md", "Phase 13 infrastructure gate"]
+    },
+    {
+      "version": "v0.4",
+      "title": "Provider LLM Adapters",
+      "status": "Released",
+      "summary": "Swappable, provider-neutral LLM layer powering structured extraction.",
+      "highlights": ["StubProvider default (no keys needed)", "Optional OpenAI/Anthropic/Gemini adapters", "LLM output is advisory; policy broker stays authoritative"]
+    },
+    {
+      "version": "v0.5",
+      "title": "Governance UI / Memory Control Plane",
+      "status": "Released",
+      "summary": "Next.js admin/governance UI over the memory lifecycle.",
+      "highlights": ["Chat, memories, governance, audit, loops, admin views", "Memory control plane", "Official product UI"]
+    },
+    {
+      "version": "v0.6",
+      "title": "Background Lifecycle Workers",
+      "status": "Released",
+      "summary": "Six background jobs off the chat request path.",
+      "highlights": ["decay, archive, conflict_scan, reflection", "deletion_compaction, deletion_verification", "Tenant scoped, idempotent, retry-safe, audited"]
+    },
+    {
+      "version": "v0.7",
+      "title": "Deletion Compaction + Vector Purge Verification",
+      "status": "Released",
+      "summary": "Clears soft-deleted content + vector material after a retention window; preserves the tombstone; verifies the purge fail-closed.",
+      "highlights": ["Content + vector compaction", "Governance tombstone preserved", "Not crypto-shred / no physical disk reclamation claim"]
+    },
+    {
+      "version": "v0.8",
+      "title": "Railway Worker Runtime + Scheduled Lifecycle Orchestration",
+      "status": "Released",
+      "summary": "Makes lifecycle jobs operable: leases, retries/backoff, dead-letter, run history, health view.",
+      "highlights": ["worker_runs history (migration 006)", "GET /healthz/workers", "Explicit tenant:user scopes"]
+    },
+    {
+      "version": "v0.9",
+      "title": "Public Results Dashboard + Evidence Explorer",
+      "status": "In progress",
+      "summary": "Read-only public evidence/demo dashboard making the system understandable and inspectable.",
+      "highlights": ["Streamlit results viewer (demo-only)", "Static/demo JSON artifacts", "Next.js remains the official product UI"]
+    }
+  ]
+}

--- a/apps/results-dashboard/data/roadmap.json
+++ b/apps/results-dashboard/data/roadmap.json
@@ -1,0 +1,19 @@
+{
+  "milestones": [
+    {"version": "v0.8", "title": "Railway Worker Runtime + Scheduled Lifecycle Orchestration", "status": "Released", "goal": "Make lifecycle jobs operable (leases, retries, dead-letter, run history)."},
+    {"version": "v0.9", "title": "Public Results Dashboard + Evidence Explorer", "status": "In progress", "goal": "Make MemoryOps understandable and inspectable publicly."},
+    {"version": "v0.10", "title": "Retention Policies + Legal Hold + Consent-Aware Memory", "status": "Planned", "goal": "Add enterprise retention rules on top of lifecycle/deletion infrastructure."},
+    {"version": "v0.11", "title": "Assistant SDK + Integration Examples", "status": "Planned", "goal": "Make MemoryOps easier for other builders to adopt."},
+    {"version": "v0.12", "title": "Hosted Demo + Public Screenshots", "status": "Planned", "goal": "Make the project easy to understand without cloning."},
+    {"version": "v1.0", "title": "Governed Memory Runtime for AI Assistants", "status": "Planned", "goal": "Stable public release."}
+  ],
+  "limitations": [
+    "Deletion compaction is NOT crypto-shred.",
+    "No physical disk/page erasure guarantee.",
+    "No full pgvector VACUUM/reindex orchestration yet.",
+    "No cross-tenant scheduler until later.",
+    "This Streamlit dashboard is demo-only and read-only.",
+    "The Next.js app remains the official product / admin governance UI.",
+    "Dashboard reads static demo JSON - it never connects to production secrets or real user data."
+  ]
+}

--- a/apps/results-dashboard/data/validation.json
+++ b/apps/results-dashboard/data/validation.json
@@ -1,0 +1,41 @@
+{
+  "note": "Validation summaries captured from local runs against the demo build. Numbers are illustrative evidence snapshots, not a live CI feed.",
+  "latest": {
+    "version": "v0.9",
+    "pytest": "206 passed, 1 skipped",
+    "ruff": "All checks passed",
+    "evals": "PASS (all invariants hold, pass rate >= 80%)",
+    "pr_invariant_gate": "No rules armed (dashboard is docs/app-only)",
+    "loop_evidence": {
+      "memory_write_loop": "pass",
+      "memory_read_loop": "pass",
+      "governance_loop": "pass",
+      "release_gate_loop": "pass"
+    }
+  },
+  "history": [
+    {
+      "version": "v0.7",
+      "pytest": "183 passed, 1 skipped",
+      "ruff": "All checks passed",
+      "evals": "PASS",
+      "pr_invariant_gate": "12 rules satisfied"
+    },
+    {
+      "version": "v0.8",
+      "pytest": "206 passed, 1 skipped",
+      "ruff": "All checks passed",
+      "evals": "PASS",
+      "pr_invariant_gate": "Satisfied; worker runtime merged",
+      "release": "Published"
+    },
+    {
+      "version": "v0.9",
+      "pytest": "206 passed, 1 skipped",
+      "ruff": "All checks passed",
+      "evals": "PASS",
+      "pr_invariant_gate": "No backend rules armed (dashboard-only change)",
+      "release": "Drafted (not tagged)"
+    }
+  ]
+}

--- a/apps/results-dashboard/data/worker_runs.json
+++ b/apps/results-dashboard/data/worker_runs.json
@@ -1,0 +1,77 @@
+{
+  "note": "Demo snapshot mirroring the worker_runs table shape (migration 006). Counts only - never memory content.",
+  "jobs": [
+    {"job": "decay", "description": "Apply time-based decay to stale memory importance.", "default_on": true},
+    {"job": "archive", "description": "Move cold memory out of the active set.", "default_on": true},
+    {"job": "conflict_scan", "description": "Detect conflicting / superseding memories.", "default_on": true},
+    {"job": "deletion_verification", "description": "Confirm soft-deleted memory is not retrievable.", "default_on": true},
+    {"job": "deletion_compaction", "description": "Clear content + vector material after the retention window.", "default_on": true},
+    {"job": "reflection", "description": "Summarize/condense memory (off by default).", "default_on": false}
+  ],
+  "job_results": [
+    {"job": "decay", "scanned_count": 48, "changed_count": 9, "verified_count": 0, "skipped_count": 39, "failed_count": 0, "audit_events": 9},
+    {"job": "archive", "scanned_count": 48, "changed_count": 3, "verified_count": 0, "skipped_count": 45, "failed_count": 0, "audit_events": 3},
+    {"job": "conflict_scan", "scanned_count": 48, "changed_count": 2, "verified_count": 0, "skipped_count": 46, "failed_count": 0, "audit_events": 4},
+    {"job": "deletion_verification", "scanned_count": 6, "changed_count": 0, "verified_count": 6, "skipped_count": 0, "failed_count": 0, "audit_events": 6},
+    {"job": "deletion_compaction", "scanned_count": 12, "changed_count": 4, "verified_count": 4, "skipped_count": 8, "failed_count": 0, "audit_events": 16},
+    {"job": "reflection", "scanned_count": 0, "changed_count": 0, "verified_count": 0, "skipped_count": 0, "failed_count": 0, "audit_events": 0}
+  ],
+  "runs": [
+    {
+      "id": "run-1001",
+      "tenant_id": "demo-tenant",
+      "user_id": "demo-user",
+      "status": "completed",
+      "jobs": ["decay", "archive", "conflict_scan", "deletion_verification", "deletion_compaction"],
+      "attempts": 1,
+      "scanned_count": 162,
+      "changed_count": 18,
+      "skipped_count": 138,
+      "error_count": 0,
+      "owner": "scheduler@worker-1",
+      "trace_id": "trace-9f2c",
+      "started_at": "2026-06-21T11:20:00Z",
+      "completed_at": "2026-06-21T11:20:43Z"
+    },
+    {
+      "id": "run-1000",
+      "tenant_id": "demo-tenant",
+      "user_id": "demo-user",
+      "status": "completed",
+      "jobs": ["decay", "archive", "conflict_scan", "deletion_verification", "deletion_compaction"],
+      "attempts": 2,
+      "scanned_count": 158,
+      "changed_count": 11,
+      "skipped_count": 147,
+      "error_count": 0,
+      "owner": "scheduler@worker-1",
+      "trace_id": "trace-7a18",
+      "started_at": "2026-06-20T11:20:00Z",
+      "completed_at": "2026-06-20T11:20:51Z"
+    },
+    {
+      "id": "run-0999",
+      "tenant_id": "demo-tenant",
+      "user_id": "demo-user",
+      "status": "dead_letter",
+      "jobs": ["decay", "archive"],
+      "attempts": 3,
+      "scanned_count": 0,
+      "changed_count": 0,
+      "skipped_count": 0,
+      "error_count": 1,
+      "owner": "scheduler@worker-1",
+      "trace_id": "trace-5d04",
+      "error": "transient storage timeout (retries exhausted; dead-lettered for inspection)",
+      "started_at": "2026-06-19T11:20:00Z",
+      "completed_at": "2026-06-19T11:21:12Z"
+    }
+  ],
+  "runtime_features": [
+    "Lease/lock prevents duplicate concurrent runs of the same scope.",
+    "Retry with backoff absorbs transient faults.",
+    "Exhausted retries dead-letter the run for inspection.",
+    "Run history is persisted (worker_runs) and exposed via GET /healthz/workers.",
+    "Scopes are explicit 'tenant:user' pairs."
+  ]
+}

--- a/apps/results-dashboard/requirements.txt
+++ b/apps/results-dashboard/requirements.txt
@@ -1,0 +1,2 @@
+streamlit>=1.36,<2
+pandas>=2.0,<3

--- a/docs/results-dashboard.md
+++ b/docs/results-dashboard.md
@@ -1,0 +1,112 @@
+# Public Results Dashboard + Evidence Explorer (v0.9)
+
+> **This is a public evidence/demo dashboard — not production UI.**
+> The Next.js app in [`apps/web`](../apps/web) remains the official product /
+> governance UI. The results dashboard reads static demo JSON; it never
+> connects to production secrets, a live database, or real user data.
+
+## Why this exists
+
+After v0.8 MemoryOps had a deep backend: governed capture, policy evaluation,
+hybrid retrieval, provider LLM adapters, a governance UI, background lifecycle
+workers, deletion compaction, vector purge verification, audit evidence, and a
+Railway-oriented worker runtime.
+
+The remaining gap was **visibility**, not capability:
+
+> People could not quickly see what MemoryOps does or what it proves.
+
+v0.9 closes that gap with a read-only Streamlit "results viewer" that explains
+the system and surfaces its evidence. It is deliberately **not** the product —
+it is the public window onto what the product proves.
+
+```text
+Streamlit  = public evidence/demo layer  (this dashboard)
+Next.js    = official product/admin governance UI  (apps/web)
+FastAPI    = real backend                 (services/api)
+Workers    = operational lifecycle system (services/worker)
+```
+
+## Where it lives
+
+[`apps/results-dashboard/`](../apps/results-dashboard) — isolated from the core
+API and the production path.
+
+```text
+apps/results-dashboard/
+  app.py                     # 8-page Streamlit router
+  requirements.txt           # streamlit + pandas
+  README.md
+  data/                      # static demo JSON artifacts (no real data)
+    releases.json
+    validation.json
+    memory_lifecycle_demo.json
+    deletion_compaction_demo.json
+    worker_runs.json
+    audit_events.json
+    roadmap.json
+  components/                # presentation-only helpers
+    cards.py
+    charts.py
+    flowcharts.py
+    timelines.py
+```
+
+## Pages
+
+1. **Overview** — what MemoryOps is, why memory needs governance, architecture.
+2. **Version Timeline** — v0.1 → v0.8 shipped, v0.9 in progress.
+3. **Memory Lifecycle Flow** — Capture → Evaluate → Store → Retrieve → Rank →
+   Compose → Update → Forget → Audit, with worked write/read examples.
+4. **Deletion Proof Explorer** — before/after deletion compaction, vector purge
+   verification, tombstone preservation (the strongest evidence MemoryOps has).
+5. **Worker Runtime Dashboard** — per-job results and run history including a
+   dead-lettered run.
+6. **Audit Evidence Viewer** — content-safe audit-event timelines.
+7. **Validation Results** — pytest / ruff / eval / PR-invariant-gate evidence.
+8. **Roadmap + Honest Limitations** — what's next and what the system does not
+   claim.
+
+## Data and safety model
+
+The dashboard renders only static JSON from `data/`. The shapes mirror the real
+backend so the evidence is faithful:
+
+- `worker_runs.json` follows the `worker_runs` table from
+  [`infra/db/migrations/006_worker_runtime.sql`](../infra/db/migrations/006_worker_runtime.sql)
+  (ids/counts/status only — never memory content).
+- `audit_events.json` uses real `AuditService` event names
+  (`memory_deleted`, `deletion_verification_passed`, `memory_content_compacted`,
+  `memory_vector_purge_verified`, `memory_purge_tombstone_preserved`, …).
+
+But every value is demo data. The dashboard has **no writes, no admin controls,
+no auth, no live DB, and no secrets**, so it adds no risk to the production path.
+
+## Honest limitations (shown in-app, page 8)
+
+- Deletion compaction is **not** crypto-shred.
+- No physical disk/page erasure guarantee.
+- No full pgvector VACUUM/reindex orchestration yet.
+- No cross-tenant scheduler until later.
+- This Streamlit dashboard is **demo-only** and read-only.
+- The Next.js app remains the official product UI.
+
+## Running
+
+```bash
+cd apps/results-dashboard
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+No environment variables or infrastructure are required. See
+[`apps/results-dashboard/README.md`](../apps/results-dashboard/README.md).
+
+## Relationship to the rest of the project
+
+- This dashboard is **not** part of the chat request path, the policy broker, or
+  any lifecycle invariant. It is an evidence surface, like the Hermes operator
+  skills and phase gates — it makes the project easier to inspect and share.
+- It does not replace, and must not be confused with, the Next.js governance UI.
+- Deployment stays **Railway-only**; this dashboard is a local/optional viewer
+  and introduces no Vercel dependency.

--- a/docs/rollout.md
+++ b/docs/rollout.md
@@ -77,14 +77,26 @@ legacy `jobs.py`). New migration `006_worker_runtime.sql`. See
 [phase-gates/phase-14-worker-runtime-orchestration.md](phase-gates/phase-14-worker-runtime-orchestration.md),
 [ADR-012](../infra/adr/ADR-012-worker-runtime-orchestration.md).
 
+## Phase 6 — Public results dashboard + evidence explorer ✅ (v0.9)
+A read-only public evidence/demo dashboard ([`apps/results-dashboard/`](../apps/results-dashboard))
+makes MemoryOps understandable and inspectable: overview, version timeline,
+memory lifecycle, deletion-compaction proof, worker runtime results, audit
+evidence, validation results, and honest limitations. It is **demo-only** —
+static demo JSON, no live DB, no secrets, no auth, no writes — and runs on
+Streamlit, isolated from the core API. The Next.js app (`apps/web`) remains the
+official product / governance UI; deployment stays Railway-only (no Vercel). See
+[results-dashboard.md](results-dashboard.md).
+
 ## Public roadmap
 
 | Version | Scope | Status |
 |---------|-------|--------|
 | v0.7 | Physical deletion compaction + vector purge verification | ✅ Done |
 | v0.8 | Worker runtime + scheduled lifecycle orchestration | ✅ Done |
-| v0.9 | Retention policies + legal hold + consent-aware memory | ⏳ Next |
-| v0.10 | Assistant SDK + example apps | ⏳ Planned |
+| v0.9 | Public results dashboard + evidence explorer | ✅ Done |
+| v0.10 | Retention policies + legal hold + consent-aware memory | ⏳ Next |
+| v0.11 | Assistant SDK + integration examples | ⏳ Planned |
+| v0.12 | Hosted demo + public screenshots | ⏳ Planned |
 | v1.0 | Production-ready governed memory runtime | ⏳ Planned |
 
 ## Production roadmap (beyond hackathon)


### PR DESCRIPTION
Adds a read-only public evidence/demo dashboard (`apps/results-dashboard`) built with Streamlit so people can quickly *see* what MemoryOps does and proves — memory lifecycle, deletion compaction + vector purge verification, worker runtime, audit evidence, validation results, roadmap, and honest limitations.

**Demo/evidence UI only:** static demo JSON, no live DB, no secrets, no auth, no writes; isolated from the core API. The Next.js app (`apps/web`) remains the official product/governance UI; deployment stays Railway-only (no Vercel).

## Pages
1. Overview · 2. Version Timeline · 3. Memory Lifecycle Flow · 4. Deletion Proof Explorer · 5. Worker Runtime Dashboard · 6. Audit Evidence Viewer · 7. Validation Results · 8. Roadmap + Honest Limitations

## Data
Static demo JSON under `apps/results-dashboard/data/`. Shapes mirror the real backend (`worker_runs` from migration 006, real `AuditService` event names like `memory_vector_purge_verified`, `memory_purge_tombstone_preserved`) but contain only demo data — never real user content.

## Docs
- New `docs/results-dashboard.md` (explains this is demo/evidence UI, not production)
- `apps/results-dashboard/README.md` with run instructions + guardrails
- Main `README.md`: repo layout, "What works as of v0.9" section, doc link, roadmap
- `docs/rollout.md`: Phase 6 note + reordered public roadmap (v0.9 = dashboard; retention → v0.10)

## Run
```
cd apps/results-dashboard && pip install -r requirements.txt && streamlit run app.py
```

## Validation
- Backend pytest: **206 passed, 1 skipped** (no backend code touched)
- ruff: all checks passed (backend + dashboard)
- Evals: PASS
- Dashboard: JSON valid, `py_compile` clean, all 8 pages render in a stubbed smoke test
- PR invariant gate: PASS — dashboard files arm **0** rules, so the gate needed no edits

## Known limitations (shown in-app)
Not crypto-shred · no physical disk/page erasure guarantee · no pgvector VACUUM/reindex orchestration · no cross-tenant scheduler yet · dashboard is demo-only & read-only · Next.js remains the official product UI.