### PR TITLE
feat: v0.12 interactive playground + hosted demo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,12 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
 - `infra/db/migrations` — SQL schema (Postgres + pgvector). RLS is **enforced** in
   `004_rls_policies.sql` (`FORCE` + tenant policy); verify with `scripts/check_rls_policies.py`. See ADR-006.
 - `apps/web` — Next.js frontend.
+- `apps/results-dashboard` — read-only public Streamlit evidence dashboard (v0.9; demo-only).
+- `apps/playground` — interactive public Streamlit playground (v0.12). Drives the
+  **real** governed pipeline from `services/api` in-process against a fresh
+  **in-memory** store per session (no DB, no secrets, no real data). Entrypoint is
+  `streamlit_app.py` (named to avoid shadowing the `app` package). Demo-only — not
+  the production UI; additive, no `services/api` changes. See `docs/playground.md`.
 - `packages/memoryops-sdk` — typed Python SDK (v0.11) over the governed HTTP API
   (`MemoryOpsClient` injects the tenant/user scope on every call) + integration
   examples (quickstart, FastAPI, RAG, agent memory). Additive client only — the

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ enforced.
 memoryops-ai/
   apps/web/            Next.js frontend (chat, memories, governance, audit, loops, admin, architecture)
   apps/results-dashboard/ Public read-only Streamlit results/evidence dashboard (demo-only; v0.9)
+  apps/playground/     Interactive Streamlit playground over the real pipeline (demo-only, in-memory; v0.12)
   services/api/        FastAPI backend (gateway, extractor, policy broker, write/read path, audit)
   services/worker/     Background jobs (decay, reflection, conflict resolution, compression)
   packages/memoryops-sdk/ Python SDK + integration examples (quickstart, FastAPI, RAG, agent) (v0.11)
@@ -417,6 +418,23 @@ MemoryOps integrates it via an adapter and does not vendor its source.
   [docs/assistant-sdk.md](docs/assistant-sdk.md) and
   [ADR-014](infra/adr/ADR-014-assistant-sdk.md).
 
+## What works as of v0.12 (interactive playground + hosted demo)
+
+- An **interactive public Playground** ([`apps/playground/`](apps/playground))
+  that *drives the real governed pipeline in-process* — capture → ask a question
+  that uses memory → apply a legal hold / withdraw consent / delete / run the
+  lifecycle workers → watch the audit trace and assistant behavior change live.
+- **Safe to host:** a fresh **in-memory** store per browser session — no database,
+  no auth, no secrets, no network (stub LLM + embeddings), no real user data. It
+  drives the same `services/api` governance code the product uses, so behavior is
+  faithful, not a reimplementation.
+- The v0.9 [results dashboard](apps/results-dashboard) remains the read-only
+  **evidence** view; the playground is the public **entry point**.
+- Run it: `cd apps/playground && pip install -r requirements.txt &&
+  streamlit run streamlit_app.py`. Screenshots/GIF + the hosted demo link are the
+  operator-run final step (see [docs/images/playground/](docs/images/playground/)).
+  See [docs/playground.md](docs/playground.md).
+
 ## Roadmap
 
 - **v0.7** — physical deletion compaction + vector purge verification ✅
@@ -424,12 +442,13 @@ MemoryOps integrates it via an adapter and does not vendor its source.
 - **v0.9** — public results dashboard + evidence explorer ✅
 - **v0.10** — retention policies + legal hold + consent-aware memory ✅
 - **v0.11** — assistant SDK + integration examples ✅
-- **v0.12** — hosted demo + public screenshots
+- **v0.12** — interactive playground + hosted demo + public screenshots ✅
 - **v1.0** — production-ready governed memory runtime
 
-## What remains (v0.12+)
+## What remains (v1.0)
 
-- Hosted demo + screenshots (v0.12); production-ready runtime (v1.0).
+- Production-ready runtime: stable API + SDK contracts, deployment guide, README
+  polish, the hosted demo link + recorded GIF wired into the hero.
 - Consent *capture* at the UI/SDK edge; cross-tenant retention scheduling.
 - Hard purge / crypto-shred and pgvector index reclamation (beyond v0.7's
   auditable compaction).
@@ -475,6 +494,7 @@ system with release discipline, review gates, and operational safety. Overview:
 - [docs/governance.md](docs/governance.md) — lifecycle, approvals, audit, retention.
 - [docs/rollout.md](docs/rollout.md) — phased delivery and production roadmap.
 - [docs/results-dashboard.md](docs/results-dashboard.md) — public read-only results/evidence dashboard (v0.9; demo-only, not production UI).
+- [docs/playground.md](docs/playground.md) — interactive public playground + hosted demo (v0.12; demo-only, in-memory, not production UI).
 - [docs/assistant-sdk.md](docs/assistant-sdk.md) — Python SDK + integration examples (v0.11).
 - [docs/demo-script.md](docs/demo-script.md) — the 6-step demo.
 - [infra/adr/](infra/adr/) — storage, retrieval, policy broker, observability, deletion ADRs.

--- a/apps/playground/Dockerfile
+++ b/apps/playground/Dockerfile
@@ -1,0 +1,28 @@
+# MemoryOps AI — Playground (v0.12). Optional public demo surface.
+#
+# IMPORTANT: build from the REPOSITORY ROOT, because the playground drives the
+# real governed pipeline from services/api in-process:
+#
+#     docker build -f apps/playground/Dockerfile -t memoryops-playground .
+#     docker run -p 8501:8501 memoryops-playground
+#
+# No database, no secrets: MEMORYOPS_STORAGE defaults to the in-memory store and
+# the LLM/embeddings default to deterministic offline stubs.
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Backend (real governed pipeline) + the playground UI.
+COPY services/api /app/services/api
+COPY apps/playground /app/apps/playground
+
+RUN pip install --no-cache-dir -r /app/apps/playground/requirements.txt
+
+ENV MEMORYOPS_STORAGE=memory \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8501
+WORKDIR /app/apps/playground
+
+# $PORT is honored when set (e.g. Railway); defaults to 8501 locally.
+CMD ["sh", "-c", "streamlit run streamlit_app.py --server.port ${PORT:-8501} --server.address 0.0.0.0 --server.headless true"]

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -1,0 +1,69 @@
+# MemoryOps AI — Playground (v0.12)
+
+An **interactive public demo** of MemoryOps AI. Unlike the read-only v0.9 results
+dashboard, the playground lets you *drive* the governed memory lifecycle and watch
+governance change the assistant's behavior live — with a full audit trail.
+
+> **Demo-only, safe to host.** The playground runs the **real** governed pipeline
+> from [`services/api`](../../services/api) **in process**, against a **fresh
+> in-memory store created per browser session**. There is no database, no auth, no
+> secrets, and no network (stub LLM + stub embeddings). Nothing is persisted and
+> there is no real user data. The Next.js app (`apps/web`) remains the official
+> product UI.
+
+## What you can do
+
+1. **Capture & ask** — type a memory, then ask a question that should use it. See
+   the policy broker's per-message decisions (`SAVE` / `DROP_LOW_UTILITY` /
+   `BLOCK`) and which memories were retrieved to answer.
+2. **Memories & governance** — apply a **legal hold** (deletion is then refused,
+   fail-closed, like the API's HTTP 409), **pin**, **withdraw consent**, or
+   **delete**. Run the **lifecycle workers** (decay · archive · retention ·
+   deletion verification · compaction) over your session.
+3. **Retention preview** — read-only preview of what the retention worker *would*
+   do under a policy pack. Deletes nothing.
+4. **Audit trace** — every governed action appends a content-free audit event.
+
+## Run it
+
+### Locally
+```bash
+cd apps/playground
+pip install -r requirements.txt      # pulls services/api deps + streamlit
+streamlit run streamlit_app.py       # http://localhost:8501
+```
+No environment variables required (`MEMORYOPS_STORAGE` defaults to `memory`).
+
+### Streamlit Community Cloud (simplest hosting)
+Point it at this repo with **main file path** `apps/playground/streamlit_app.py`.
+It installs `apps/playground/requirements.txt` and the app adds `services/api` to
+`sys.path` automatically. No secrets to configure.
+
+### Docker / Railway (optional)
+Build from the **repository root** (the image needs `services/api`):
+```bash
+docker build -f apps/playground/Dockerfile -t memoryops-playground .
+docker run -p 8501:8501 memoryops-playground
+```
+`apps/playground/railway.toml` describes an *optional* Railway demo service (not
+one of the five core services). See [docs/playground.md](../../docs/playground.md).
+
+## How it stays safe
+
+- **In-memory only** — each session builds its own `InMemoryRepository`; resetting
+  or reconnecting starts clean. No Postgres, no shared state across sessions.
+- **No secrets / no network** — LLM and embedding providers default to
+  deterministic offline stubs; no API keys are read.
+- **Server-authoritative** — the playground does not reimplement governance; it
+  calls the same gateway / policy broker / governance / retention code the product
+  uses. What you see is how MemoryOps actually behaves.
+
+## Files
+```text
+apps/playground/
+  streamlit_app.py     # entrypoint (named to avoid colliding with the `app` package)
+  requirements.txt     # -r services/api/requirements.txt + streamlit
+  Dockerfile           # optional; build from repo root
+  railway.toml         # optional Railway demo service
+  README.md
+```

--- a/apps/playground/railway.toml
+++ b/apps/playground/railway.toml
@@ -1,0 +1,16 @@
+# Railway service config for the OPTIONAL MemoryOps AI Playground demo.
+#
+# This is NOT one of the five core services (web/api/worker/Postgres/Redis). It is
+# an optional public demo surface, like the v0.9 results dashboard. It needs no
+# database and no secrets (in-memory store + offline stubs).
+#
+# Build context must be the repository ROOT so services/api is available to the
+# in-process pipeline — set the Railway service "Root Directory" to the repo root
+# and the Dockerfile path to apps/playground/Dockerfile.
+[build]
+builder = "dockerfile"
+dockerfilePath = "apps/playground/Dockerfile"
+
+[deploy]
+startCommand = "streamlit run streamlit_app.py --server.port $PORT --server.address 0.0.0.0 --server.headless true"
+restartPolicyType = "on_failure"

--- a/apps/playground/requirements.txt
+++ b/apps/playground/requirements.txt
@@ -1,0 +1,5 @@
+# The playground drives the real governed pipeline from services/api in-process,
+# so it needs the API's runtime deps plus Streamlit. No DB / no secrets required
+# (MEMORYOPS_STORAGE defaults to the in-memory store).
+-r ../../services/api/requirements.txt
+streamlit>=1.36,<2

--- a/apps/playground/streamlit_app.py
+++ b/apps/playground/streamlit_app.py
@@ -1,0 +1,290 @@
+"""MemoryOps AI — Public Playground (v0.12).
+
+An INTERACTIVE public demo that runs the *real* governed memory pipeline in
+process, against a fresh **in-memory** store created per browser session. Visitors
+can capture a memory, ask a question that uses it, then govern it — apply a legal
+hold, withdraw consent, run the lifecycle workers — and watch the audit trace and
+assistant behavior change live.
+
+Safe to host:
+  * No database, no secrets, no auth, no network calls (stub LLM + stub embeddings).
+  * State is an in-memory repository held in ``st.session_state`` — it is
+    per-session and ephemeral; nothing is persisted and there is no real user data.
+  * The server-side governance is the *real* code from ``services/api`` (gateway,
+    policy broker, governance, retention) — the playground does not reimplement it,
+    it drives it. So what you see is how MemoryOps actually behaves.
+
+This is a demo/evidence surface, like the v0.9 results dashboard — NOT the
+production product. The Next.js app (``apps/web``) remains the official UI.
+
+Run locally:
+    cd apps/playground
+    pip install -r requirements.txt
+    streamlit run app.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import streamlit as st
+
+# The playground drives the real governed pipeline from services/api in-process.
+os.environ.setdefault("MEMORYOPS_STORAGE", "memory")
+_API_DIR = Path(__file__).resolve().parents[2] / "services" / "api"
+if _API_DIR.is_dir() and str(_API_DIR) not in sys.path:
+    sys.path.insert(0, str(_API_DIR))
+
+from app.db import governance as gov  # noqa: E402
+from app.db.memory_repo import InMemoryRepository  # noqa: E402
+from app.schemas.memory import ChatRequest  # noqa: E402
+from app.services.audit import AuditService  # noqa: E402
+from app.services.gateway import Gateway  # noqa: E402
+from app.services.retention import available_policies, evaluate, get_policy  # noqa: E402
+from app.workers.runner import run_jobs  # noqa: E402
+
+TENANT = "playground"
+SEED_MESSAGES = [
+    "Remember that I prefer metric units and dark mode.",
+    "Remember my project is named Atlas and I deploy on Railway.",
+    "By the way, my favorite color is teal.",
+]
+
+
+# ── per-session governed pipeline ────────────────────────────────────────────
+def _session():
+    """Return (repo, gateway, audit, user_id), creating a fresh stack per session."""
+    if "repo" not in st.session_state:
+        repo = InMemoryRepository()
+        st.session_state.repo = repo
+        st.session_state.gateway = Gateway(repo)
+        st.session_state.audit = AuditService(repo)
+        st.session_state.user_id = f"visitor_{uuid.uuid4().hex[:8]}"
+        st.session_state.trace_n = 0
+        st.session_state.last_chat = None
+    return (
+        st.session_state.repo,
+        st.session_state.gateway,
+        st.session_state.audit,
+        st.session_state.user_id,
+    )
+
+
+def _reset() -> None:
+    for key in ("repo", "gateway", "audit", "user_id", "trace_n", "last_chat"):
+        st.session_state.pop(key, None)
+
+
+def _trace() -> str:
+    st.session_state.trace_n += 1
+    return f"pg-{st.session_state.trace_n:04d}"
+
+
+def _chat(message: str, *, temporary: bool = False):
+    _, gateway, _, user_id = _session()
+    req = ChatRequest(tenant_id=TENANT, user_id=user_id, message=message, temporary_chat=temporary)
+    return gateway.handle_chat(req, trace_id=_trace())
+
+
+def _active(repo, user_id):
+    return repo.list_memories(TENANT, user_id, status="active")
+
+
+def _badges(memory) -> str:
+    out = []
+    if gov.is_legal_hold(memory):
+        out.append("🔒 legal hold")
+    if gov.is_pinned(memory):
+        out.append("📌 pinned")
+    if gov.is_protected(memory):
+        out.append("🛡 protected")
+    consent = gov.consent_status(memory)
+    if consent != gov.ConsentStatus.granted:
+        out.append(f"⚠ consent:{consent}")
+    return "  ".join(out)
+
+
+# ── pages ─────────────────────────────────────────────────────────────────────
+def page_capture() -> None:
+    st.subheader("1 · Capture & ask")
+    st.caption("Type something to remember, then ask a question that should use it. "
+               "Every message runs through extraction + the policy broker.")
+
+    with st.form("capture", clear_on_submit=True):
+        msg = st.text_input("Message", placeholder="Remember that I prefer metric units…")
+        temp = st.checkbox("Temporary chat (reads & writes nothing — invariant #6)")
+        sent = st.form_submit_button("Send")
+    if sent and msg.strip():
+        st.session_state.last_chat = _chat(msg.strip(), temporary=temp)
+
+    result = st.session_state.get("last_chat")
+    if result is None:
+        return
+    st.markdown(f"**Assistant:** {result.assistant_message}")
+    st.caption(f"retrieval_mode = `{result.retrieval_mode}` · trace = `{result.trace_id}`"
+               + ("  ·  temporary (nothing stored)" if result.temporary_chat else ""))
+    if result.candidate_memories:
+        st.markdown("**Policy decisions on this message:**")
+        st.dataframe(
+            [{"content": c.content, "decision": c.decision, "reason": c.reason}
+             for c in result.candidate_memories],
+            use_container_width=True, hide_index=True,
+        )
+    if result.used_memories:
+        st.markdown("**Memories used to answer:**")
+        st.dataframe(
+            [{"content": u.content, "score": round(u.score, 3)} for u in result.used_memories],
+            use_container_width=True, hide_index=True,
+        )
+
+
+def page_memories() -> None:
+    repo, _, audit, user_id = _session()
+    st.subheader("2 · Memories & governance")
+    st.caption("Apply a legal hold, pin/protect, withdraw consent, or delete. "
+               "Legal hold is fail-closed: deletion is refused until released.")
+
+    memories = _active(repo, user_id)
+    if not memories:
+        st.info("No active memories yet. Capture some on the **Capture & ask** tab "
+                "or click **Seed demo memories** in the sidebar.")
+        return
+
+    for m in memories:
+        with st.container(border=True):
+            st.markdown(f"**{m.content}**")
+            meta = f"`{m.memory_type}` · importance {m.importance} · {m.sensitivity}"
+            badges = _badges(m)
+            st.caption(meta + ("  —  " + badges if badges else ""))
+            c1, c2, c3, c4 = st.columns(4)
+            held = gov.is_legal_hold(m)
+            if c1.button("Release hold" if held else "Legal hold", key=f"hold-{m.id}"):
+                gov.set_legal_hold(m, on=not held, reason="playground demo")
+                repo.update_memory(m)
+                audit.record(tenant_id=TENANT, user_id=user_id, memory_id=m.id,
+                             action="memory_legal_hold_set" if not held else
+                             "memory_legal_hold_released", reason="playground", trace_id=_trace())
+                st.rerun()
+            if c2.button("Toggle pin", key=f"pin-{m.id}"):
+                gov.set_pinned(m, on=not gov.is_pinned(m))
+                repo.update_memory(m)
+                st.rerun()
+            if c3.button("Withdraw consent", key=f"consent-{m.id}"):
+                gov.set_consent(m, status=gov.ConsentStatus.withdrawn)
+                repo.update_memory(m)
+                audit.record(tenant_id=TENANT, user_id=user_id, memory_id=m.id,
+                             action="memory_consent_updated", reason="consent withdrawn",
+                             trace_id=_trace())
+                st.rerun()
+            if c4.button("Delete", key=f"del-{m.id}"):
+                if gov.is_legal_hold(m):
+                    audit.record(tenant_id=TENANT, user_id=user_id, memory_id=m.id,
+                                 action="memory_legal_hold_delete_blocked",
+                                 reason="delete refused; memory under legal hold",
+                                 trace_id=_trace())
+                    st.error("Delete blocked — memory is under legal hold (HTTP 409). "
+                             "Release the hold first.")
+                else:
+                    repo.soft_delete(TENANT, user_id, m.id)
+                    audit.record(tenant_id=TENANT, user_id=user_id, memory_id=m.id,
+                                 action="memory_deleted",
+                                 reason="soft-deleted; excluded from all future retrieval",
+                                 trace_id=_trace())
+                    st.rerun()
+
+    st.divider()
+    st.markdown("**Run the lifecycle workers** (decay · archive · retention · "
+                "deletion verification · compaction) over this session:")
+    if st.button("▶ Run lifecycle workers"):
+        report = run_jobs(repo, tenant_id=TENANT, user_id=user_id, jobs=["all"],
+                          trace_id=_trace())
+        st.success(f"Ran {len(report.results)} jobs · "
+                   f"scanned={report.scanned_count} changed={report.changed_count}")
+        st.dataframe(
+            [{"job": r.job, "status": r.status, "scanned": r.scanned_count,
+              "changed": r.changed_count, "skipped": r.skipped_count} for r in report.results],
+            use_container_width=True, hide_index=True,
+        )
+
+
+def page_retention() -> None:
+    repo, _, _, user_id = _session()
+    st.subheader("3 · Retention preview")
+    st.caption("Read-only preview of what the retention worker *would* do under a "
+               "policy pack. Deletes nothing.")
+    names = [p.name for p in available_policies()]
+    policy = get_policy(st.selectbox("Policy pack", names))
+    rows = _active(repo, user_id)
+    if not rows:
+        st.info("No active memories to evaluate.")
+        return
+    decisions = [evaluate(m, policy=policy) for m in rows]
+    st.dataframe(
+        [{"memory": d.memory_id[:8], "outcome": d.outcome.value,
+          "eligible_for_deletion": d.eligible_for_deletion,
+          "blocked_by": ", ".join(d.blocked_by) or "—", "reason": d.reason}
+         for d in decisions],
+        use_container_width=True, hide_index=True,
+    )
+
+
+def page_audit() -> None:
+    repo, _, _, user_id = _session()
+    st.subheader("4 · Audit trace")
+    st.caption("Every governed action appends a content-free audit event (invariant #7).")
+    events = repo.list_audit(TENANT, user_id, limit=200)
+    if not events:
+        st.info("No audit events yet — interact on the other tabs.")
+        return
+    st.dataframe(
+        [{"action": e.action, "reason": e.reason, "memory": (e.memory_id or "")[:8]}
+         for e in events],
+        use_container_width=True, hide_index=True,
+    )
+
+
+# ── shell ───────────────────────────────────────────────────────────────────
+def main() -> None:
+    st.set_page_config(page_title="MemoryOps AI — Playground", page_icon="🧠", layout="wide")
+    repo, _, _, user_id = _session()
+
+    st.sidebar.title("🧠 MemoryOps Playground")
+    st.sidebar.caption("Interactive public demo (v0.12) — runs the real governed "
+                       "pipeline against a fresh in-memory store, per session.")
+    st.sidebar.markdown(f"**Session scope:** `{TENANT} / {user_id}`")
+    st.sidebar.metric("Active memories", len(_active(repo, user_id)))
+    if st.sidebar.button("🌱 Seed demo memories"):
+        for msg in SEED_MESSAGES:
+            _chat(msg)
+        st.rerun()
+    if st.sidebar.button("♻ Reset session"):
+        _reset()
+        st.rerun()
+    st.sidebar.divider()
+    st.sidebar.caption(
+        "Demo-only · in-memory · ephemeral · no DB · no secrets · no real user data.\n\n"
+        "The Next.js app (`apps/web`) is the official product UI; the v0.9 results "
+        "dashboard is the static evidence view."
+    )
+
+    st.title("MemoryOps AI — Playground")
+    st.caption("Capture → ask → govern → audit. Watch governance change assistant "
+               "behavior live, with a full audit trail.")
+    tab1, tab2, tab3, tab4 = st.tabs(
+        ["Capture & ask", "Memories & governance", "Retention preview", "Audit trace"]
+    )
+    with tab1:
+        page_capture()
+    with tab2:
+        page_memories()
+    with tab3:
+        page_retention()
+    with tab4:
+        page_audit()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/agent/HANDOFF.md
+++ b/docs/agent/HANDOFF.md
@@ -1,0 +1,102 @@
+# Agent Handoff — MemoryOps AI
+
+_Last updated: 2026-06-22 (end of v0.12 build; PR #11 open)._
+
+## Current state (verified)
+
+- **Branch:** `feat/v0.12-hosted-demo` (working tree clean except this untracked HANDOFF).
+- **HEAD:** `18f2a5b feat: v0.12 interactive playground + hosted demo`.
+- **Stacking:** `feat/v0.12-hosted-demo` is **stacked on `feat/v0.11-assistant-sdk`**
+  (branched from the v0.11 tip, NOT from main), because v0.11 (PR #10) is not merged
+  yet. This avoids rollout/README doc divergence. Until #10 merges, PR #11's diff
+  includes the v0.11 commit; it reduces to just v0.12 once #10 lands.
+- **Open PRs:**
+  - [#10](https://github.com/patibandlavenkatamanideep/memoryops-ai/pull/10) — v0.11 SDK → main, **OPEN**.
+  - [#11](https://github.com/patibandlavenkatamanideep/memoryops-ai/pull/11) — v0.12 playground → main, **OPEN** (this work).
+- **main:** `0036da4` (v0.10). **Tags:** through `v0.10`; v0.11/v0.12 not tagged.
+
+### Milestone status
+- v0.9 dashboard, v0.10 retention — merged + tagged.
+- v0.11 SDK — **PR #10 open** (not merged/tagged).
+- v0.12 interactive playground + hosted demo — **PR #11 open** (not merged/tagged).
+- v1.0 — remaining.
+
+## v0.12 — what was built (PR #11, commit 18f2a5b)
+
+Interactive public **Playground** that drives the **real** governed pipeline from
+`services/api` **in-process**, against a fresh **in-memory** store per browser
+session. Additive only — no `services/api` changes; not the production UI.
+
+### Files (10 files)
+- `apps/playground/streamlit_app.py` — 4 tabs (Capture & ask · Memories &
+  governance · Retention preview · Audit trace). **Entrypoint named
+  `streamlit_app.py` to avoid shadowing the backend `app` package** (see Failures).
+- `apps/playground/requirements.txt` (`-r ../../services/api/requirements.txt` +
+  streamlit), `Dockerfile` (build from repo ROOT — needs services/api),
+  `railway.toml` (optional demo service, not a core service), `README.md`.
+- `docs/playground.md` (architecture + demo-safety + demo-only vs production),
+  `docs/images/playground/README.md` (screenshot/GIF capture guide).
+- Modified: `README.md` (layout + "v0.12" section + roadmap + docs link),
+  `docs/rollout.md` (Phase 9 + roadmap), `CLAUDE.md` (layout entry).
+
+### Design
+- Per Streamlit session: fresh `InMemoryRepository` + `Gateway` + `AuditService`
+  in `st.session_state`, scope `playground/visitor_<rand>`. No DB, no secrets, no
+  network (stub LLM + embeddings). Drives the real `gateway.handle_chat`,
+  `db.governance` (legal hold / pin / consent), `services.retention.evaluate`,
+  and `workers.runner.run_jobs` — so behavior is faithful, not reimplemented.
+
+## Commands run (and results)
+- `services/api/.venv/bin/python -m pytest -q` (in services/api) → **249 passed, 1
+  skipped** (unchanged; no backend code touched).
+- `services/api/.venv/bin/ruff check app ../../apps/playground` → **All checks passed**.
+- Playground smoke (stub Streamlit, real in-process pipeline): seed → policy
+  decisions (`SAVE`/`DROP_LOW_UTILITY`) → legal-hold blocks delete → retention
+  outcome `held` → all 7 lifecycle workers `ok=True` → 26 audit events → hybrid
+  retrieval used seeded memories. ✅
+- `py_compile streamlit_app.py` → OK.
+- PR gate `--base feat/v0.11-assistant-sdk --head HEAD` and `--base main --head HEAD`
+  → **PASS, 0 rules armed** (additive).
+- `git push -u origin feat/v0.12-hosted-demo`; `gh pr create` → PR #11.
+
+## Failures encountered (and fixes)
+1. **Name collision:** the entrypoint `app.py` shadowed the `services/api` **`app`
+   package**, so `from app.db import ...` resolved to the playground module →
+   `ModuleNotFoundError: No module named 'app.db'`. **Fix:** rename entrypoint to
+   `streamlit_app.py` (also Streamlit Cloud's default). Smoke then passed.
+2. **ruff** flagged an unused `Status` import → removed via `ruff --fix`.
+3. Earlier this session: a `mv`/`git mv` Bash call was blocked by a transient
+   classifier outage; re-ran the rename successfully after.
+
+No outstanding failures. Everything green.
+
+## Key decisions
+- **Stack v0.12 on v0.11** (not branch from main) to keep rollout/README docs
+  consistent and avoid merge churn; PR #11 targets main and self-reduces post-#10.
+- **Drive the real pipeline in-process** (not via the SDK/HTTP) for true
+  per-session isolation and to showcase actual governance behavior live.
+- **Hostable without infra** — Streamlit Community Cloud (`streamlit_app.py`) or an
+  optional Railway demo service; no Vercel, not one of the five core services.
+- Screenshots/GIF + hosted link deferred to operator (need a live browser/host);
+  shipped a capture guide instead of binary placeholders.
+- **Did not** tag/merge/release.
+
+## Next 3 actions
+1. **Land the stack in order:** merge **PR #10 (v0.11)** to main + tag `v0.11`;
+   then PR #11's base auto-updates and its diff reduces to just v0.12 — merge
+   **PR #11**, tag `v0.12`. Run `git fetch --tags` locally afterward.
+2. **Finish v0.12 operator steps:** host the playground (Streamlit Community Cloud
+   or Railway), capture the 4 tab screenshots + demo GIF per
+   `docs/images/playground/README.md`, and wire the demo link + images into the
+   README hero.
+3. **Start v1.0 — Production-Ready Governed Memory Runtime:** stabilize API + SDK
+   contracts, complete deployment guide + security model docs, README polish,
+   known-limitations page, and fold in the hosted demo link. Branch from updated
+   `main` once #10/#11 land.
+
+## Pointers
+- Playground: `apps/playground/README.md`, `docs/playground.md`, `docs/images/playground/`.
+- Results dashboard (v0.9 evidence): `apps/results-dashboard/`, `docs/results-dashboard.md`.
+- SDK (v0.11): `packages/memoryops-sdk/README.md`, `docs/assistant-sdk.md`, `infra/adr/ADR-014-assistant-sdk.md`.
+- Roadmap/phases: `docs/rollout.md`. PR-gate: `scripts/pr_invariant_gate.py`. Invariants: `CLAUDE.md`.
+- Tooling: no `python`/`pytest` on PATH — use `services/api/.venv/bin/python` (Python 3.14).

--- a/docs/images/playground/README.md
+++ b/docs/images/playground/README.md
@@ -1,0 +1,35 @@
+# Playground screenshots — capture guide
+
+This folder holds the public screenshots + demo GIF referenced by the main
+`README.md` hero section. They are produced from a **running** playground, so they
+are an operator step (a live browser is required); this guide makes them
+reproducible.
+
+## Capture
+
+```bash
+cd apps/playground
+pip install -r requirements.txt
+streamlit run streamlit_app.py   # http://localhost:8501
+```
+
+In the app, click **🌱 Seed demo memories** in the sidebar, then capture one image
+per tab into this folder:
+
+| File | Tab | What it should show |
+|------|-----|---------------------|
+| `01-capture.png` | Capture & ask | A message + the policy decisions (`SAVE`/`DROP_LOW_UTILITY`/`BLOCK`) and the memories used to answer a follow-up question. |
+| `02-governance.png` | Memories & governance | A memory under **legal hold** with a blocked delete (the HTTP-409 message), and the lifecycle-worker run table. |
+| `03-retention.png` | Retention preview | The retention decision table with `held` / `expired` / `retain` outcomes and `blocked_by`. |
+| `04-audit.png` | Audit trace | The content-free audit-event timeline. |
+| `demo.gif` | (whole flow) | Capture → ask → legal hold → blocked delete → withdraw consent → run workers → audit. |
+
+## Recording the GIF
+
+Any screen recorder works; e.g. with `ffmpeg` + a screen capture, or a tool like
+LICEcap / Kap. Keep it under ~15s and scoped to the four-step story above.
+
+## Naming / referencing
+
+Keep the filenames above so the `README.md` image links resolve without edits.
+Images are demo-only (no real data) and safe to publish.

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -1,0 +1,108 @@
+# MemoryOps AI — Playground + Hosted Demo (v0.12)
+
+> **This is a public demo/evidence surface — not the production product.**
+> The Next.js app in [`apps/web`](../apps/web) remains the official product /
+> governance UI. The playground is interactive but **demo-scoped**: in-memory,
+> ephemeral, no database, no auth, no secrets, no real user data.
+
+## Why v0.12
+
+By v0.11 MemoryOps had the full governed runtime (capture → policy → retrieval →
+lifecycle workers → retention → legal hold → consent → deletion compaction →
+audit) plus a typed SDK. What was still missing was a way to **understand it
+without cloning the repo**.
+
+v0.12 adds two public surfaces:
+
+| Surface | Type | Lives in | Purpose |
+|---------|------|----------|---------|
+| **Playground** | Interactive | [`apps/playground/`](../apps/playground) | *Drive* the real governed lifecycle live and watch governance change behavior |
+| **Results dashboard** (v0.9) | Read-only evidence | [`apps/results-dashboard/`](../apps/results-dashboard) | Static proof: lifecycle, deletion compaction, worker runtime, audit, validation |
+
+The playground is the public **entry point**; the dashboard remains the technical
+**evidence** view.
+
+## What the playground proves (interactively)
+
+```text
+Capture → ask a question that uses memory → govern (legal hold / consent /
+delete / run workers) → watch the audit trace and assistant behavior change.
+```
+
+- **Policy-before-storage** — every message shows the broker's `SAVE` /
+  `DROP_LOW_UTILITY` / `BLOCK` decisions before anything is stored.
+- **Legal hold (fail-closed)** — deleting a held memory is refused (the same
+  HTTP 409 the API returns); release the hold to proceed.
+- **Consent-aware** — withdrawing consent flips the retention outcome to
+  eligible-for-deletion on the next worker run.
+- **Lifecycle workers** — run decay / archive / retention / deletion verification
+  / compaction over your session and see the per-job counts.
+- **Auditability** — every governed action appends a content-free audit event.
+
+## Architecture
+
+The playground does **not** reimplement governance. It imports and drives the
+exact `services/api` code the product uses, against a per-session in-memory store.
+
+```mermaid
+flowchart LR
+    U["Visitor (browser)"] --> PG["Streamlit Playground<br/>apps/playground"]
+    PG -->|in-process call| GW["Gateway"]
+    GW --> EX["Extractor"] --> PB["Policy Broker"] --> WS["Write Service"]
+    WS --> REPO[("InMemoryRepository<br/>(per session, ephemeral)")]
+    GW --> RT["Retriever → Ranker → Composer"] --> REPO
+    PG -->|in-process call| GOV["governance<br/>(legal hold / pin / consent)"]
+    PG -->|in-process call| RET["retention.evaluate"]
+    PG -->|in-process call| WK["lifecycle workers"]
+    GOV --> REPO
+    WK --> REPO
+    GW --> AUD[["Audit log (append-only)"]]
+    WK --> AUD
+    REPO -. no DB / no secrets / no network .-> X[" "]
+```
+
+## Demo-safety model
+
+| Concern | How it's handled |
+|---------|------------------|
+| Real user data | None. State is a fresh `InMemoryRepository` per browser session. |
+| Persistence | None. Nothing is written to disk; a reset/reconnect starts clean. |
+| Secrets / keys | None read. LLM + embeddings default to deterministic offline **stubs**. |
+| Database | None. `MEMORYOPS_STORAGE=memory` (the default). |
+| Auth | None needed — there is nothing sensitive to protect. |
+| Cross-session leakage | Avoided — each session has its own scope `playground/visitor_<rand>`. |
+| Production blast radius | Zero — the playground is isolated tooling, not on the chat request path or any deploy of the five core services. |
+
+## Demo-only vs production-capable
+
+- **Demo-only here:** in-memory store, ephemeral sessions, seeded sample data, a
+  single anonymous scope per session, stub providers.
+- **Production-capable in the real product:** Postgres + pgvector with enforced
+  RLS, the worker runtime (leases/retries/dead-letter), provider LLM/embedding
+  adapters, the governance UI, and the typed SDK — all already shipped in
+  v0.3–v0.11. The playground is a *window* onto that behavior, not a reduced
+  reimplementation of it.
+
+## Honest limitations
+
+- The playground is **demo-only** and **not** the production UI.
+- In-memory + ephemeral by design — not a durable multi-user service.
+- Inherits the project's standing honesty: deletion compaction is **not**
+  crypto-shred and makes no physical disk/page-erasure guarantee.
+
+## Screenshots
+
+Static images live in [`docs/images/playground/`](images/playground/) and are
+referenced from the main `README.md` hero section. Because capturing them needs a
+live browser against a running app, the repo ships a capture guide rather than
+binary placeholders — see
+[`docs/images/playground/README.md`](images/playground/README.md). Hosting the
+public demo and recording the GIF are the final, operator-run steps of v0.12.
+
+## Running
+
+See [`apps/playground/README.md`](../apps/playground/README.md). TL;DR:
+
+```bash
+cd apps/playground && pip install -r requirements.txt && streamlit run streamlit_app.py
+```

--- a/docs/rollout.md
+++ b/docs/rollout.md
@@ -113,6 +113,20 @@ Additive only — no `services/api` changes. See
 [assistant-sdk.md](assistant-sdk.md),
 [ADR-014](../infra/adr/ADR-014-assistant-sdk.md).
 
+## Phase 9 — Interactive playground + hosted demo ✅ (v0.12)
+An interactive public **Playground** ([`apps/playground/`](../apps/playground))
+that *drives the real governed pipeline in-process* — capture → ask → govern
+(legal hold / consent / delete / run lifecycle workers) → watch the audit trace
+and assistant behavior change live. **Safe to host:** a fresh in-memory store per
+browser session — no database, no auth, no secrets, no network (stub LLM +
+embeddings), no real user data; it calls the same `services/api` governance code
+the product uses (not a reimplementation). Additive only — no `services/api`
+changes. The v0.9 results dashboard stays the read-only **evidence** view; the
+playground is the public **entry point**. Hostable on Streamlit Community Cloud or
+as an optional Railway demo service (not one of the five core services; no Vercel).
+Screenshots/GIF + the hosted link are the operator-run final step. See
+[playground.md](playground.md), [images/playground/](images/playground/).
+
 ## Public roadmap
 
 | Version | Scope | Status |
@@ -122,8 +136,8 @@ Additive only — no `services/api` changes. See
 | v0.9 | Public results dashboard + evidence explorer | ✅ Done |
 | v0.10 | Retention policies + legal hold + consent-aware memory | ✅ Done |
 | v0.11 | Assistant SDK + integration examples | ✅ Done |
-| v0.12 | Hosted demo + public screenshots | ⏳ Next |
-| v1.0 | Production-ready governed memory runtime | ⏳ Planned |
+| v0.12 | Interactive playground + hosted demo + public screenshots | ✅ Done |
+| v1.0 | Production-ready governed memory runtime | ⏳ Next |
 
 ## Production roadmap (beyond hackathon)
 


### PR DESCRIPTION
## v0.12 — Interactive Playground + Hosted Demo

Adds an interactive public **Playground** ([`apps/playground/`](apps/playground)) that *drives the real governed pipeline in-process* so people can understand MemoryOps without cloning: **capture → ask a question that uses memory → govern (legal hold / withdraw consent / delete / run the lifecycle workers) → watch the audit trace and assistant behavior change live.**

### Safe to host
A fresh **in-memory** store per browser session — no database, no auth, no secrets, no network (stub LLM + embeddings), no real user data. It calls the same `services/api` governance code the product uses (gateway, policy broker, governance, retention, workers), so behavior is faithful, **not a reimplementation**. **Additive only — no `services/api` changes.**

### What landed
- `apps/playground/streamlit_app.py` — 4 tabs: Capture & ask · Memories & governance · Retention preview · Audit trace. (Entrypoint named `streamlit_app.py` to avoid shadowing the backend `app` package.)
- Packaging: `requirements.txt` (`-r services/api/requirements.txt` + streamlit), `Dockerfile` (build from repo root), `railway.toml` for an **optional** demo service (not one of the five core services; no Vercel). Also hostable on Streamlit Community Cloud.
- Docs: `docs/playground.md` (architecture + demo-safety + demo-only vs production), `docs/images/playground/` screenshot/GIF capture guide, README hero + section, `docs/rollout.md` Phase 9 + roadmap, `CLAUDE.md` layout entry.
- The v0.9 results dashboard remains the read-only **evidence** view; the playground is the public **entry point**.

### Validation
- Backend: **249 passed, 1 skipped** (unchanged — no backend code touched).
- `ruff check` (api + playground): **clean**.
- Playground smoke (real in-process pipeline): seed → policy decisions → legal-hold blocks delete → retention `held` → all 7 lifecycle workers `ok` → audit trail → hybrid retrieval. ✅
- PR invariant gate: **PASS, 0 rules armed** (additive).

### Notes
- **Stacked on `feat/v0.11-assistant-sdk`** (PR #10, still open). Until that merges, this PR's diff includes the v0.11 commit; it reduces to just v0.12 once #10 lands.
- Hosting the public demo + recording the screenshots/GIF are the operator-run final steps (see `docs/images/playground/`).
- Not tagged, not merged.