### PR TITLE
feat: v0.11 assistant SDK + integration examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,12 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
 - `infra/db/migrations` — SQL schema (Postgres + pgvector). RLS is **enforced** in
   `004_rls_policies.sql` (`FORCE` + tenant policy); verify with `scripts/check_rls_policies.py`. See ADR-006.
 - `apps/web` — Next.js frontend.
+- `packages/memoryops-sdk` — typed Python SDK (v0.11) over the governed HTTP API
+  (`MemoryOpsClient` injects the tenant/user scope on every call) + integration
+  examples (quickstart, FastAPI, RAG, agent memory). Additive client only — the
+  server stays authoritative for all governance; the SDK adds none. Tested against
+  the real app in-process via an injectable `httpx.Client`. See ADR-014 and
+  `docs/assistant-sdk.md`.
 - `evals` — golden + adversarial cases, `run_evals.py`.
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ memoryops-ai/
   apps/results-dashboard/ Public read-only Streamlit results/evidence dashboard (demo-only; v0.9)
   services/api/        FastAPI backend (gateway, extractor, policy broker, write/read path, audit)
   services/worker/     Background jobs (decay, reflection, conflict resolution, compression)
+  packages/memoryops-sdk/ Python SDK + integration examples (quickstart, FastAPI, RAG, agent) (v0.11)
   packages/shared/     Shared types
   infra/db/            Postgres + pgvector migrations and seed
   infra/adr/           Architecture Decision Records
@@ -401,19 +402,34 @@ MemoryOps integrates it via an adapter and does not vendor its source.
   [docs/retention-policies.md](docs/retention-policies.md) and
   [ADR-013](infra/adr/ADR-013-retention-legal-hold-consent.md).
 
+## What works as of v0.11 (assistant SDK + integration examples)
+
+- A typed **Python SDK** ([`packages/memoryops-sdk/`](packages/memoryops-sdk))
+  wraps the governed HTTP API (chat, memories, retention/legal-hold/consent,
+  audit, metrics, loops, health) and injects the tenant/user scope on every call.
+  The **server stays authoritative** for all governance — the SDK adds none of
+  its own.
+- Runnable **integration examples**: quickstart, a FastAPI assistant endpoint, a
+  RAG assistant (governed user memory + your RAG docs), and an agent-memory tool.
+- Typed errors (`LegalHoldError`, `NotFoundError`, `APIError`) and an injectable
+  `httpx.Client` for in-process testing (the SDK is tested against the real app).
+- `pip install -e packages/memoryops-sdk`. See
+  [docs/assistant-sdk.md](docs/assistant-sdk.md) and
+  [ADR-014](infra/adr/ADR-014-assistant-sdk.md).
+
 ## Roadmap
 
 - **v0.7** — physical deletion compaction + vector purge verification ✅
 - **v0.8** — worker runtime + scheduled lifecycle orchestration ✅
 - **v0.9** — public results dashboard + evidence explorer ✅
 - **v0.10** — retention policies + legal hold + consent-aware memory ✅
-- **v0.11** — assistant SDK + integration examples
+- **v0.11** — assistant SDK + integration examples ✅
 - **v0.12** — hosted demo + public screenshots
 - **v1.0** — production-ready governed memory runtime
 
-## What remains (v0.11+)
+## What remains (v0.12+)
 
-- Assistant SDK + integration examples (v0.11); hosted demo + screenshots (v0.12).
+- Hosted demo + screenshots (v0.12); production-ready runtime (v1.0).
 - Consent *capture* at the UI/SDK edge; cross-tenant retention scheduling.
 - Hard purge / crypto-shred and pgvector index reclamation (beyond v0.7's
   auditable compaction).
@@ -459,5 +475,6 @@ system with release discipline, review gates, and operational safety. Overview:
 - [docs/governance.md](docs/governance.md) — lifecycle, approvals, audit, retention.
 - [docs/rollout.md](docs/rollout.md) — phased delivery and production roadmap.
 - [docs/results-dashboard.md](docs/results-dashboard.md) — public read-only results/evidence dashboard (v0.9; demo-only, not production UI).
+- [docs/assistant-sdk.md](docs/assistant-sdk.md) — Python SDK + integration examples (v0.11).
 - [docs/demo-script.md](docs/demo-script.md) — the 6-step demo.
 - [infra/adr/](infra/adr/) — storage, retrieval, policy broker, observability, deletion ADRs.

--- a/docs/assistant-sdk.md
+++ b/docs/assistant-sdk.md
@@ -1,0 +1,90 @@
+# Assistant SDK + Integration Examples (v0.11)
+
+> Makes MemoryOps easy to adopt: a typed Python client over the governed HTTP API,
+> plus runnable integration examples. The SDK adds **no** governance of its own —
+> the server stays authoritative for tenant isolation, policy-before-storage, the
+> deletion guarantee, legal hold, consent, and audit. See
+> [ADR-014](../infra/adr/ADR-014-assistant-sdk.md).
+
+## Why
+
+Through v0.10 MemoryOps was a deep, governed backend, but adopting it meant
+hand-writing HTTP calls and remembering to inject the tenant/user scope on every
+request. v0.11 closes that gap with `memoryops-sdk`: construct a client once with
+your scope, then call `mo.chat(...)`, `mo.list_memories()`, `mo.set_legal_hold(...)`.
+
+```text
+memoryops-sdk (this) = thin typed client over the governed API
+services/api          = the real backend (source of truth for governance)
+apps/web              = official product / governance UI
+apps/results-dashboard= public evidence/demo dashboard (v0.9)
+```
+
+## Where it lives
+
+[`packages/memoryops-sdk/`](../packages/memoryops-sdk):
+
+```text
+packages/memoryops-sdk/
+  pyproject.toml
+  README.md
+  memoryops/
+    __init__.py
+    client.py        # MemoryOpsClient (sync, httpx)
+    models.py        # typed response models (keep .raw for forward-compat)
+    errors.py        # MemoryOpsError / APIError / NotFoundError / LegalHoldError
+  examples/
+    quickstart.py
+    fastapi_integration.py
+    rag_assistant.py
+    agent_memory.py
+  tests/
+    test_client_unit.py   # httpx.MockTransport contract tests
+    test_client_e2e.py    # against the real ASGI app (in-process)
+```
+
+## Design
+
+- **Scope injection.** `tenant_id` / `user_id` are set at construction and added to
+  every body/query, so application code can't accidentally cross scopes.
+- **Faithful, not clever.** One method per endpoint; responses parse into small
+  dataclasses that always keep the full `.raw` payload so new server fields are
+  never dropped.
+- **Typed errors.** 404 → `NotFoundError`, 409 (held-memory delete) →
+  `LegalHoldError`, other non-2xx → `APIError`.
+- **Injectable transport.** Pass any `httpx.Client` (e.g. FastAPI `TestClient`)
+  via `http_client=` for in-process testing with no network.
+- **One dependency** (`httpx`); sync client; Python ≥ 3.10.
+
+## Coverage
+
+The SDK wraps the full HTTP surface: chat; memory CRUD + audit + provenance;
+retention / legal hold / pin / protect / consent / decisions (v0.10); audit;
+metrics; loops; and health.
+
+## Examples
+
+- **quickstart** — capture → retrieve → govern → forget in ~20 lines.
+- **fastapi_integration** — expose your own `/assistant` endpoint backed by
+  governed memory; per-user scope from your auth layer.
+- **rag_assistant** — blend governed *user* memory (MemoryOps) with *task*
+  knowledge from your own RAG store, then prompt your LLM (stubbed; swap in the
+  latest Claude model).
+- **agent_memory** — a governed memory *tool* for a tool-using agent (remember /
+  recall / forget / withdraw consent), with the agent able to read its own audit
+  trail.
+
+## Testing
+
+`test_client_unit.py` uses `httpx.MockTransport` for fast, self-contained contract
+tests (request shaping, response parsing, error mapping). `test_client_e2e.py`
+binds the SDK to the real FastAPI app in-process (via `TestClient`) so it verifies
+the SDK against the **live** contract, including legal-hold-blocks-delete and
+consent withdrawal. Both run with `cd packages/memoryops-sdk && pytest -q`.
+
+## Limitations / scope
+
+- Synchronous client only (an async client can follow if needed).
+- No bundled auth — pass your own `httpx.Client` with auth headers, or front the
+  API with your gateway. MemoryOps' own auth model is on the roadmap.
+- The SDK is a client; it cannot weaken server-side governance.

--- a/docs/rollout.md
+++ b/docs/rollout.md
@@ -101,6 +101,18 @@ legal hold is a *preservation* control, not crypto-shred. See
 [phase-gates/phase-15-governance.md](phase-gates/phase-15-governance.md),
 [ADR-013](../infra/adr/ADR-013-retention-legal-hold-consent.md).
 
+## Phase 8 — Assistant SDK + integration examples ✅ (v0.11)
+A typed Python SDK ([`packages/memoryops-sdk/`](../packages/memoryops-sdk)) wraps
+the governed HTTP API (chat, memories, retention/legal-hold/consent, audit,
+metrics, loops, health) and injects the tenant/user scope on every call. The
+**server stays authoritative** for all governance — the SDK adds none of its own.
+Ships with runnable examples (quickstart, FastAPI integration, RAG assistant,
+agent memory), typed errors (`LegalHoldError`/`NotFoundError`/`APIError`), and an
+injectable `httpx.Client` so it is tested against the real app in-process.
+Additive only — no `services/api` changes. See
+[assistant-sdk.md](assistant-sdk.md),
+[ADR-014](../infra/adr/ADR-014-assistant-sdk.md).
+
 ## Public roadmap
 
 | Version | Scope | Status |
@@ -109,8 +121,8 @@ legal hold is a *preservation* control, not crypto-shred. See
 | v0.8 | Worker runtime + scheduled lifecycle orchestration | ✅ Done |
 | v0.9 | Public results dashboard + evidence explorer | ✅ Done |
 | v0.10 | Retention policies + legal hold + consent-aware memory | ✅ Done |
-| v0.11 | Assistant SDK + integration examples | ⏳ Next |
-| v0.12 | Hosted demo + public screenshots | ⏳ Planned |
+| v0.11 | Assistant SDK + integration examples | ✅ Done |
+| v0.12 | Hosted demo + public screenshots | ⏳ Next |
 | v1.0 | Production-ready governed memory runtime | ⏳ Planned |
 
 ## Production roadmap (beyond hackathon)

--- a/infra/adr/ADR-014-assistant-sdk.md
+++ b/infra/adr/ADR-014-assistant-sdk.md
@@ -1,0 +1,48 @@
+# ADR-014 — Assistant SDK + Integration Examples
+
+- Status: Accepted (v0.11)
+- Date: 2026-06-22
+- Supersedes: none
+- Related: ADR-013 (retention/legal hold/consent), ADR-009 (memory control plane)
+
+## Context
+
+Through v0.10 MemoryOps exposed a complete governed HTTP API, but the only way to
+adopt it was to hand-write `httpx`/`requests` calls and remember to attach the
+`tenant_id` / `user_id` scope to every request. That is a real adoption tax and an
+easy place to introduce a cross-scope bug. The roadmap's v0.11 goal is to make
+MemoryOps easy for other builders to use.
+
+## Decision
+
+Ship a thin, typed **Python SDK** (`packages/memoryops-sdk`) plus runnable
+integration examples.
+
+- **`MemoryOpsClient`** wraps the full HTTP surface (chat; memory CRUD + audit +
+  provenance; retention / legal hold / consent / decisions; audit; metrics; loops;
+  health) and injects the tenant/user scope on every call.
+- **The server stays authoritative.** The SDK performs no governance of its own —
+  tenant isolation, policy-before-storage, the deletion guarantee, legal hold,
+  consent, and audit are all enforced by the API. A client cannot weaken them.
+- **Forward-compatible models.** Responses parse into small dataclasses that retain
+  the full `.raw` payload, so new server fields are never lost.
+- **Typed errors** map governance outcomes: `LegalHoldError` for a 409 held-memory
+  delete, `NotFoundError` for 404, `APIError` otherwise.
+- **Injectable transport.** Any `httpx.Client` (including FastAPI `TestClient`)
+  can be passed in, enabling in-process tests against the real app with no network.
+- **One dependency** (`httpx`); sync; Python ≥ 3.10. Examples cover a FastAPI
+  integration, a RAG assistant, and an agent-memory tool.
+
+## Consequences
+
+- Adoption drops to a few method calls; the scope-injection design removes a class
+  of cross-tenant bugs in caller code.
+- The SDK is **additive** — it lives in `packages/`, ships independently, and
+  changes no `services/api` code, so it arms no core invariant gate rules. Existing
+  backend tests are unaffected.
+- Out of scope for v0.11: an async client, bundled auth (callers supply their own
+  `httpx.Client`/headers; MemoryOps auth is a later milestone), and SDKs for other
+  languages.
+
+See [docs/assistant-sdk.md](../../docs/assistant-sdk.md) and
+[packages/memoryops-sdk/README.md](../../packages/memoryops-sdk/README.md).

--- a/packages/memoryops-sdk/README.md
+++ b/packages/memoryops-sdk/README.md
@@ -1,0 +1,133 @@
+# MemoryOps AI — Python SDK (v0.11)
+
+A small, typed Python client for the [MemoryOps AI](../../README.md) API. It makes
+the governed memory lifecycle — capture, retrieve, govern, forget, audit — a few
+method calls, while the **server stays the source of truth** for tenant isolation,
+policy-before-storage, the deletion guarantee, legal hold, consent, and audit.
+
+> The SDK is a thin, faithful client over the HTTP API. It adds no governance of
+> its own — it just makes the governed API easy to call from assistants, agents,
+> and RAG apps.
+
+## Install
+
+```bash
+pip install memoryops-sdk          # from PyPI (once published)
+# or, from this repo:
+pip install -e packages/memoryops-sdk
+```
+
+Only dependency: `httpx`.
+
+## Quickstart
+
+Run a MemoryOps API (no infra needed):
+
+```bash
+cd services/api && MEMORYOPS_STORAGE=memory uvicorn app.main:app --reload
+```
+
+```python
+from memoryops import MemoryOpsClient
+
+with MemoryOpsClient("http://localhost:8000", "tenant_demo", "user_demo") as mo:
+    # Capture (governed write)
+    mo.chat("Remember I prefer metric units and dark mode.")
+
+    # Retrieve (later turns get the governed memory context)
+    answer = mo.chat("What units should I use?")
+    print(answer.assistant_message)
+    print([u.content for u in answer.used_memories])
+
+    # Inspect
+    for m in mo.list_memories():
+        print(m.memory_type, m.content, m.status)
+```
+
+The `tenant_id` and `user_id` you pass to the constructor are injected on **every**
+call — your code never hand-builds request bodies or leaks another user's scope.
+
+## Copy-paste snippets
+
+**Govern a memory (legal hold blocks deletion):**
+
+```python
+from memoryops import LegalHoldError
+
+mo.set_legal_hold(memory_id, on=True, reason="litigation")
+try:
+    mo.delete_memory(memory_id)
+except LegalHoldError:
+    ...  # blocked until the hold is released
+mo.set_legal_hold(memory_id, on=False)
+mo.delete_memory(memory_id)
+```
+
+**Honor consent withdrawal (retention worker will expire it):**
+
+```python
+mo.set_consent(memory_id, status="withdrawn")
+```
+
+**Preview retention decisions (read-only, deletes nothing):**
+
+```python
+for d in mo.retention_decisions(policy="strict"):
+    print(d.memory_id, d.outcome, d.eligible_for_deletion, d.blocked_by)
+```
+
+**Recall without storing (read-only turn):**
+
+```python
+hits = mo.chat("What do you know about me?", temporary_chat=True).used_memories
+```
+
+**Read the audit trail (governance evidence):**
+
+```python
+for e in mo.audit(limit=20):
+    print(e.action, e.reason)
+```
+
+## API surface
+
+| Area | Methods |
+|---|---|
+| Chat | `chat(message, temporary_chat=, conversation_id=)` |
+| Memories | `list_memories`, `get_memory`, `update_memory`, `delete_memory`, `memory_audit`, `memory_provenance` |
+| Retention / hold / consent | `set_legal_hold`, `pin`, `protect`, `set_consent`, `retention_policies`, `retention_decisions`, `memory_governance` |
+| Governance / ops | `audit`, `metrics`, `loops`, `loop_trace`, `health`, `workers_health` |
+
+Errors are typed: `NotFoundError` (404), `LegalHoldError` (409 from a held-memory
+delete), and `APIError` (other non-2xx) — all subclasses of `MemoryOpsError`.
+
+## Examples
+
+Runnable scripts in [`examples/`](examples):
+
+- [`quickstart.py`](examples/quickstart.py) — capture → retrieve → govern → forget.
+- [`fastapi_integration.py`](examples/fastapi_integration.py) — put governed memory behind your own assistant endpoint.
+- [`rag_assistant.py`](examples/rag_assistant.py) — blend governed user memory with your own RAG context.
+- [`agent_memory.py`](examples/agent_memory.py) — give a tool-using agent governed, inspectable long-term memory.
+
+## Testing / in-process use
+
+Pass any `httpx.Client` (including FastAPI's `TestClient`) via `http_client=` to
+drive the SDK in-process without a network:
+
+```python
+from fastapi.testclient import TestClient
+from app.main import app
+from memoryops import MemoryOpsClient
+
+mo = MemoryOpsClient("http://testserver", "t", "u", http_client=TestClient(app))
+```
+
+Run the SDK test suite:
+
+```bash
+cd packages/memoryops-sdk && pytest -q
+```
+
+See [docs/assistant-sdk.md](../../docs/assistant-sdk.md) for the project-level
+overview.

--- a/packages/memoryops-sdk/examples/agent_memory.py
+++ b/packages/memoryops-sdk/examples/agent_memory.py
@@ -1,0 +1,65 @@
+"""Agent memory: give a tool-using agent governed, inspectable long-term memory.
+
+MemoryOps becomes the agent's memory tool. The agent can remember facts across
+sessions, recall them, and respect governance (consent withdrawal, legal hold)
+without implementing any of that itself. Each tool call is audited server-side.
+
+The "agent" here is a tiny stub loop; wire these tools into your real agent
+framework (function/tool calling) as needed.
+"""
+
+from __future__ import annotations
+
+from memoryops import MemoryOpsClient
+
+BASE_URL = "http://localhost:8000"
+
+
+class MemoryTool:
+    """A governed memory tool an agent can call."""
+
+    def __init__(self, mo: MemoryOpsClient) -> None:
+        self._mo = mo
+
+    def remember(self, fact: str) -> str:
+        result = self._mo.chat(f"Remember this: {fact}")
+        decided = [c.decision for c in result.candidate_memories]
+        return f"stored (decisions={decided})"
+
+    def recall(self, query: str) -> list[str]:
+        result = self._mo.chat(query, temporary_chat=True)  # recall without storing
+        return [u.content for u in result.used_memories]
+
+    def forget(self, memory_id: str) -> str:
+        self._mo.delete_memory(memory_id)
+        return "forgotten"
+
+    def withdraw_consent(self, memory_id: str) -> str:
+        """Honor a user revoking consent — the retention worker will expire it."""
+        self._mo.set_consent(memory_id, status="withdrawn")
+        return "consent withdrawn; memory now eligible for retention deletion"
+
+
+def main() -> None:
+    with MemoryOpsClient(BASE_URL, tenant_id="tenant_demo", user_id="agent_demo") as mo:
+        tool = MemoryTool(mo)
+
+        # Session 1: the agent learns durable facts.
+        print(tool.remember("The user's project is named Atlas."))
+        print(tool.remember("The user deploys on Railway."))
+
+        # Session 2 (later): the agent recalls them.
+        recalled = tool.recall("What is the user's project and where do they deploy?")
+        print("recalled:", recalled)
+
+        # Governance: the user withdraws consent for one memory.
+        memories = mo.list_memories()
+        if memories:
+            print(tool.withdraw_consent(memories[0].id))
+
+        # The agent can inspect its own audit trail (governance evidence).
+        print("recent audit:", [e.action for e in mo.audit(limit=5)])
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/memoryops-sdk/examples/fastapi_integration.py
+++ b/packages/memoryops-sdk/examples/fastapi_integration.py
@@ -1,0 +1,53 @@
+"""FastAPI integration: put governed memory behind your own assistant endpoint.
+
+Your app stays in control of the HTTP surface; MemoryOps handles capture, policy,
+retrieval, and audit. The per-user scope comes from your auth layer (here a
+header, for brevity) and is passed straight to the SDK.
+
+Run:
+
+    pip install fastapi uvicorn memoryops-sdk
+    uvicorn examples.fastapi_integration:app --reload
+    curl -s localhost:8000/assistant -H 'x-user-id: user_demo' \
+         -H 'content-type: application/json' -d '{"message":"Remember I like tea."}'
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Header
+from pydantic import BaseModel
+
+from memoryops import MemoryOpsClient
+
+MEMORYOPS_URL = "http://localhost:8000"  # the MemoryOps API (not this app)
+TENANT_ID = "tenant_demo"
+
+app = FastAPI(title="My Assistant (MemoryOps-backed)")
+
+
+class AskRequest(BaseModel):
+    message: str
+
+
+def _client(user_id: str) -> MemoryOpsClient:
+    # One client per request scope; cheap to construct. In production share a
+    # single httpx.Client via the http_client= argument for connection pooling.
+    return MemoryOpsClient(MEMORYOPS_URL, tenant_id=TENANT_ID, user_id=user_id)
+
+
+@app.post("/assistant")
+def assistant(req: AskRequest, x_user_id: str = Header(...)) -> dict:
+    with _client(x_user_id) as mo:
+        result = mo.chat(req.message)
+        return {
+            "reply": result.assistant_message,
+            "used_memories": [u.content for u in result.used_memories],
+            "trace_id": result.trace_id,
+        }
+
+
+@app.get("/assistant/memories")
+def list_memories(x_user_id: str = Header(...)) -> list[dict]:
+    with _client(x_user_id) as mo:
+        return [{"id": m.id, "type": m.memory_type, "content": m.content}
+                for m in mo.list_memories()]

--- a/packages/memoryops-sdk/examples/quickstart.py
+++ b/packages/memoryops-sdk/examples/quickstart.py
@@ -1,0 +1,56 @@
+"""Quickstart: capture, retrieve, govern, and forget — in ~20 lines.
+
+Run a MemoryOps API first (no infra needed):
+
+    cd services/api && MEMORYOPS_STORAGE=memory uvicorn app.main:app --reload
+
+Then:
+
+    python examples/quickstart.py
+"""
+
+from __future__ import annotations
+
+from memoryops import LegalHoldError, MemoryOpsClient
+
+BASE_URL = "http://localhost:8000"
+
+
+def main() -> None:
+    with MemoryOpsClient(BASE_URL, tenant_id="tenant_demo", user_id="user_demo") as mo:
+        # 1. Capture — the message flows through extraction + the policy broker.
+        result = mo.chat("Remember that I prefer metric units and dark mode.")
+        print("assistant:", result.assistant_message)
+        print("stored candidates:", [c.decision for c in result.candidate_memories])
+
+        # 2. Retrieve — later turns get the governed memory context.
+        answer = mo.chat("What units should I use in the summary?")
+        print("retrieval_mode:", answer.retrieval_mode)
+        for used in answer.used_memories:
+            print("  used:", used.content, f"(score={used.score:.2f})")
+
+        # 3. Inspect what is stored.
+        memories = mo.list_memories()
+        print(f"\n{len(memories)} memories:")
+        for m in memories:
+            print(f"  [{m.memory_type}] {m.content}  (status={m.status})")
+
+        if not memories:
+            return
+        first = memories[0]
+
+        # 4. Govern — put a memory on legal hold; deletion is now refused.
+        mo.set_legal_hold(first.id, on=True, reason="demo hold")
+        try:
+            mo.delete_memory(first.id)
+        except LegalHoldError:
+            print(f"\ndelete of {first.id} blocked by legal hold (as expected)")
+
+        # 5. Release the hold and forget.
+        mo.set_legal_hold(first.id, on=False)
+        mo.delete_memory(first.id)
+        print("deleted after releasing hold")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/memoryops-sdk/examples/rag_assistant.py
+++ b/packages/memoryops-sdk/examples/rag_assistant.py
@@ -1,0 +1,58 @@
+"""RAG assistant: blend governed long-term memory with your own RAG context.
+
+The pattern: retrieve durable user memory from MemoryOps, retrieve task documents
+from your own vector store / RAG pipeline, then compose a prompt for your LLM.
+MemoryOps governs the *user* memory (what is remembered about the person, with
+policy + consent + audit); your RAG store holds the *knowledge* (docs, tickets).
+
+This example stubs the LLM + doc retriever so it runs without keys; swap in your
+provider and retriever.
+"""
+
+from __future__ import annotations
+
+from memoryops import MemoryOpsClient
+
+BASE_URL = "http://localhost:8000"
+
+
+def retrieve_docs(query: str) -> list[str]:
+    """Stub doc retriever — replace with your vector store / RAG pipeline."""
+    corpus = {
+        "refund": "Refunds are processed within 5 business days to the original method.",
+        "shipping": "Standard shipping takes 3-5 days; express is next-day.",
+    }
+    return [text for key, text in corpus.items() if key in query.lower()]
+
+
+def call_llm(system: str, user: str) -> str:
+    """Stub LLM — replace with your provider (e.g. the latest Claude model)."""
+    return f"[stub answer]\nSYSTEM:\n{system}\n\nUSER: {user}"
+
+
+def answer(mo: MemoryOpsClient, question: str) -> str:
+    # 1. Governed user memory (preferences, constraints) from MemoryOps.
+    mem = mo.chat(question, temporary_chat=True)  # read-only: don't store the question
+    user_facts = [u.content for u in mem.used_memories]
+
+    # 2. Task knowledge from your own RAG store.
+    docs = retrieve_docs(question)
+
+    # 3. Compose and answer.
+    system = "You are a support assistant.\n"
+    if user_facts:
+        system += "Known user preferences:\n- " + "\n- ".join(user_facts) + "\n"
+    if docs:
+        system += "Relevant policy:\n- " + "\n- ".join(docs) + "\n"
+    return call_llm(system, question)
+
+
+def main() -> None:
+    with MemoryOpsClient(BASE_URL, tenant_id="tenant_demo", user_id="user_demo") as mo:
+        # Seed a durable preference (governed write).
+        mo.chat("Remember I always want express shipping.")
+        print(answer(mo, "How long will shipping take?"))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/memoryops-sdk/memoryops/__init__.py
+++ b/packages/memoryops-sdk/memoryops/__init__.py
@@ -1,0 +1,42 @@
+"""MemoryOps AI — Python SDK.
+
+A thin, typed client over the MemoryOps AI HTTP API. The server stays the source
+of truth for governance (tenant isolation, policy-before-storage, the deletion
+guarantee, legal hold, auditability); the SDK just makes the governed API easy to
+call from assistants, agents, and RAG apps.
+
+    from memoryops import MemoryOpsClient
+
+    with MemoryOpsClient("http://localhost:8000", "tenant_demo", "user_demo") as mo:
+        print(mo.chat("Remember I prefer metric units.").assistant_message)
+"""
+
+from __future__ import annotations
+
+from .client import MemoryOpsClient
+from .errors import APIError, LegalHoldError, MemoryOpsError, NotFoundError
+from .models import (
+    AuditEvent,
+    CandidateDecision,
+    ChatResult,
+    Memory,
+    RetentionDecision,
+    UsedMemory,
+)
+
+__version__ = "0.11.0"
+
+__all__ = [
+    "MemoryOpsClient",
+    "MemoryOpsError",
+    "APIError",
+    "NotFoundError",
+    "LegalHoldError",
+    "ChatResult",
+    "Memory",
+    "UsedMemory",
+    "CandidateDecision",
+    "AuditEvent",
+    "RetentionDecision",
+    "__version__",
+]

--- a/packages/memoryops-sdk/memoryops/client.py
+++ b/packages/memoryops-sdk/memoryops/client.py
@@ -1,0 +1,224 @@
+"""MemoryOpsClient — a small, typed Python client for the MemoryOps AI API.
+
+It wraps the HTTP surface (chat, memories, retention/legal-hold/consent, audit,
+metrics, loops, health) and injects the ``tenant_id`` / ``user_id`` scope on every
+call so application code never hand-builds request bodies. Tenant isolation,
+the deletion guarantee, policy-before-storage, and auditability are enforced by
+the server — the SDK is a thin, faithful client over that governed API.
+
+Example::
+
+    from memoryops import MemoryOpsClient
+
+    with MemoryOpsClient("http://localhost:8000", "tenant_demo", "user_demo") as mo:
+        result = mo.chat("Remember I prefer metric units.")
+        print(result.assistant_message)
+        for m in mo.list_memories():
+            print(m.memory_type, m.content)
+
+The client is synchronous and built on ``httpx``. For tests or in-process use you
+can pass a pre-built ``httpx.Client`` (e.g. one bound to an ASGI app) via
+``http_client``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from .errors import APIError, LegalHoldError, NotFoundError
+from .models import AuditEvent, ChatResult, Memory, RetentionDecision
+
+__all__ = ["MemoryOpsClient"]
+
+
+class MemoryOpsClient:
+    def __init__(
+        self,
+        base_url: str,
+        tenant_id: str,
+        user_id: str,
+        *,
+        timeout: float = 30.0,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self.tenant_id = tenant_id
+        self.user_id = user_id
+        self._owns_client = http_client is None
+        self._http = http_client or httpx.Client(base_url=base_url.rstrip("/"), timeout=timeout)
+
+    # ── lifecycle ──────────────────────────────────────────────────────────────
+    def close(self) -> None:
+        if self._owns_client:
+            self._http.close()
+
+    def __enter__(self) -> MemoryOpsClient:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # ── transport ──────────────────────────────────────────────────────────────
+    def _request(self, method: str, path: str, **kwargs: Any) -> Any:
+        resp = self._http.request(method, path, **kwargs)
+        if resp.status_code >= 400:
+            self._raise(resp)
+        if resp.content:
+            return resp.json()
+        return None
+
+    @staticmethod
+    def _raise(resp: httpx.Response) -> None:
+        detail: str | None = None
+        try:
+            detail = resp.json().get("detail")
+        except Exception:  # noqa: BLE001 — non-JSON error bodies are fine
+            detail = None
+        if resp.status_code == 404:
+            raise NotFoundError(resp.status_code, detail, resp.text)
+        if resp.status_code == 409:
+            raise LegalHoldError(resp.status_code, detail, resp.text)
+        raise APIError(resp.status_code, detail, resp.text)
+
+    def _scope(self, **extra: Any) -> dict:
+        return {"tenant_id": self.tenant_id, "user_id": self.user_id, **extra}
+
+    # ── chat ───────────────────────────────────────────────────────────────────
+    def chat(
+        self,
+        message: str,
+        *,
+        temporary_chat: bool = False,
+        conversation_id: str | None = None,
+    ) -> ChatResult:
+        """Send a message through the governed memory pipeline (write + read).
+
+        With ``temporary_chat=True`` the server reads and writes nothing
+        (invariant #6) — useful for one-off prompts that must not be remembered.
+        """
+        body = self._scope(
+            message=message,
+            temporary_chat=temporary_chat,
+            conversation_id=conversation_id,
+        )
+        return ChatResult.from_dict(self._request("POST", "/api/chat", json=body))
+
+    # ── memories ───────────────────────────────────────────────────────────────
+    def list_memories(
+        self, *, status: str | None = None, memory_type: str | None = None
+    ) -> list[Memory]:
+        params = self._scope()
+        if status:
+            params["status"] = status
+        if memory_type:
+            params["memory_type"] = memory_type
+        rows = self._request("GET", "/api/memories", params=params)
+        return [Memory.from_dict(r) for r in rows]
+
+    def get_memory(self, memory_id: str) -> Memory:
+        return Memory.from_dict(
+            self._request("GET", f"/api/memories/{memory_id}", params=self._scope())
+        )
+
+    def update_memory(
+        self,
+        memory_id: str,
+        *,
+        content: str | None = None,
+        importance: int | None = None,
+        confidence: float | None = None,
+        status: str | None = None,
+    ) -> Memory:
+        body = self._scope()
+        for key, val in (
+            ("content", content),
+            ("importance", importance),
+            ("confidence", confidence),
+            ("status", status),
+        ):
+            if val is not None:
+                body[key] = val
+        return Memory.from_dict(self._request("PATCH", f"/api/memories/{memory_id}", json=body))
+
+    def delete_memory(self, memory_id: str) -> dict:
+        """Soft-delete a memory.
+
+        Raises :class:`LegalHoldError` (HTTP 409) if the memory is under legal
+        hold — release the hold first (``set_legal_hold(..., on=False)``).
+        """
+        return self._request("DELETE", f"/api/memories/{memory_id}", json=self._scope())
+
+    def memory_audit(self, memory_id: str, *, limit: int = 200) -> list[AuditEvent]:
+        rows = self._request(
+            "GET", f"/api/memories/{memory_id}/audit", params=self._scope(limit=limit)
+        )
+        return [AuditEvent.from_dict(r) for r in rows]
+
+    def memory_provenance(self, memory_id: str) -> dict:
+        return self._request("GET", f"/api/memories/{memory_id}/provenance", params=self._scope())
+
+    # ── retention / legal hold / consent (v0.10) ───────────────────────────────
+    def set_legal_hold(self, memory_id: str, *, on: bool, reason: str | None = None) -> dict:
+        body = self._scope(memory_id=memory_id, on=on, reason=reason)
+        return self._request("POST", "/api/retention/legal-hold", json=body)
+
+    def pin(self, memory_id: str, *, on: bool = True) -> dict:
+        return self._request(
+            "POST", "/api/retention/pin", json=self._scope(memory_id=memory_id, on=on)
+        )
+
+    def protect(self, memory_id: str, *, on: bool = True) -> dict:
+        return self._request(
+            "POST", "/api/retention/protect", json=self._scope(memory_id=memory_id, on=on)
+        )
+
+    def set_consent(
+        self, memory_id: str, *, status: str, expires_at: str | None = None
+    ) -> dict:
+        body = self._scope(memory_id=memory_id, status=status, expires_at=expires_at)
+        return self._request("POST", "/api/retention/consent", json=body)
+
+    def retention_policies(self) -> list[dict]:
+        return self._request("GET", "/api/retention/policies")["policies"]
+
+    def retention_decisions(self, *, policy: str | None = None) -> list[RetentionDecision]:
+        """Read-only preview of retention decisions for active memory in scope.
+
+        Deletes nothing — this is exactly what the retention worker would act on
+        when enabled.
+        """
+        params = self._scope()
+        if policy:
+            params["policy"] = policy
+        body = self._request("GET", "/api/retention/decisions", params=params)
+        return [RetentionDecision.from_dict(d) for d in body["decisions"]]
+
+    def memory_governance(self, memory_id: str, *, policy: str | None = None) -> dict:
+        params = self._scope()
+        if policy:
+            params["policy"] = policy
+        return self._request("GET", f"/api/retention/memory/{memory_id}", params=params)
+
+    # ── audit / metrics / loops / health ───────────────────────────────────────
+    def audit(self, *, memory_id: str | None = None, limit: int = 200) -> list[AuditEvent]:
+        params = self._scope(limit=limit)
+        if memory_id:
+            params["memory_id"] = memory_id
+        rows = self._request("GET", "/api/audit", params=params)
+        return [AuditEvent.from_dict(r) for r in rows]
+
+    def metrics(self) -> dict:
+        return self._request("GET", "/api/metrics", params={"tenant_id": self.tenant_id})
+
+    def loops(self) -> list[dict]:
+        return self._request("GET", "/api/loops")
+
+    def loop_trace(self, trace_id: str) -> dict:
+        return self._request("GET", f"/api/loops/trace/{trace_id}")
+
+    def health(self) -> dict:
+        return self._request("GET", "/healthz")
+
+    def workers_health(self) -> dict:
+        return self._request("GET", "/healthz/workers")

--- a/packages/memoryops-sdk/memoryops/errors.py
+++ b/packages/memoryops-sdk/memoryops/errors.py
@@ -1,0 +1,33 @@
+"""Typed errors raised by the MemoryOps SDK."""
+
+from __future__ import annotations
+
+
+class MemoryOpsError(Exception):
+    """Base class for all SDK errors."""
+
+
+class APIError(MemoryOpsError):
+    """A non-2xx HTTP response from the MemoryOps API.
+
+    Carries the status code, the parsed ``detail`` (when present), and the raw
+    response body so callers can branch on either.
+    """
+
+    def __init__(self, status_code: int, detail: str | None = None, body: str = "") -> None:
+        self.status_code = status_code
+        self.detail = detail
+        self.body = body
+        super().__init__(f"HTTP {status_code}: {detail or body or 'request failed'}")
+
+
+class NotFoundError(APIError):
+    """A 404 — the memory (or other resource) does not exist in this scope."""
+
+
+class LegalHoldError(APIError):
+    """A 409 from a delete blocked by an active legal hold (v0.10).
+
+    Release the hold with :meth:`MemoryOpsClient.set_legal_hold` (``on=False``)
+    before deleting.
+    """

--- a/packages/memoryops-sdk/memoryops/models.py
+++ b/packages/memoryops-sdk/memoryops/models.py
@@ -1,0 +1,147 @@
+"""Lightweight typed models for MemoryOps API responses.
+
+These are thin, forgiving dataclasses: each keeps the full ``raw`` payload so new
+server fields are never lost, while surfacing the common fields with types. Use
+``.raw`` whenever you need something not modeled here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class UsedMemory:
+    memory_id: str
+    content: str
+    score: float
+    memory_type: str = "semantic"
+    reason: str = ""
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> UsedMemory:
+        return cls(
+            memory_id=d.get("memory_id", ""),
+            content=d.get("content", ""),
+            score=d.get("score", 0.0),
+            memory_type=d.get("memory_type", "semantic"),
+            reason=d.get("reason", ""),
+            raw=d,
+        )
+
+
+@dataclass
+class CandidateDecision:
+    content: str
+    decision: str
+    reason: str = ""
+    memory_id: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> CandidateDecision:
+        return cls(
+            content=d.get("content", ""),
+            decision=d.get("decision", ""),
+            reason=d.get("reason", ""),
+            memory_id=d.get("memory_id"),
+            raw=d,
+        )
+
+
+@dataclass
+class ChatResult:
+    assistant_message: str
+    used_memories: list[UsedMemory]
+    candidate_memories: list[CandidateDecision]
+    retrieval_mode: str
+    trace_id: str
+    temporary_chat: bool = False
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> ChatResult:
+        return cls(
+            assistant_message=d.get("assistant_message", ""),
+            used_memories=[UsedMemory.from_dict(m) for m in d.get("used_memories", [])],
+            candidate_memories=[
+                CandidateDecision.from_dict(c) for c in d.get("candidate_memories", [])
+            ],
+            retrieval_mode=d.get("retrieval_mode", "none"),
+            trace_id=d.get("trace_id", ""),
+            temporary_chat=d.get("temporary_chat", False),
+            raw=d,
+        )
+
+
+@dataclass
+class Memory:
+    id: str
+    content: str
+    memory_type: str
+    status: str
+    importance: int
+    confidence: float
+    sensitivity: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> Memory:
+        return cls(
+            id=d.get("id", ""),
+            content=d.get("content", ""),
+            memory_type=d.get("memory_type", ""),
+            status=d.get("status", ""),
+            importance=d.get("importance", 0),
+            confidence=d.get("confidence", 0.0),
+            sensitivity=d.get("sensitivity", "low"),
+            metadata=d.get("metadata", {}),
+            raw=d,
+        )
+
+
+@dataclass
+class AuditEvent:
+    id: str
+    action: str
+    reason: str
+    memory_id: str | None = None
+    created_at: str = ""
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> AuditEvent:
+        return cls(
+            id=d.get("id", ""),
+            action=d.get("action", ""),
+            reason=d.get("reason", ""),
+            memory_id=d.get("memory_id"),
+            created_at=d.get("created_at", ""),
+            raw=d,
+        )
+
+
+@dataclass
+class RetentionDecision:
+    memory_id: str
+    policy: str
+    outcome: str
+    eligible_for_deletion: bool
+    blocked_by: list[str]
+    reason: str = ""
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> RetentionDecision:
+        return cls(
+            memory_id=d.get("memory_id", ""),
+            policy=d.get("policy", ""),
+            outcome=d.get("outcome", ""),
+            eligible_for_deletion=d.get("eligible_for_deletion", False),
+            blocked_by=list(d.get("blocked_by", [])),
+            reason=d.get("reason", ""),
+            raw=d,
+        )

--- a/packages/memoryops-sdk/pyproject.toml
+++ b/packages/memoryops-sdk/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "memoryops-sdk"
+version = "0.11.0"
+description = "Python SDK for MemoryOps AI — governed memory infrastructure for AI assistants."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "MemoryOps AI" }]
+keywords = ["memoryops", "ai", "memory", "governance", "llm", "agents", "rag"]
+dependencies = ["httpx>=0.24,<1"]
+
+[project.urls]
+Homepage = "https://github.com/patibandlavenkatamanideep/memoryops-ai"
+Documentation = "https://github.com/patibandlavenkatamanideep/memoryops-ai/blob/main/docs/assistant-sdk.md"
+
+[project.optional-dependencies]
+dev = ["pytest>=7", "ruff>=0.4"]
+
+[tool.setuptools]
+packages = ["memoryops"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"

--- a/packages/memoryops-sdk/tests/conftest.py
+++ b/packages/memoryops-sdk/tests/conftest.py
@@ -1,0 +1,57 @@
+"""Test fixtures for the MemoryOps SDK.
+
+Two ways to drive the client without a network:
+  * ``mock_client`` — an httpx.MockTransport with canned JSON, for fast,
+    self-contained contract tests of request shaping + response parsing.
+  * ``live_client`` — the SDK bound in-process to the real FastAPI app via
+    httpx.ASGITransport, proving the SDK matches the live API contract. Skipped
+    automatically if the API package isn't importable.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from memoryops import MemoryOpsClient
+
+# Make the API package importable for the in-process end-to-end fixture.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_API_DIR = _REPO_ROOT / "services" / "api"
+if _API_DIR.is_dir() and str(_API_DIR) not in sys.path:
+    sys.path.insert(0, str(_API_DIR))
+
+
+@pytest.fixture
+def live_client():
+    """SDK bound to the real ASGI app with a fresh in-memory repo per test."""
+    import os
+
+    os.environ["MEMORYOPS_STORAGE"] = "memory"
+    pytest.importorskip("fastapi")
+    try:
+        from app import deps  # type: ignore
+        from app.db import factory  # type: ignore
+        from app.main import app  # type: ignore
+    except Exception:  # noqa: BLE001 — API package not available in this checkout
+        pytest.skip("MemoryOps API package not importable")
+
+    from fastapi.testclient import TestClient
+
+    factory.get_repository.cache_clear()
+    deps.gateway.cache_clear()
+    deps.audit_service.cache_clear()
+
+    # TestClient is a sync httpx.Client that bridges to the ASGI app — pass it
+    # straight to the SDK so the client exercises the real route handlers.
+    http = TestClient(app)
+    client = MemoryOpsClient(
+        "http://testserver", tenant_id="tenant_demo", user_id="user_demo", http_client=http
+    )
+    yield client
+    client.close()
+    factory.get_repository.cache_clear()
+    deps.gateway.cache_clear()
+    deps.audit_service.cache_clear()

--- a/packages/memoryops-sdk/tests/test_client_e2e.py
+++ b/packages/memoryops-sdk/tests/test_client_e2e.py
@@ -1,0 +1,63 @@
+"""End-to-end tests — the SDK against the real MemoryOps FastAPI app, in process.
+
+These prove the SDK matches the *live* contract (paths, scopes, governance
+behavior), not a mock. Skipped automatically if the API package isn't importable
+(see conftest.live_client).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_chat_then_list_roundtrip(live_client) -> None:
+    result = live_client.chat("Remember that I prefer dark mode dashboards.")
+    assert result.assistant_message
+    assert result.trace_id
+
+    memories = live_client.list_memories()
+    assert any("dark mode" in m.content for m in memories)
+
+
+def test_legal_hold_blocks_delete_then_release_allows(live_client) -> None:
+    from memoryops import LegalHoldError
+
+    live_client.chat("Remember my account id is 12345.")
+    memory = live_client.list_memories()[0]
+
+    live_client.set_legal_hold(memory.id, on=True, reason="audit")
+    with pytest.raises(LegalHoldError):
+        live_client.delete_memory(memory.id)
+
+    live_client.set_legal_hold(memory.id, on=False)
+    out = live_client.delete_memory(memory.id)
+    assert out["status"] == "deleted"
+
+
+def test_retention_decisions_and_policies(live_client) -> None:
+    live_client.chat("Remember I like espresso.")
+    policies = live_client.retention_policies()
+    assert {"default", "strict", "extended"} <= {p["name"] for p in policies}
+
+    decisions = live_client.retention_decisions()
+    assert all(d.memory_id for d in decisions)
+
+
+def test_consent_withdrawal_is_recorded(live_client) -> None:
+    live_client.chat("Remember I live in Berlin.")
+    memory = live_client.list_memories()[0]
+    live_client.set_consent(memory.id, status="withdrawn")
+    gov = live_client.memory_governance(memory.id)
+    assert gov["governance"]["consent_status"] == "withdrawn"
+
+
+def test_temporary_chat_writes_nothing(live_client) -> None:
+    before = len(live_client.list_memories())
+    live_client.chat("Remember a temporary secret.", temporary_chat=True)
+    assert len(live_client.list_memories()) == before
+
+
+def test_audit_trail_is_readable(live_client) -> None:
+    live_client.chat("Remember I prefer tabs.")
+    events = live_client.audit(limit=10)
+    assert any(e.action for e in events)

--- a/packages/memoryops-sdk/tests/test_client_unit.py
+++ b/packages/memoryops-sdk/tests/test_client_unit.py
@@ -1,0 +1,130 @@
+"""Unit contract tests — SDK request shaping + response parsing + error mapping.
+
+Uses httpx.MockTransport so no server is needed. Asserts the SDK injects the
+tenant/user scope, hits the right paths, parses responses into typed models, and
+maps HTTP errors to typed exceptions.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from memoryops import LegalHoldError, MemoryOpsClient, NotFoundError
+
+
+def _client(handler) -> MemoryOpsClient:
+    transport = httpx.MockTransport(handler)
+    http = httpx.Client(transport=transport, base_url="http://test")
+    return MemoryOpsClient("http://test", "t1", "u1", http_client=http)
+
+
+def test_chat_injects_scope_and_parses_result() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={
+            "assistant_message": "ok",
+            "used_memories": [{"memory_id": "m1", "content": "likes tea", "score": 0.9}],
+            "candidate_memories": [{"content": "likes tea", "decision": "SAVE"}],
+            "retrieval_mode": "hybrid",
+            "trace_id": "tr1",
+            "temporary_chat": False,
+        })
+
+    with _client(handler) as mo:
+        result = mo.chat("hi there", temporary_chat=False)
+
+    assert seen["url"].endswith("/api/chat")
+    assert seen["body"]["tenant_id"] == "t1" and seen["body"]["user_id"] == "u1"
+    assert seen["body"]["message"] == "hi there"
+    assert result.assistant_message == "ok"
+    assert result.retrieval_mode == "hybrid"
+    assert result.used_memories[0].content == "likes tea"
+    assert result.candidate_memories[0].decision == "SAVE"
+
+
+def test_list_memories_passes_scope_as_query() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json=[
+            {"id": "m1", "content": "x", "memory_type": "preference", "status": "active",
+             "importance": 5, "confidence": 0.8, "sensitivity": "low"},
+        ])
+
+    with _client(handler) as mo:
+        mems = mo.list_memories(status="active")
+
+    assert seen["params"]["tenant_id"] == "t1"
+    assert seen["params"]["user_id"] == "u1"
+    assert seen["params"]["status"] == "active"
+    assert mems[0].id == "m1" and mems[0].memory_type == "preference"
+
+
+def test_delete_under_legal_hold_raises_typed_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(409, json={"detail": "memory is under legal hold"})
+
+    with _client(handler) as mo:
+        with pytest.raises(LegalHoldError) as exc:
+            mo.delete_memory("m1")
+    assert exc.value.status_code == 409
+    assert "legal hold" in (exc.value.detail or "")
+
+
+def test_missing_memory_raises_not_found() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "memory not found"})
+
+    with _client(handler) as mo:
+        with pytest.raises(NotFoundError):
+            mo.get_memory("nope")
+
+
+def test_set_legal_hold_builds_body() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"memory_id": "m1", "governance": {"legal_hold": True}})
+
+    with _client(handler) as mo:
+        out = mo.set_legal_hold("m1", on=True, reason="litigation")
+
+    assert seen["url"].endswith("/api/retention/legal-hold")
+    assert seen["body"] == {"tenant_id": "t1", "user_id": "u1", "memory_id": "m1",
+                            "on": True, "reason": "litigation"}
+    assert out["governance"]["legal_hold"] is True
+
+
+def test_retention_decisions_parses_models() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            "policy": "default", "scanned": 1, "summary": {"expired": 1},
+            "decisions": [{"memory_id": "m1", "policy": "default", "outcome": "expired",
+                           "eligible_for_deletion": True, "blocked_by": [], "reason": "old"}],
+        })
+
+    with _client(handler) as mo:
+        decisions = mo.retention_decisions(policy="default")
+    assert decisions[0].outcome == "expired"
+    assert decisions[0].eligible_for_deletion is True
+
+
+def test_generic_api_error_surfaces_status() -> None:
+    from memoryops import APIError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    with _client(handler) as mo:
+        with pytest.raises(APIError) as exc:
+            mo.metrics()
+    assert exc.value.status_code == 500


### PR DESCRIPTION
Makes MemoryOps easy to adopt: a typed Python SDK over the governed HTTP API, plus runnable integration examples (ADR-014). **Additive only** — no `services/api` changes; the server stays the source of truth for all governance and the SDK adds none of its own.

## What landed
- **`MemoryOpsClient`** ([`packages/memoryops-sdk`](packages/memoryops-sdk)) wraps the full surface — chat; memory CRUD + audit + provenance; retention / legal hold / pin / protect / consent / decisions (v0.10); audit; metrics; loops; health — and injects the `tenant_id`/`user_id` scope on every call, removing a class of cross-scope bugs in caller code.
- **Forward-compatible models** (dataclasses that keep the full `.raw` payload) and **typed errors**: `LegalHoldError` (409 held-memory delete), `NotFoundError` (404), `APIError` (other non-2xx).
- **Injectable transport** — pass any `httpx.Client` (incl. FastAPI `TestClient`) to drive the SDK in-process with no network.
- **Examples**: `quickstart.py`, `fastapi_integration.py`, `rag_assistant.py` (governed user memory + your RAG docs), `agent_memory.py` (governed memory tool for an agent).

## Validation
- **SDK tests: 13 passed** — `test_client_unit.py` (httpx `MockTransport` contract tests: scope injection, response parsing, error mapping) + `test_client_e2e.py` (in-process against the **real** ASGI app: legal-hold-blocks-delete, consent withdrawal, temporary-chat-writes-nothing, audit trail).
- **Backend tests: 249 passed, 1 skipped** (unchanged — no backend code touched).
- **ruff**: clean (api + sdk). **evals**: PASS.
- **PR invariant gate**: PASS — 0 rules armed (additive package + docs).

## Design / scope
- One dependency (`httpx`); sync client; Python ≥ 3.10; `pip install -e packages/memoryops-sdk`.
- Out of scope for v0.11: async client, bundled auth (callers supply their own `httpx.Client`/headers), and non-Python SDKs.

## Docs
`docs/assistant-sdk.md`, `packages/memoryops-sdk/README.md` (with copy-paste snippets), ADR-014, and README / rollout / CLAUDE updates.

Not tagged, not merged.