### PR TITLE
release: v1.0 production-ready governed memory runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,83 @@
+# Changelog — MemoryOps AI
+
+All notable releases. Git tags + GitHub Releases are the source of truth; this
+file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
+
+## v1.0 — Production-Ready Governed Memory Runtime
+The stable public release. The governed memory lifecycle (Capture → Evaluate →
+Store → Retrieve → Rank → Compose → Update → Forget → Audit), its seven enforced
+invariants, and the security/governance/reliability/observability/evaluation
+planes are implemented, tested, and operable.
+
+- **Stable contracts** — the public HTTP API and Python SDK are declared stable
+  under a `1.x` additive-compatibility promise ([docs/api-stability.md](docs/api-stability.md)).
+  Package versions bumped to `1.0.0`.
+- **Release-readiness docs** — consolidated [known limitations](docs/limitations.md),
+  a [production-readiness](docs/production-readiness.md) map (invariant → where
+  enforced; production-capable vs demo-only), and this changelog.
+- No behavior changes vs v0.12 — v1.0 is stabilization, documentation, and the
+  stability guarantee.
+
+## v0.12 — Interactive Playground + Hosted Demo
+Interactive public Playground (`apps/playground`) that drives the real governed
+pipeline in-process against a fresh in-memory store per session — capture → ask →
+govern (legal hold / consent / delete / run workers) → audit trace. Demo-only;
+safe to host (no DB/secrets/real data). See [docs/playground.md](docs/playground.md).
+
+## v0.11 — Assistant SDK + Integration Examples
+Typed Python SDK (`packages/memoryops-sdk`) over the governed HTTP API with
+tenant/user scope injection, typed errors, and `.raw`-preserving models. Examples:
+quickstart, FastAPI, RAG, agent memory. Additive only.
+
+## v0.10 — Retention Policies + Legal Hold + Consent-Aware Memory
+Retention policy packs (sensitivity → window) driving an off-by-default retention
+worker; legal hold as a fail-closed preservation override (API delete → 409);
+consent withdrawal/expiry drives deletion eligibility. Governance state is
+metadata-driven (migration `007`). See [docs/retention-policies.md](docs/retention-policies.md).
+
+## v0.9 — Public Results Dashboard + Evidence Explorer
+Read-only Streamlit evidence dashboard (`apps/results-dashboard`) — lifecycle,
+deletion-compaction proof, worker runtime, audit, validation, limitations.
+Static demo data; demo-only.
+
+## v0.8 — Worker Runtime + Scheduled Lifecycle Orchestration
+Lifecycle jobs made operable: leases (no duplicate runs), retry/backoff,
+dead-letter, persisted run history, `GET /healthz/workers`. Migration `006`.
+
+## v0.7 — Deletion Compaction + Vector Purge Verification
+Clears soft-deleted content + vector material after a retention window, preserves
+the governance tombstone, and verifies the purge fail-closed. Not crypto-shred.
+
+## v0.6 — Background Memory Lifecycle Workers
+Decay, archive, deletion verification, conflict scan, proposal-only reflection —
+tenant-scoped, idempotent, retry-safe, audited; off the chat path.
+
+## v0.5 — Governance UI + Memory Control Plane
+Next.js memory control plane: memories, governance queue, audit viewer,
+per-memory provenance; additive read routes. Official product UI.
+
+## v0.4 — Provider LLM Adapters + Structured Memory Intelligence
+Provider-neutral LLM layer (stub default; optional OpenAI/Anthropic/Gemini),
+schema-validated structured extraction + conflict detection. LLM output advisory.
+
+## v0.3.2 — Railway-Only Deployment Alignment
+One Railway project, five services; no Vercel.
+
+## v0.3.1 — Loop Engineering
+Memory workflows modeled as Observe → Decide → Act → Verify → Audit → Learn loops;
+`/api/loops` timelines.
+
+## v0.3 — pgvector Retrieval + RLS / Tenant Enforcement
+pgvector candidate search; Postgres RLS enforced (`FORCE` + tenant policy).
+
+## v0.2.1 — Context Compression
+Optional headroom context compression at the LLM boundary; default no-op, runs
+after governance, never before the policy broker.
+
+## v0.2 — Agentic Governance + Hermes Operator Layer
+Operator/developer skills, agentic-swe-kit phase gates, and the PR Invariant
+Evidence Gate around the core.
+
+## v0.1 — Governed Memory Path
+The write/read path: extractor → policy broker → write service → typed store →
+audit; retriever → ranker → composer. The seven invariants land.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,12 @@ MemoryOps AI is a governed memory lifecycle system for AI assistants — not a c
 The lifecycle is: **Capture → Evaluate → Store → Retrieve → Rank → Compose → Update → Forget → Audit**,
 wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
 
+> **v1.0 (stable).** The public HTTP API and Python SDK follow a `1.x`
+> additive-compatibility promise — existing endpoints/methods keep their shape,
+> responses only gain fields. A breaking change to that surface needs a MAJOR bump
+> + deprecation window. See `docs/api-stability.md`, `docs/production-readiness.md`,
+> `docs/limitations.md`, and `CHANGELOG.md`.
+
 ## Non-negotiable invariants (enforced in code + tests)
 
 1. Tenant isolation — every memory query filters by `tenant_id` + `user_id`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # MemoryOps AI
 
+> **v1.0 — production-ready governed memory runtime.** The public HTTP API and
+> Python SDK are **stable** under a `1.x` additive-compatibility promise
+> ([docs/api-stability.md](docs/api-stability.md)). See the
+> [CHANGELOG](CHANGELOG.md), [production-readiness](docs/production-readiness.md),
+> and [known limitations](docs/limitations.md).
+
 MemoryOps AI is an enterprise-shaped, loop-engineered memory governance layer for AI assistants.
 It implements a ChatGPT-style memory lifecycle with capture, policy evaluation, typed storage,
 hybrid retrieval, controlled forgetting, auditability, and tenant isolation.
@@ -435,6 +441,17 @@ MemoryOps integrates it via an adapter and does not vendor its source.
   operator-run final step (see [docs/images/playground/](docs/images/playground/)).
   See [docs/playground.md](docs/playground.md).
 
+## What works as of v1.0 (production-ready governed memory runtime)
+
+- **Stable contracts** — the public HTTP API and Python SDK are declared stable
+  under a `1.x` additive-compatibility promise
+  ([docs/api-stability.md](docs/api-stability.md)); package versions are `1.0.0`.
+- **Release-readiness docs** — a consolidated [known-limitations](docs/limitations.md)
+  page, a [production-readiness](docs/production-readiness.md) map (each invariant
+  → where enforced; production-capable vs demo-only), and a full
+  [CHANGELOG](CHANGELOG.md).
+- v1.0 is **stabilization + documentation**: no behavior changes vs v0.12.
+
 ## Roadmap
 
 - **v0.7** — physical deletion compaction + vector purge verification ✅
@@ -443,18 +460,18 @@ MemoryOps integrates it via an adapter and does not vendor its source.
 - **v0.10** — retention policies + legal hold + consent-aware memory ✅
 - **v0.11** — assistant SDK + integration examples ✅
 - **v0.12** — interactive playground + hosted demo + public screenshots ✅
-- **v1.0** — production-ready governed memory runtime
+- **v1.0** — production-ready governed memory runtime ✅
 
-## What remains (v1.0)
+## Beyond v1.0
 
-- Production-ready runtime: stable API + SDK contracts, deployment guide, README
-  polish, the hosted demo link + recorded GIF wired into the hero.
 - Consent *capture* at the UI/SDK edge; cross-tenant retention scheduling.
 - Hard purge / crypto-shred and pgvector index reclamation (beyond v0.7's
   auditable compaction).
 - Optional queue/cron backend behind the orchestrator interface; auto-discovered
   scope enumeration.
 - Observability + economics, AI PR review runtime, deployment hardening.
+- Operator step to finish the public launch: host the playground + wire the live
+  demo link and recorded GIF into the hero (see [docs/images/playground/](docs/images/playground/)).
 
 See [docs/rollout.md](docs/rollout.md) and the build phases in [CLAUDE.md](CLAUDE.md).
 
@@ -487,6 +504,10 @@ system with release discipline, review gates, and operational safety. Overview:
 
 ## Documentation
 
+- [CHANGELOG.md](CHANGELOG.md) — release notes, v0.1 → v1.0.
+- [docs/api-stability.md](docs/api-stability.md) — stable v1 API + SDK surface, semver + deprecation policy.
+- [docs/production-readiness.md](docs/production-readiness.md) — invariants/planes → where enforced; production-capable vs demo-only.
+- [docs/limitations.md](docs/limitations.md) — the consolidated, authoritative list of what MemoryOps does **not** claim.
 - [docs/architecture.md](docs/architecture.md) — write path, read path, planes, invariants.
 - [docs/loop-engineering.md](docs/loop-engineering.md) — loop definitions, states, gates, evidence.
 - [docs/loop-contracts.md](docs/loop-contracts.md) — LoopDefinition, LoopRun, LoopEvent contracts.

--- a/docs/agent/HANDOFF.md
+++ b/docs/agent/HANDOFF.md
@@ -1,102 +1,73 @@
 # Agent Handoff — MemoryOps AI
 
-_Last updated: 2026-06-22 (end of v0.12 build; PR #11 open)._
+_Last updated: 2026-06-22 (end of v1.0 build; PR #12 open). v0.11 + v0.12 merged + tagged._
 
 ## Current state (verified)
 
-- **Branch:** `feat/v0.12-hosted-demo` (working tree clean except this untracked HANDOFF).
-- **HEAD:** `18f2a5b feat: v0.12 interactive playground + hosted demo`.
-- **Stacking:** `feat/v0.12-hosted-demo` is **stacked on `feat/v0.11-assistant-sdk`**
-  (branched from the v0.11 tip, NOT from main), because v0.11 (PR #10) is not merged
-  yet. This avoids rollout/README doc divergence. Until #10 merges, PR #11's diff
-  includes the v0.11 commit; it reduces to just v0.12 once #10 lands.
-- **Open PRs:**
-  - [#10](https://github.com/patibandlavenkatamanideep/memoryops-ai/pull/10) — v0.11 SDK → main, **OPEN**.
-  - [#11](https://github.com/patibandlavenkatamanideep/memoryops-ai/pull/11) — v0.12 playground → main, **OPEN** (this work).
-- **main:** `0036da4` (v0.10). **Tags:** through `v0.10`; v0.11/v0.12 not tagged.
+- **Branch:** `feat/v1.0-production-runtime` (branched from updated `main`).
+- **HEAD:** `9868dec release: v1.0 production-ready governed memory runtime`.
+- **main:** `36efe47` (v0.12 merge, PR #11). **Tags:** through `v0.12`.
+- **Open PR:** [#12](https://github.com/patibandlavenkatamanideep/memoryops-ai/pull/12)
+  — v1.0 → main, **OPEN, not merged, not tagged**.
+- **Working tree:** clean except this untracked HANDOFF.
 
-### Milestone status
-- v0.9 dashboard, v0.10 retention — merged + tagged.
-- v0.11 SDK — **PR #10 open** (not merged/tagged).
-- v0.12 interactive playground + hosted demo — **PR #11 open** (not merged/tagged).
-- v1.0 — remaining.
+### Milestone status — ALL FEATURE MILESTONES SHIPPED
+- v0.9 dashboard, v0.10 retention, v0.11 SDK (PR #10), v0.12 playground (PR #11) —
+  all **merged + tagged**.
+- v1.0 production-ready runtime — **PR #12 open** (the last milestone).
 
-## v0.12 — what was built (PR #11, commit 18f2a5b)
+## v1.0 — what was built (PR #12, commit 9868dec)
 
-Interactive public **Playground** that drives the **real** governed pipeline from
-`services/api` **in-process**, against a fresh **in-memory** store per browser
-session. Additive only — no `services/api` changes; not the production UI.
+**Stabilization + documentation only — no behavior changes vs v0.12.** 11 files.
 
-### Files (10 files)
-- `apps/playground/streamlit_app.py` — 4 tabs (Capture & ask · Memories &
-  governance · Retention preview · Audit trace). **Entrypoint named
-  `streamlit_app.py` to avoid shadowing the backend `app` package** (see Failures).
-- `apps/playground/requirements.txt` (`-r ../../services/api/requirements.txt` +
-  streamlit), `Dockerfile` (build from repo ROOT — needs services/api),
-  `railway.toml` (optional demo service, not a core service), `README.md`.
-- `docs/playground.md` (architecture + demo-safety + demo-only vs production),
-  `docs/images/playground/README.md` (screenshot/GIF capture guide).
-- Modified: `README.md` (layout + "v0.12" section + roadmap + docs link),
-  `docs/rollout.md` (Phase 9 + roadmap), `CLAUDE.md` (layout entry).
-
-### Design
-- Per Streamlit session: fresh `InMemoryRepository` + `Gateway` + `AuditService`
-  in `st.session_state`, scope `playground/visitor_<rand>`. No DB, no secrets, no
-  network (stub LLM + embeddings). Drives the real `gateway.handle_chat`,
-  `db.governance` (legal hold / pin / consent), `services.retention.evaluate`,
-  and `workers.runner.run_jobs` — so behavior is faithful, not reimplemented.
+- **Stable contracts:** declared the public HTTP API + Python SDK stable under a
+  `1.x` additive-compatibility promise. New `docs/api-stability.md`; stability
+  header added to `docs/api-contracts.md`. Bumped versions to **1.0.0**
+  (`services/api/pyproject.toml`, `packages/memoryops-sdk/pyproject.toml`,
+  `memoryops/__init__.__version__`); added `Production/Stable` classifier to the SDK.
+- **Release-readiness docs:** new `docs/production-readiness.md` (7 invariants +
+  planes → where enforced; production-capable vs demo-only) and
+  `docs/limitations.md` (single authoritative "what we do NOT claim" list).
+- **`CHANGELOG.md`** (new, v0.1 → v1.0).
+- Updated `README.md` (v1.0 banner + section + doc links), `docs/rollout.md`
+  (Phase 10 + roadmap done), `CLAUDE.md` (stability note).
 
 ## Commands run (and results)
-- `services/api/.venv/bin/python -m pytest -q` (in services/api) → **249 passed, 1
-  skipped** (unchanged; no backend code touched).
-- `services/api/.venv/bin/ruff check app ../../apps/playground` → **All checks passed**.
-- Playground smoke (stub Streamlit, real in-process pipeline): seed → policy
-  decisions (`SAVE`/`DROP_LOW_UTILITY`) → legal-hold blocks delete → retention
-  outcome `held` → all 7 lifecycle workers `ok=True` → 26 audit events → hybrid
-  retrieval used seeded memories. ✅
-- `py_compile streamlit_app.py` → OK.
-- PR gate `--base feat/v0.11-assistant-sdk --head HEAD` and `--base main --head HEAD`
-  → **PASS, 0 rules armed** (additive).
-- `git push -u origin feat/v0.12-hosted-demo`; `gh pr create` → PR #11.
+- `cd services/api && .venv/bin/python -m pytest -q` → **249 passed, 1 skipped** (unchanged).
+- `cd packages/memoryops-sdk && PYTHONPATH="$PWD" ../../services/api/.venv/bin/python -m pytest -q` → **13 passed** (version bump only).
+- `ruff check services/api/app packages/memoryops-sdk apps/playground` → **All checks passed**.
+- `cd evals && ../services/api/.venv/bin/python run_evals.py` → **PASS**.
+- `pr_invariant_gate.py --base main --head HEAD` → **PASS, 0 rules armed**.
+- `git push`; `gh pr create` → PR #12.
+- Verified no test pins old version strings before bumping (grep clean).
 
-## Failures encountered (and fixes)
-1. **Name collision:** the entrypoint `app.py` shadowed the `services/api` **`app`
-   package**, so `from app.db import ...` resolved to the playground module →
-   `ModuleNotFoundError: No module named 'app.db'`. **Fix:** rename entrypoint to
-   `streamlit_app.py` (also Streamlit Cloud's default). Smoke then passed.
-2. **ruff** flagged an unused `Status` import → removed via `ruff --fix`.
-3. Earlier this session: a `mv`/`git mv` Bash call was blocked by a transient
-   classifier outage; re-ran the rename successfully after.
-
-No outstanding failures. Everything green.
+## Failures encountered
+None. Everything green first pass.
 
 ## Key decisions
-- **Stack v0.12 on v0.11** (not branch from main) to keep rollout/README docs
-  consistent and avoid merge churn; PR #11 targets main and self-reduces post-#10.
-- **Drive the real pipeline in-process** (not via the SDK/HTTP) for true
-  per-session isolation and to showcase actual governance behavior live.
-- **Hostable without infra** — Streamlit Community Cloud (`streamlit_app.py`) or an
-  optional Railway demo service; no Vercel, not one of the five core services.
-- Screenshots/GIF + hosted link deferred to operator (need a live browser/host);
-  shipped a capture guide instead of binary placeholders.
-- **Did not** tag/merge/release.
+- **v1.0 = stabilization, not a feature.** Per user choice (“Full stabilization
+  pass”): freeze/document contracts + release-readiness docs; **no behavior change**.
+- **Bumped both packages to 1.0.0** (RELEASING.md allows the api version to lag,
+  but a v1.0 stability milestone should signal stability in-package).
+- Did **not** wire a live demo link/GIF into the README hero — that needs a live
+  host/browser (operator step); shipped the capture guide + placeholders instead.
+- Did **not** tag/merge/release.
 
 ## Next 3 actions
-1. **Land the stack in order:** merge **PR #10 (v0.11)** to main + tag `v0.11`;
-   then PR #11's base auto-updates and its diff reduces to just v0.12 — merge
-   **PR #11**, tag `v0.12`. Run `git fetch --tags` locally afterward.
-2. **Finish v0.12 operator steps:** host the playground (Streamlit Community Cloud
-   or Railway), capture the 4 tab screenshots + demo GIF per
-   `docs/images/playground/README.md`, and wire the demo link + images into the
-   README hero.
-3. **Start v1.0 — Production-Ready Governed Memory Runtime:** stabilize API + SDK
-   contracts, complete deployment guide + security model docs, README polish,
-   known-limitations page, and fold in the hosted demo link. Branch from updated
-   `main` once #10/#11 land.
+1. **Land + tag v1.0:** wait for CI on PR #12, then (user) merge to `main`, tag
+   `v1.0`, publish the GitHub Release (use the PR body / `CHANGELOG.md` v1.0 entry
+   as notes). `git fetch --tags` locally after.
+2. **Finish the public launch (operator):** host the playground (Streamlit
+   Community Cloud or Railway) + results dashboard, capture screenshots + demo GIF
+   per `docs/images/playground/README.md`, and wire the live demo link + images
+   into the README hero. This is the only remaining "Beyond v1.0" launch item.
+3. **Post-1.0 backlog (when desired):** consent capture at the UI/SDK edge;
+   cross-tenant retention scheduling; OTel/Prometheus/Langfuse observability;
+   publish `memoryops-sdk` to PyPI; pgvector VACUUM/reindex orchestration. See
+   README “Beyond v1.0” and `docs/rollout.md` production roadmap.
 
 ## Pointers
-- Playground: `apps/playground/README.md`, `docs/playground.md`, `docs/images/playground/`.
-- Results dashboard (v0.9 evidence): `apps/results-dashboard/`, `docs/results-dashboard.md`.
-- SDK (v0.11): `packages/memoryops-sdk/README.md`, `docs/assistant-sdk.md`, `infra/adr/ADR-014-assistant-sdk.md`.
+- v1.0 docs: `CHANGELOG.md`, `docs/api-stability.md`, `docs/production-readiness.md`, `docs/limitations.md`.
+- Surfaces: `apps/web` (official UI), `apps/results-dashboard` (v0.9 evidence), `apps/playground` (v0.12 demo), `packages/memoryops-sdk` (v0.11 SDK).
 - Roadmap/phases: `docs/rollout.md`. PR-gate: `scripts/pr_invariant_gate.py`. Invariants: `CLAUDE.md`.
-- Tooling: no `python`/`pytest` on PATH — use `services/api/.venv/bin/python` (Python 3.14).
+- Tooling: no `python`/`pytest` on PATH — use `services/api/.venv/bin/python` (Python 3.14); SDK tests need `PYTHONPATH="$PWD"` from the package dir.

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -3,6 +3,10 @@
 Canonical reference for the HTTP surface. Changes to `services/api/app/routes/**`
 must update this file (enforced by the PR Invariant Evidence Gate).
 
+> **Stable as of v1.0.** This surface follows a `1.x` additive-compatibility
+> promise — existing endpoints keep their methods/paths/required fields and
+> responses only gain fields. See [api-stability.md](api-stability.md).
+
 Base URL (dev): `http://localhost:8000`. Interactive docs: `/docs`.
 
 ## POST /api/chat

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -1,0 +1,64 @@
+# API & SDK Stability — MemoryOps AI (v1.0)
+
+As of **v1.0**, the public HTTP API and the Python SDK surface are **stable**:
+within the `1.x` line they are additive-compatible. This document is the contract
+for what "stable" means and how changes are governed.
+
+## Versioning
+
+- Releases are git tags `vMAJOR.MINOR[.PATCH]` (see [RELEASING.md](../RELEASING.md));
+  the tag + GitHub Release are the source of truth for "what shipped".
+- Package versions (`services/api`, `packages/memoryops-sdk`) are **1.0.0** at v1.0.
+- Within `1.x`: **MINOR** adds backward-compatible capability, **PATCH** is
+  fixes/hardening. A breaking change to the stable surface requires a **MAJOR**
+  bump (`2.0`) and a deprecation window.
+
+## Stable HTTP surface
+
+Canonical request/response shapes live in [api-contracts.md](api-contracts.md)
+(kept in sync by the PR Invariant Evidence Gate). Stable endpoints:
+
+| Area | Endpoints |
+|------|-----------|
+| Chat | `POST /api/chat` |
+| Memories | `GET /api/memories`, `GET /api/memories/{id}`, `PATCH /api/memories/{id}`, `DELETE /api/memories/{id}`, `GET /api/memories/{id}/audit`, `GET /api/memories/{id}/provenance` |
+| Retention / governance | `POST /api/retention/{legal-hold,pin,protect,consent}`, `GET /api/retention/{policies,decisions}`, `GET /api/retention/memory/{id}` |
+| Audit & metrics | `GET /api/audit`, `GET /api/metrics` |
+| Loops | `GET /api/loops`, `/api/loops/runs`, `/api/loops/events`, `/api/loops/trace/{id}`, `/api/loops/{id}` |
+| Health | `GET /healthz`, `GET /healthz/workers`, `GET /readyz` |
+
+**Compatibility promise (1.x):** existing endpoints keep their methods, paths, and
+required request fields; responses only **gain** fields. New fields may appear on
+any response, so clients must ignore unknown fields (the SDK does — see below).
+
+## Stable SDK surface
+
+`MemoryOpsClient` ([packages/memoryops-sdk](../packages/memoryops-sdk)) is the
+stable client. Stable methods: `chat`, `list_memories`, `get_memory`,
+`update_memory`, `delete_memory`, `memory_audit`, `memory_provenance`,
+`set_legal_hold`, `pin`, `protect`, `set_consent`, `retention_policies`,
+`retention_decisions`, `memory_governance`, `audit`, `metrics`, `loops`,
+`loop_trace`, `health`, `workers_health`.
+
+Stable client guarantees:
+
+- **Scope injection** — `tenant_id`/`user_id` are attached to every call.
+- **Forward compatibility** — response models keep `.raw`, so new server fields are
+  never lost and never break parsing.
+- **Typed errors** — `LegalHoldError` (409), `NotFoundError` (404), `APIError`
+  (other), all subclasses of `MemoryOpsError`.
+
+## What is explicitly NOT covered by the stability promise
+
+- Internal modules under `services/api/app/**` (services, workers, repositories) —
+  implementation detail; import at your own risk.
+- The demo surfaces (`apps/results-dashboard`, `apps/playground`) — demo-only.
+- Provider adapters' generation *quality* (stub vs OpenAI/Anthropic/Gemini).
+- Anything listed in [limitations.md](limitations.md).
+
+## Deprecation policy
+
+A stable endpoint/method is removed or changed incompatibly only across a MAJOR
+bump, after at least one MINOR release where it is documented as deprecated (and,
+for the SDK, emits a `DeprecationWarning`). Audit-event action names are treated as
+a stable vocabulary on the same terms.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,0 +1,84 @@
+# Known Limitations — MemoryOps AI (v1.0)
+
+The single, authoritative list of what MemoryOps **does not** claim. Stating these
+plainly is part of the product: a governed memory system earns trust by being
+honest about its boundaries. Individual feature docs link here rather than
+re-deriving their own caveats.
+
+## Deletion & forgetting
+
+- **Not crypto-shred.** Deletion compaction clears retrievable content + vector
+  material and preserves a governance tombstone; it does **not** perform
+  cryptographic erasure of keys.
+- **No physical disk/page-erasure guarantee.** Compaction is an application- and
+  repository-level clear, not a guarantee that database pages or ANN-index bytes
+  are physically overwritten/reclaimed.
+- **No pgvector VACUUM / reindex orchestration yet.** Vector material is cleared
+  and verified unreachable, but index compaction/reclamation is not orchestrated.
+- **Legal hold is a *preservation* control, not shred.** It blocks forgetting
+  (decay, archive, retention, deletion, compaction) fail-closed; it is not a
+  compliance certification.
+- Honest scope of what deletion *does* guarantee: retrieval exclusion, repository
+  content/vector clearing where supported, deletion verification, compaction,
+  vector purge verification, tombstone preservation, and audit evidence. See
+  [deletion-compaction.md](deletion-compaction.md) and
+  [vector-purge-verification.md](vector-purge-verification.md).
+
+## Retention, legal hold & consent
+
+- Retention auto-deletion is **OFF by default** and per-tenant/user scoped; there
+  is no cross-tenant retention scheduler yet.
+- **Consent is captured/edited via the API/SDK, not yet at a first-class UI edge**
+  for end users; the worker acts on the conservative outcome only.
+- Retention/legal-hold/consent are governance metadata + workers, not a legal
+  compliance product. See [retention-policies.md](retention-policies.md).
+
+## Storage, security & isolation
+
+- **RLS is enforced** on Postgres (`FORCE` + tenant policy), but **field-level
+  encryption** for high-sensitivity rows is not implemented.
+- Tenant isolation is enforced in code + tests on every scoped read; the
+  in-memory backend mirrors the Postgres semantics but is for dev/demo only.
+- No built-in end-user **authentication/authorization** layer ships in v1.0 — the
+  API trusts the `tenant_id`/`user_id` scope the caller provides; deploy it behind
+  your own auth. See [security.md](security.md).
+
+## Models & retrieval
+
+- The default **LLM and embedding providers are deterministic offline stubs** (no
+  API key). Optional OpenAI/Anthropic/Gemini adapters exist; quality with stubs is
+  intentionally reproducible, not production-grade generation.
+- LLM output is **advisory** — the deterministic policy broker stays authoritative
+  and is never bypassed.
+- Retrieval is hybrid (vector + keyword) with graceful degradation to keyword-only
+  on embedding failure; ranking is heuristic, not a learned ranker.
+
+## Observability & operations
+
+- Structured logs, audit events, worker run history, and `GET /healthz/workers`
+  ship; full **OpenTelemetry traces / Prometheus metrics / Langfuse** wiring is on
+  the production roadmap, not in the box.
+- Workers run on a thin lease/scheduler runtime, not Celery/Temporal; there is no
+  external queue/broker.
+
+## Demo surfaces
+
+- The **results dashboard** (`apps/results-dashboard`, v0.9) is **read-only and
+  static** — demo JSON, not a live view. See [results-dashboard.md](results-dashboard.md).
+- The **playground** (`apps/playground`, v0.12) is **interactive but demo-only**:
+  in-memory, ephemeral, per-session, no DB/secrets/real data. See
+  [playground.md](playground.md).
+- Both are evidence/demo surfaces. The **Next.js app (`apps/web`) is the official
+  product / governance UI.**
+
+## Deployment
+
+- Deployment is **Railway-only** (no Vercel): one project, five core services
+  (web/api/worker + Postgres + Redis). The demo surfaces are optional and are not
+  part of the five. See [deployment/railway.md](deployment/railway.md).
+
+---
+
+For the complementary "what *is* guaranteed" view, see
+[production-readiness.md](production-readiness.md) and the enforced invariants in
+[architecture.md](architecture.md).

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -1,0 +1,69 @@
+# Production Readiness — MemoryOps AI (v1.0)
+
+What "production-ready governed memory runtime" means for v1.0: the governed memory
+lifecycle, its seven non-negotiable invariants, and the cross-cutting planes are
+implemented, enforced in code + tests, and operable. This page maps each guarantee
+to where it lives, and states plainly what is production-capable vs demo-only.
+
+For the inverse (what is *not* claimed), see [limitations.md](limitations.md).
+
+## The seven invariants (enforced in code + tests)
+
+| # | Invariant | Where enforced |
+|---|-----------|----------------|
+| 1 | Tenant isolation | Repository scoped reads/writes; Postgres RLS (`FORCE`); `scripts/check_rls_policies.py`; `tests/test_rls.py` |
+| 2 | Deletion guarantee | `status='deleted'` excluded from all retrieval; deletion verification worker; `tests/` |
+| 3 | Provenance | `source` is NOT NULL on every memory; preserved through compaction (`source.kind`) |
+| 4 | Graceful degradation | Retrieval failure degrades to keyword-only; workers never raise into chat |
+| 5 | Policy-before-storage | Policy broker runs before any write; LLM output is advisory |
+| 6 | Temporary chat | `temporary_chat=true` reads/writes nothing |
+| 7 | Auditability | Every lifecycle action appends an append-only audit event |
+
+## Cross-cutting planes
+
+- **Security** — tenant isolation, enforced RLS, secret detection/redaction before
+  storage, deletion guarantee. See [security.md](security.md).
+- **Governance** — capture/evaluate/approve/forget lifecycle, retention policy
+  packs, legal hold (fail-closed), consent-aware eligibility, deletion compaction +
+  vector purge verification, full audit trail. See [governance.md](governance.md),
+  [retention-policies.md](retention-policies.md).
+- **Reliability** — worker runtime with leases (no duplicate runs), retry/backoff,
+  dead-letter, persisted run history, `GET /healthz/workers`. See
+  [worker-runtime.md](worker-runtime.md).
+- **Observability** — structured logs, audit events, worker run history, loop
+  timelines (`/api/loops`). Full OTel/Prometheus/Langfuse is roadmap.
+- **Evaluation** — golden + adversarial eval suite (`evals/run_evals.py`) plus the
+  invariant test suite and the deterministic PR Invariant Evidence Gate.
+
+## Production-capable vs demo-only
+
+| Capability | Production-capable | Demo-only |
+|------------|--------------------|-----------|
+| Storage | Postgres + pgvector, enforced RLS | In-memory backend (dev/tests, playground) |
+| LLM / embeddings | OpenAI / Anthropic / Gemini adapters | Deterministic offline stubs (default) |
+| UI | Next.js app (`apps/web`) | Results dashboard (v0.9), Playground (v0.12) |
+| Workers | Lease/scheduler runtime (`services/worker`) | One-shot `runner.py` invocations |
+| Client | Typed Python SDK (`memoryops-sdk`) | Example scripts |
+
+## Deploying
+
+Railway-only: one project, five core services (web/api/worker + Postgres + Redis).
+Run migrations from `infra/db/migrations`; set `MEMORYOPS_STORAGE=postgres`. Put
+the API behind your own authentication — v1.0 trusts the caller-supplied
+`tenant_id`/`user_id` scope. See [deployment/railway.md](deployment/railway.md).
+
+## Release gate (must be green to ship)
+
+```bash
+cd services/api && pytest -q && ruff check app
+cd evals && python run_evals.py
+python scripts/pr_invariant_gate.py --base main --head HEAD
+cd apps/web && npm run build
+```
+
+See [release-loop.md](release-loop.md) and [RELEASING.md](../RELEASING.md).
+
+## Stability
+
+The public HTTP API and SDK surface are **stable** as of v1.0 under a `1.x`
+additive-compatibility promise — see [api-stability.md](api-stability.md).

--- a/docs/rollout.md
+++ b/docs/rollout.md
@@ -127,6 +127,18 @@ as an optional Railway demo service (not one of the five core services; no Verce
 Screenshots/GIF + the hosted link are the operator-run final step. See
 [playground.md](playground.md), [images/playground/](images/playground/).
 
+## Phase 10 — Production-ready governed memory runtime ✅ (v1.0)
+The stable public release. The governed lifecycle, its seven enforced invariants,
+and the security/governance/reliability/observability/evaluation planes are
+implemented, tested, and operable. The public HTTP API and Python SDK are declared
+**stable** under a `1.x` additive-compatibility promise; package versions are
+`1.0.0`. Adds release-readiness docs — a consolidated
+[limitations](limitations.md) page, a [production-readiness](production-readiness.md)
+map (invariant → where enforced; production-capable vs demo-only), an
+[api-stability](api-stability.md) contract, and a top-level
+[CHANGELOG](../CHANGELOG.md). v1.0 is stabilization + documentation: **no behavior
+changes vs v0.12**.
+
 ## Public roadmap
 
 | Version | Scope | Status |
@@ -137,7 +149,7 @@ Screenshots/GIF + the hosted link are the operator-run final step. See
 | v0.10 | Retention policies + legal hold + consent-aware memory | ✅ Done |
 | v0.11 | Assistant SDK + integration examples | ✅ Done |
 | v0.12 | Interactive playground + hosted demo + public screenshots | ✅ Done |
-| v1.0 | Production-ready governed memory runtime | ⏳ Next |
+| v1.0 | Production-ready governed memory runtime | ✅ Done |
 
 ## Production roadmap (beyond hackathon)
 

--- a/packages/memoryops-sdk/memoryops/__init__.py
+++ b/packages/memoryops-sdk/memoryops/__init__.py
@@ -24,7 +24,7 @@ from .models import (
     UsedMemory,
 )
 
-__version__ = "0.11.0"
+__version__ = "1.0.0"
 
 __all__ = [
     "MemoryOpsClient",

--- a/packages/memoryops-sdk/pyproject.toml
+++ b/packages/memoryops-sdk/pyproject.toml
@@ -4,13 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memoryops-sdk"
-version = "0.11.0"
+version = "1.0.0"
 description = "Python SDK for MemoryOps AI — governed memory infrastructure for AI assistants."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [{ name = "MemoryOps AI" }]
 keywords = ["memoryops", "ai", "memory", "governance", "llm", "agents", "rag"]
+classifiers = ["Development Status :: 5 - Production/Stable"]
 dependencies = ["httpx>=0.24,<1"]
 
 [project.urls]

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memoryops-api"
-version = "0.1.0"
+version = "1.0.0"
 description = "MemoryOps AI — enterprise memory governance API (write path)"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
## v1.0 — Production-Ready Governed Memory Runtime

The stable public release. **Stabilization + documentation only — no behavior changes vs v0.12.**

### Stable contracts
- The public HTTP API and Python SDK are declared **stable** under a `1.x` additive-compatibility promise: existing endpoints/methods keep their shape; responses only gain fields; breaking changes require a MAJOR bump + deprecation window.
- New [docs/api-stability.md](docs/api-stability.md) + a stability header on [docs/api-contracts.md](docs/api-contracts.md).
- Package versions bumped to **1.0.0** (`services/api`, `packages/memoryops-sdk`); SDK gets the `Production/Stable` classifier and `__version__ = "1.0.0"`.

### Release-readiness docs
- [docs/production-readiness.md](docs/production-readiness.md) — each of the 7 invariants + cross-cutting planes mapped to *where enforced*, plus a production-capable vs demo-only table.
- [docs/limitations.md](docs/limitations.md) — the single, authoritative list of what MemoryOps does **not** claim (not crypto-shred, no physical erasure guarantee, no pgvector VACUUM orchestration, demo surfaces are demo-only, etc.). Feature docs link here.
- [CHANGELOG.md](CHANGELOG.md) — consolidated release notes, v0.1 → v1.0.
- README v1.0 banner + section + doc links; rollout Phase 10 + roadmap marked done; CLAUDE stability note.

### Validation
- Backend: **249 passed, 1 skipped** (unchanged — no code-path changes).
- SDK: **13 passed** (version bump only).
- `ruff` (api + sdk + playground): **clean**. Evals: **PASS**.
- PR invariant gate: **PASS, 0 rules armed** (docs + version bumps).

### Notes
- Operator step to finish the public launch: host the playground and wire the live demo link + recorded GIF into the README hero (see `docs/images/playground/`).
- Not tagged, not merged.