### PR TITLE
fix(railway): playground healthcheck — drop startCommand, use Dockerfile CMD

### DIFF
--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -52,10 +52,13 @@ be the repo root**, so configure the service as:
 - **Root Directory:** `/` (repo root)
 - **Config File (config-as-code):** `railway/playground.railway.json`
 
-That config sets `builder = DOCKERFILE`, `dockerfilePath = apps/playground/Dockerfile`,
-and the Streamlit start command on `$PORT`. **Do not** set the Root Directory to
-`apps/playground` — the `COPY services/api` step would fail and Railway would fall
-back to its Railpack auto-detector. See [docs/playground.md](../../docs/playground.md).
+That config sets `builder = DOCKERFILE` and `dockerfilePath = apps/playground/Dockerfile`.
+The **start command comes from the Dockerfile `CMD`** (`sh -c "streamlit run … --server.port ${PORT:-8501} …"`),
+not from the config — a config-as-code `startCommand` on a Dockerfile service runs
+without shell expansion, so `$PORT` would be passed literally and Streamlit would
+crash. **Do not** set the Root Directory to `apps/playground` — the
+`COPY services/api` step would fail and Railway would fall back to its Railpack
+auto-detector. See [docs/playground.md](../../docs/playground.md).
 
 ## How it stays safe
 

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -102,10 +102,15 @@ host. Its Dockerfile copies `services/api`, so the Docker build context must be 
   missing `start.sh`).
 - **Builder / Dockerfile:** `DOCKERFILE`, `dockerfilePath: apps/playground/Dockerfile`
   (set in the config file).
-- **Start command:** owned by the config file —
-  `streamlit run streamlit_app.py --server.address=0.0.0.0 --server.port=$PORT --server.headless=true`
-  (runs from the image `WORKDIR /app/apps/playground`).
-- **Health check:** `/_stcore/health` (Streamlit).
+- **Start command:** owned by the **Dockerfile `CMD`** (runs from the image
+  `WORKDIR /app/apps/playground`):
+  `sh -c "streamlit run streamlit_app.py --server.port ${PORT:-8501} --server.address 0.0.0.0 --server.headless true"`.
+  Do **not** put this start command in `railway/playground.railway.json`: a
+  config-as-code `startCommand` on a Dockerfile service runs in **exec form
+  without shell expansion**, so Streamlit would receive the literal string
+  `$PORT` and crash (healthcheck then fails). The Dockerfile `CMD` uses `sh -c`,
+  so `${PORT:-8501}` expands correctly.
+- **Health check:** `/_stcore/health` (Streamlit), `healthcheckTimeout: 300`.
 
 ## Health checks
 

--- a/railway/playground.railway.json
+++ b/railway/playground.railway.json
@@ -5,9 +5,8 @@
     "dockerfilePath": "apps/playground/Dockerfile"
   },
   "deploy": {
-    "startCommand": "streamlit run streamlit_app.py --server.address=0.0.0.0 --server.port=$PORT --server.headless=true",
     "healthcheckPath": "/_stcore/health",
-    "healthcheckTimeout": 100,
+    "healthcheckTimeout": 300,
     "numReplicas": 1,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10


### PR DESCRIPTION
## Root cause (confirmed by Railway's own diagnosis)
The Playground Docker build succeeded, but the **healthcheck** failed every attempt. A config-as-code `startCommand` on a **Dockerfile** service runs in **exec form without shell expansion**, so Streamlit received the literal string `$PORT`, failed to parse the port, and crashed on startup → all healthchecks failed.

## Fix
- **Remove `startCommand`** from `railway/playground.railway.json` so Railway runs the image's `CMD`:
  `sh -c "streamlit run streamlit_app.py --server.port ${PORT:-8501} --server.address 0.0.0.0 --server.headless true"` — a real shell that **expands `$PORT`** (with an `8501` fallback).
- Bump `healthcheckTimeout` to `300` for cold-start headroom; keep health path `/_stcore/health`.
- Docs (`apps/playground/README.md`, `docs/deployment/railway.md`) updated: the **Dockerfile `CMD`** owns the start command, not the config file.

## Validation
- `railway/playground.railway.json`: valid JSON, **no `startCommand`**, `builder=DOCKERFILE`, health `/_stcore/health`, timeout 300.
- Dockerfile `CMD` is the `sh -c` shell form with `${PORT:-8501}`.
- (Real `docker build`/Railway healthcheck verified by the next deploy.)

Demo-only: in-memory, no DB, no secrets. No Vercel. No code/behavior changes.