### PR TITLE
feat(observability): Prometheus metrics exposition at GET /metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable releases. Git tags + GitHub Releases are the source of truth; this
 file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
 
+## v1.1 — Prometheus Metrics Exposition
+Additive under the `1.x` compatibility promise. Process-wide, content-free
+Prometheus text metrics at `GET /metrics` (HTTP traffic, retrieval latency/mode,
+policy-decision rate, pull-derived worker run counts) for a Prometheus/Grafana
+scrape. Dependency-free (hand-rolled in `app/observability/`), low-cardinality
+(no `tenant_id`/`user_id` labels), and graceful — recording is no-throw and the
+scrape never 500s. `/healthz` now reports `uptime_seconds` + `metrics_enabled`.
+Toggle with `MEMORYOPS_METRICS_ENABLED`. No chat-path behavior change; distinct
+from the per-tenant `GET /api/metrics` JSON.
+See [docs/observability.md](docs/observability.md), [ADR-015](infra/adr/ADR-015-prometheus-metrics-exposition.md).
+
 ## v1.0 — Production-Ready Governed Memory Runtime
 The stable public release. The governed memory lifecycle (Capture → Evaluate →
 Store → Retrieve → Rank → Compose → Update → Forget → Audit), its seven enforced

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,11 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
   `app/services/{retriever,ranker,context_composer}.py`.
 - `services/api/app/embeddings` — swappable `EmbeddingProvider` (stub default + optional OpenAI).
   `MEMORYOPS_EMBEDDING_PROVIDER=stub|openai`. `app/core/embeddings.py` is a back-compat shim.
+- `services/api/app/observability` — process-wide, dependency-free Prometheus
+  metrics exposition at `GET /metrics` (v1.1). Content-free + low-cardinality
+  (no tenant/user labels); recording is no-throw (invariant #4); worker gauges are
+  pull-derived at scrape time. Distinct from the per-tenant `GET /api/metrics` JSON.
+  Toggle `MEMORYOPS_METRICS_ENABLED`. See ADR-015, `docs/observability.md`.
 - `services/api/app/compression` — optional context compression at the LLM boundary
   (`MEMORYOPS_CONTEXT_COMPRESSION=none|headroom`). `NoopCompressor` is the default;
   `HeadroomCompressor` is optional and degrades to no-op. Runs **after** policy/governance/

--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # MemoryOps AI
 
-> **v1.0 — production-ready governed memory runtime.** The public HTTP API and
-> Python SDK are **stable** under a `1.x` additive-compatibility promise
-> ([docs/api-stability.md](docs/api-stability.md)). See the
-> [CHANGELOG](CHANGELOG.md), [production-readiness](docs/production-readiness.md),
+Enterprise memory governance for AI assistants. MemoryOps AI implements a
+ChatGPT-style memory lifecycle — capture, policy evaluation, typed storage, hybrid
+retrieval, controlled forgetting, auditability, and tenant isolation. Most demos
+treat memory as a vector database; MemoryOps AI treats it as governed state.
+
+## Live demo
+
+**[memoryops-ai-production.up.railway.app](https://memoryops-ai-production.up.railway.app)**
+
+Try the MemoryOps Playground — an interactive, demo-safe governed memory runtime
+that runs the real MemoryOps pipeline in-process with ephemeral session state.
+
+> v1.0 is production-ready. The public HTTP API and Python SDK are stable under a
+> `1.x` additive-compatibility promise ([docs/api-stability.md](docs/api-stability.md)).
+> See the [CHANGELOG](CHANGELOG.md), [production-readiness](docs/production-readiness.md),
 > and [known limitations](docs/limitations.md).
-
-MemoryOps AI is an enterprise-shaped, loop-engineered memory governance layer for AI assistants.
-It implements a ChatGPT-style memory lifecycle with capture, policy evaluation, typed storage,
-hybrid retrieval, controlled forgetting, auditability, and tenant isolation.
-
-Most demos treat memory as a vector database. MemoryOps AI treats memory as **governed state**.
-
-> **Tagline:** Enterprise memory governance for AI assistants.
-> **Core claim:** Memory is not a database. Memory is a governed decision system that decides what
-> information is valuable enough to carry into the future.
 
 ---
 
@@ -148,10 +149,10 @@ docker compose up --build
 Compose runs migrations from `infra/db/migrations` on first boot and sets
 `MEMORYOPS_STORAGE=postgres` for the API.
 
-### Embeddings (v0.3)
+### Embeddings
 
 Retrieval uses a swappable embedding provider. The default is a deterministic,
-offline **stub** — no API key required — so tests and demos are reproducible.
+offline stub — no API key required — so tests and demos are reproducible.
 
 ```bash
 export MEMORYOPS_EMBEDDING_PROVIDER=stub     # default; deterministic, no key
@@ -164,10 +165,10 @@ export OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 An unconfigured or failing provider degrades to the stub, and a query-embedding
 failure degrades retrieval to keyword-only (`retrieval_mode="fallback"`).
 
-### LLM provider adapters (v0.4)
+### LLM provider adapters
 
 Extraction and conflict detection run through a provider-neutral LLM layer
-(`app/llm/`). The default is a deterministic, offline **stub** — no API key — so
+(`app/llm/`). The default is a deterministic, offline stub — no API key — so
 behavior is reproducible and tests never touch the network. Optional OpenAI,
 Anthropic, and Gemini adapters are used only when their key is set.
 
@@ -180,9 +181,9 @@ export ANTHROPIC_API_KEY=...   ANTHROPIC_MODEL=claude-haiku-4-5-20251001
 export MEMORYOPS_LLM_FALLBACK_TO_HEURISTIC=true   # invalid JSON / failure → heuristic
 ```
 
-LLM output is **advisory**: the deterministic policy broker runs after extraction
-and stays authoritative — a model can never override policy, and secret-like
-content is still blocked. See [docs/provider-llm-adapters.md](docs/provider-llm-adapters.md),
+LLM output is advisory: the deterministic policy broker runs after extraction and
+stays authoritative — a model can never override policy, and secret-like content is
+still blocked. See [docs/provider-llm-adapters.md](docs/provider-llm-adapters.md),
 [docs/structured-memory-intelligence.md](docs/structured-memory-intelligence.md),
 and [ADR-008](infra/adr/ADR-008-provider-llm-adapters.md).
 
@@ -204,10 +205,10 @@ The frontend reads `NEXT_PUBLIC_API_URL` (defaults to `http://localhost:8000`).
 
 ---
 
-## Deployment — Railway only (v0.3.2)
+## Deployment — Railway only
 
-MemoryOps deploys to **Railway only**. There is **no Vercel** path. One Railway
-project (`memoryops-ai`) runs five services:
+MemoryOps deploys to Railway only. There is no Vercel path. One Railway project
+(`memoryops-ai`) runs five services:
 
 | Service | Role | Source |
 |---------|------|--------|
@@ -233,274 +234,186 @@ python scripts/railway_smoke_test.py \
 
 ---
 
-## What works today (Phase 0 + Phase 1)
+## Capabilities
 
-- Full design spine: README, architecture/security/governance/rollout docs, 5 ADRs, DB schema.
-- FastAPI write path: **Gateway → Extractor → Policy Broker → Write Service → Memory Store → Audit**.
-- Heuristic extractor + policy broker (works with **no API keys**); pluggable LLM adapter interface.
-- Typed memory classification, importance/confidence/sensitivity scoring, provenance capture.
-- Policy decisions: `SAVE`, `PENDING_APPROVAL`, `BLOCK`, `DROP_LOW_UTILITY`, `UPDATE_EXISTING`, `MERGE_WITH_EXISTING`.
-- Secret / PII detection blocks API keys and credentials before storage.
-- Append-only audit log for every lifecycle event.
-- Temporary chat short-circuits both read and write.
-- Memory dashboard + admin/audit + architecture pages (frontend skeleton).
-- Invariant test suite + eval harness scaffolding.
+The build history is in the [CHANGELOG](CHANGELOG.md). What the system does today:
 
-## Loop Engineering Layer (v0.3.1)
+### Governed write and read path
 
-MemoryOps models memory as a set of governed loops rather than a passive store.
+- Write path: Gateway → Extractor → Policy Broker → Write Service → typed memory
+  store → audit. The heuristic extractor and policy broker work with no API keys;
+  LLM adapters are optional enhancements.
+- Typed memory classification with importance / confidence / sensitivity scoring and
+  provenance capture on every memory.
+- Policy decisions — `SAVE`, `PENDING_APPROVAL`, `BLOCK`, `DROP_LOW_UTILITY`,
+  `UPDATE_EXISTING`, `MERGE_WITH_EXISTING` — with secret / PII detection that blocks
+  API keys and credentials before storage.
+- Append-only audit log for every lifecycle event; temporary chat short-circuits
+  both read and write.
 
-The core loops are:
+### Retrieval, ranking, and storage
 
-1. Memory Write Loop
-2. Memory Read Loop
-3. Governance Loop
-4. Evaluation Loop
-5. Release Gate Loop
-6. Continuous Learning Loop
+- Swappable embedding provider (`app/embeddings/`): deterministic offline stub plus
+  optional OpenAI.
+- Hybrid retrieval — pgvector cosine (`search_candidates`) blended with keyword
+  overlap by the ranker, with a per-memory `score_breakdown` and a response
+  `retrieval_mode` (`hybrid` / `fallback` / `none`).
+- Enforced Postgres Row-Level Security (migration `004`, `FORCE` + tenant policy +
+  session GUC), verified by `scripts/check_rls_policies.py`.
 
-Each loop has explicit states, policy gates, audit events, fallback behavior, and
-evidence requirements. Loop definitions live in `services/api/app/loops/`, loop
-runs/events are exposed through `/api/loops`, and the frontend includes a Loops page.
+### LLM intelligence layer
 
-See [docs/loop-engineering.md](docs/loop-engineering.md),
+- Provider-neutral LLM layer (`app/llm/`): deterministic `StubProvider` default plus
+  optional OpenAI / Anthropic / Gemini adapters selected by `MEMORYOPS_LLM_PROVIDER`.
+- Schema-validated structured extraction and conflict detection with a prompt
+  registry and deterministic heuristic fallback. Invalid JSON, provider failure, or
+  timeout degrades to the heuristic and never blocks chat; LLM output cannot override
+  the policy broker. See [ADR-008](infra/adr/ADR-008-provider-llm-adapters.md).
+
+### Governance control plane
+
+- Browser control plane over the governed lifecycle: `/memories` (filterable
+  inventory), `/memories/[id]` (detail + provenance + per-memory audit timeline +
+  inline edit), `/governance` (approval queue + recorded policy decisions), and
+  `/audit` (tenant-wide append-only history).
+- Additive read routes (`GET /api/memories/{id}`, `/{id}/provenance`, `/{id}/audit`,
+  plus a `memory_id` filter on `/api/audit`). The deletion guarantee holds in the UI:
+  deleted memories are never listed or shown as active. See
+  [docs/governance-ui.md](docs/governance-ui.md),
+  [docs/memory-control-plane.md](docs/memory-control-plane.md), and
+  [ADR-009](infra/adr/ADR-009-memory-control-plane.md).
+
+### Background lifecycle workers
+
+- Workers (`services/api/app/workers/`) maintain memory after capture, off the chat
+  request path: decay, archive, conflict scan, deletion verification, deletion
+  compaction, retention, and proposal-only reflection (retention and reflection off
+  by default). A tenant-scoped runner drives them:
+  `python -m app.workers.runner --tenant t1 --user u1 --job all`.
+- Deletion compaction (v0.7) clears a soft-deleted memory's content, normalized
+  content, vector material, and provenance excerpt after a retention window, while
+  preserving the governance tombstone and audit trail. The purge is verified
+  fail-closed. This is auditable content/vector compaction and retrieval-exclusion
+  verification — not crypto-shred, and no physical disk/page erasure claim.
+- Worker runtime (v0.8) makes the jobs operable: leases prevent duplicate concurrent
+  runs, retry/backoff absorbs transient faults, exhausted retries become dead-letter
+  records, and every run is persisted as content-free history. Worker health is at
+  `GET /healthz/workers` (migration `006`).
+- See [docs/background-lifecycle-workers.md](docs/background-lifecycle-workers.md),
+  [docs/deletion-compaction.md](docs/deletion-compaction.md),
+  [docs/worker-runtime.md](docs/worker-runtime.md), and ADRs
+  [010](infra/adr/ADR-010-background-memory-lifecycle-workers.md),
+  [011](infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md),
+  [012](infra/adr/ADR-012-worker-runtime-orchestration.md).
+
+### Retention, legal hold, and consent
+
+- Retention policy packs (sensitivity tier → retention window: `default` / `strict` /
+  `extended`) drive a retention worker that soft-deletes expired or consent-revoked
+  memory before the deletion-verification and compaction pipeline takes over. Off by
+  default; a disabled or dry run records a decision preview without deleting.
+- Legal hold is a fail-closed override that blocks all forgetting and the API delete
+  route (`DELETE` → HTTP 409). It is a preservation control, not crypto-shred.
+- Consent-aware memory records consent state (`granted` / `withdrawn` / `expired` /
+  `not_required`); withdrawn or expired consent makes memory eligible for deletion.
+  Governance state is metadata-driven (migration `007`) and audited; the admin surface
+  is `/api/retention/*`. See [docs/retention-policies.md](docs/retention-policies.md)
+  and [ADR-013](infra/adr/ADR-013-retention-legal-hold-consent.md).
+
+### Loop engineering
+
+MemoryOps models memory as governed loops rather than a passive store. The six core
+loops — Memory Write, Memory Read, Governance, Evaluation, Release Gate, and
+Continuous Learning — each have explicit states, policy gates, audit events, fallback
+behavior, and evidence requirements. Loop definitions live in
+`services/api/app/loops/`, runs and events are exposed through `/api/loops`, and the
+frontend includes a Loops page. See [docs/loop-engineering.md](docs/loop-engineering.md),
 [docs/loop-contracts.md](docs/loop-contracts.md), and
 [docs/release-loop.md](docs/release-loop.md).
 
-## Token Compression Layer (v0.2.1)
+### Token compression (optional)
 
-MemoryOps supports an optional [Headroom](https://github.com/chopratejas/headroom)-powered
-context compression layer. Compression runs **after** policy checks, governance
-filtering, and context composition, and **only** on the composed context block —
-never the raw user message and never before the policy broker. It reduces tokens
-sent to the LLM while preserving MemoryOps invariants (provenance, deletion
-guarantee, tenant isolation, temporary-chat behavior, explainability metadata).
-
-It is **off by default** and **not a dependency** — the app runs without
-`headroom-ai` installed, and any compression failure degrades safely to the
-uncompressed context.
+An optional [Headroom](https://github.com/chopratejas/headroom)-powered context
+compression layer runs after policy checks, governance filtering, and context
+composition, and only on the composed context block — never the raw user message and
+never before the policy broker. It is off by default and not a dependency; any
+compression failure degrades safely to the uncompressed context.
 
 ```bash
 pip install "headroom-ai[all]"            # optional
 export MEMORYOPS_CONTEXT_COMPRESSION=headroom   # default: none
 ```
 
-Each chat response carries a `compression` block with estimated tokens saved and
-the compression ratio. See [docs/token-compression.md](docs/token-compression.md),
+Each chat response carries a `compression` block with estimated tokens saved and the
+compression ratio. See [docs/token-compression.md](docs/token-compression.md),
 [docs/integrations/headroom.md](docs/integrations/headroom.md), and
-[ADR-007](infra/adr/ADR-007-headroom-token-compression.md). Headroom is Apache-2.0;
-MemoryOps integrates it via an adapter and does not vendor its source.
+[ADR-007](infra/adr/ADR-007-headroom-token-compression.md).
 
-## What works as of v0.3 (real data layer)
+### SDK, dashboard, and playground
 
-- Swappable embedding provider (`app/embeddings/`): deterministic offline stub + optional OpenAI.
-- **Hybrid retrieval**: pgvector cosine (`search_candidates`) + keyword overlap, blended by the ranker.
-- Per-memory **`score_breakdown`** + response **`retrieval_mode`** (`hybrid` / `fallback` / `none`).
-- **Enforced** Postgres Row-Level Security (migration `004`, `FORCE` + tenant policy + session GUC).
-- Expanded evals (semantic / keyword / archived / score-breakdown) + new tests; RLS test is DB-guarded.
-
-## What works as of v0.4 (provider LLM adapters)
-
-- Provider-neutral LLM layer (`app/llm/`): deterministic `StubProvider` default +
-  optional OpenAI/Anthropic/Gemini adapters, selected by `MEMORYOPS_LLM_PROVIDER`.
-- **Structured memory intelligence**: schema-validated extraction + minimal conflict
-  detection, with prompt registry and deterministic heuristic fallback.
-- Invalid JSON / provider failure / timeout degrades to the heuristic and never
-  blocks chat; LLM output is advisory and cannot override the policy broker.
-- New observability events (`llm_provider_call`, `llm_provider_failure`,
-  `structured_output_invalid`, `llm_fallback_used`, `memory_extraction_structured`,
-  `conflict_detection_result`) + `structured`/`conflict` evals; tests need no API keys.
-
-## What works as of v0.5 (governance UI + memory control plane)
-
-- Browser control plane over the governed lifecycle: `/memories` (filterable
-  inventory), `/memories/[id]` (detail + provenance + per-memory audit timeline +
-  inline edit), `/governance` (approval queue + recorded policy decisions),
-  `/audit` (tenant-wide append-only history).
-- Additive read routes: `GET /api/memories/{id}`, `/{id}/provenance`,
-  `/{id}/audit`, plus a `memory_id` filter on `/api/audit`. Approve/reject/edit/
-  archive/restore/delete reuse the existing PATCH/DELETE — every action is audited
-  and the policy broker stays authoritative.
-- Deletion guarantee holds in the UI: deleted memories are never listed or shown
-  as active. Provenance is metadata only (no embeddings/secrets).
-- See [docs/governance-ui.md](docs/governance-ui.md),
-  [docs/memory-control-plane.md](docs/memory-control-plane.md), and
-  [ADR-009](infra/adr/ADR-009-memory-control-plane.md).
-
-## What works as of v0.6 (background memory lifecycle workers)
-
-- Background workers (`services/api/app/workers/`) maintain memory **after**
-  capture, off the chat request path: **decay** (demote aged/low-confidence
-  memory), **archive** (retire stale, non-pinned, not-recently-used memory),
-  **conflict scan** (flag contradictions as review candidates), **deletion
-  verification** (prove soft-deleted memory stays unreachable), and proposal-only
-  **reflection** (off by default).
-- A tenant-scoped `runner` drives them:
-  `python -m app.workers.runner --tenant t1 --user u1 --job all` (returns a
-  structured `WorkerRunReport`; non-zero exit on a failed job or deletion finding).
-- Every job is tenant scoped, idempotent, retry-safe, and audited; none resurrects
-  deleted memory and none bypasses the policy broker. A worker failure never
-  blocks chat.
-- See [docs/background-lifecycle-workers.md](docs/background-lifecycle-workers.md),
-  [docs/memory-decay-policy.md](docs/memory-decay-policy.md),
-  [docs/deletion-verification.md](docs/deletion-verification.md), and
-  [ADR-010](infra/adr/ADR-010-background-memory-lifecycle-workers.md).
-
-## What works as of v0.7 (deletion compaction + vector purge verification)
-
-- A sixth lifecycle job — **deletion compaction** — clears a soft-deleted memory's
-  content, normalized content, embedding/vector material, and provenance excerpt
-  (after a retention window), while **preserving the governance tombstone** (id,
-  tenant/user, `status='deleted'`, `deleted_at`, `source.kind`) and the full audit
-  trail. Run it with
-  `python -m app.workers.runner --tenant t1 --user u1 --job deletion_compaction`.
-- The purge is **verified fail-closed**: a still-reachable id, intact material, a
-  missing tombstone, or a verification-path error all record evidence and flag the
-  run — never a silent pass.
-- Honest scope: this is **auditable content/vector compaction + retrieval-exclusion
-  verification**. It is **not** crypto-shred and does **not** claim physical
-  disk/page erasure or pgvector reindex orchestration.
-- See [docs/deletion-compaction.md](docs/deletion-compaction.md),
-  [docs/vector-purge-verification.md](docs/vector-purge-verification.md), and
-  [ADR-011](infra/adr/ADR-011-physical-deletion-compaction-vector-purge.md).
-
-## What works as of v0.8 (worker runtime + scheduled orchestration)
-
-- The lifecycle jobs are now **operable**, not just callable: a **lease/lock**
-  prevents duplicate concurrent runs of a scope, a **retry/backoff** policy
-  absorbs transient faults, exhausted retries become **dead-letter** records, and
-  every run is persisted as content-free **run history**.
-- A thin **scheduler** drives the orchestrator over explicit `"tenant:user"`
-  scopes; `services/worker/main.py` now runs the real lifecycle workers.
-- **Worker health is visible** at `GET /healthz/workers` (recent runs, dead-letter
-  / failure counts, last run per scope). New migration `006_worker_runtime.sql`.
-- Leases expire, so a crashed worker never deadlocks a scope; multiple replicas
-  are safe (the lease arbitrates). No queue/broker added.
-- See [docs/worker-runtime.md](docs/worker-runtime.md) and
-  [ADR-012](infra/adr/ADR-012-worker-runtime-orchestration.md).
-
-## What works as of v0.9 (public results dashboard + evidence explorer)
-
-- A **read-only public results dashboard** ([`apps/results-dashboard/`](apps/results-dashboard))
-  built with Streamlit makes MemoryOps understandable and inspectable: overview,
-  version timeline, memory lifecycle, **deletion compaction proof**, worker
-  runtime results, audit evidence, validation results, and honest limitations.
-- It is **demo/evidence UI only** — static demo JSON, no live DB, no secrets, no
-  auth, no writes. The Next.js app in `apps/web` remains the official product UI.
-- Run it with `cd apps/results-dashboard && pip install -r requirements.txt &&
-  streamlit run app.py`. See [docs/results-dashboard.md](docs/results-dashboard.md).
-
-## What works as of v0.10 (retention + legal hold + consent-aware memory)
-
-- **Retention policy packs** (sensitivity tier → retention window: `default` /
-  `strict` / `extended`) drive a new `retention` lifecycle worker that soft-deletes
-  expired or consent-revoked memory — then the v0.7 deletion-verification +
-  compaction pipeline takes over. **OFF by default**; a disabled/dry run records
-  an admin-readable decision preview without deleting.
-- **Legal hold** is a fail-closed override that blocks **all** forgetting (decay,
-  archive, retention, compaction) and the API delete route (`DELETE` → HTTP 409).
-  A held memory's content is *preserved* for discovery — a preservation control,
-  **not** crypto-shred.
-- **Consent-aware memory** records consent (`granted`/`withdrawn`/`expired`/
-  `not_required`); withdrawn/expired consent makes memory eligible for deletion.
-  Pins exempt from decay/archive; protection exempts from retention auto-deletion.
-- Governance state is metadata-driven (new migration `007_…`) and every change is
-  audited. Admin surface: `/api/retention/*`. See
-  [docs/retention-policies.md](docs/retention-policies.md) and
-  [ADR-013](infra/adr/ADR-013-retention-legal-hold-consent.md).
-
-## What works as of v0.11 (assistant SDK + integration examples)
-
-- A typed **Python SDK** ([`packages/memoryops-sdk/`](packages/memoryops-sdk))
-  wraps the governed HTTP API (chat, memories, retention/legal-hold/consent,
-  audit, metrics, loops, health) and injects the tenant/user scope on every call.
-  The **server stays authoritative** for all governance — the SDK adds none of
-  its own.
-- Runnable **integration examples**: quickstart, a FastAPI assistant endpoint, a
-  RAG assistant (governed user memory + your RAG docs), and an agent-memory tool.
-- Typed errors (`LegalHoldError`, `NotFoundError`, `APIError`) and an injectable
-  `httpx.Client` for in-process testing (the SDK is tested against the real app).
-- `pip install -e packages/memoryops-sdk`. See
+- A typed [Python SDK](packages/memoryops-sdk) wraps the governed HTTP API (chat,
+  memories, retention / legal-hold / consent, audit, metrics, loops, health) and
+  injects the tenant/user scope on every call. The server stays authoritative for all
+  governance — the SDK adds none. Runnable integration examples cover a quickstart, a
+  FastAPI assistant endpoint, a RAG assistant, and an agent-memory tool. See
   [docs/assistant-sdk.md](docs/assistant-sdk.md) and
   [ADR-014](infra/adr/ADR-014-assistant-sdk.md).
+- The read-only [results dashboard](apps/results-dashboard) (Streamlit) is the static
+  evidence view: version timeline, memory lifecycle, deletion-compaction proof, worker
+  runtime results, audit evidence, validation results, and honest limitations. See
+  [docs/results-dashboard.md](docs/results-dashboard.md).
+- The interactive [playground](apps/playground) drives the real governed pipeline
+  in-process against a fresh in-memory store per session — capture, ask a question
+  that uses memory, apply a legal hold / withdraw consent / delete / run the lifecycle
+  workers, and watch the audit trace and assistant behavior change live. No database,
+  auth, secrets, or network. See [docs/playground.md](docs/playground.md) and the
+  [live demo](https://memoryops-ai-production.up.railway.app).
 
-## What works as of v0.12 (interactive playground + hosted demo)
+---
 
-- An **interactive public Playground** ([`apps/playground/`](apps/playground))
-  that *drives the real governed pipeline in-process* — capture → ask a question
-  that uses memory → apply a legal hold / withdraw consent / delete / run the
-  lifecycle workers → watch the audit trace and assistant behavior change live.
-- **Safe to host:** a fresh **in-memory** store per browser session — no database,
-  no auth, no secrets, no network (stub LLM + embeddings), no real user data. It
-  drives the same `services/api` governance code the product uses, so behavior is
-  faithful, not a reimplementation.
-- The v0.9 [results dashboard](apps/results-dashboard) remains the read-only
-  **evidence** view; the playground is the public **entry point**.
-- Run it: `cd apps/playground && pip install -r requirements.txt &&
-  streamlit run streamlit_app.py`. Screenshots/GIF + the hosted demo link are the
-  operator-run final step (see [docs/images/playground/](docs/images/playground/)).
-  See [docs/playground.md](docs/playground.md).
+## Status and roadmap
 
-## What works as of v1.0 (production-ready governed memory runtime)
+v1.0 is the stable, production-ready governed memory runtime. The public HTTP API and
+Python SDK are declared stable under a `1.x` additive-compatibility promise
+([docs/api-stability.md](docs/api-stability.md)); package versions are `1.0.0`.
+Release-readiness is documented in [known limitations](docs/limitations.md), the
+[production-readiness map](docs/production-readiness.md), and the
+[CHANGELOG](CHANGELOG.md).
 
-- **Stable contracts** — the public HTTP API and Python SDK are declared stable
-  under a `1.x` additive-compatibility promise
-  ([docs/api-stability.md](docs/api-stability.md)); package versions are `1.0.0`.
-- **Release-readiness docs** — a consolidated [known-limitations](docs/limitations.md)
-  page, a [production-readiness](docs/production-readiness.md) map (each invariant
-  → where enforced; production-capable vs demo-only), and a full
-  [CHANGELOG](CHANGELOG.md).
-- v1.0 is **stabilization + documentation**: no behavior changes vs v0.12.
+Planned beyond v1.0:
 
-## Roadmap
-
-- **v0.7** — physical deletion compaction + vector purge verification ✅
-- **v0.8** — worker runtime + scheduled lifecycle orchestration ✅
-- **v0.9** — public results dashboard + evidence explorer ✅
-- **v0.10** — retention policies + legal hold + consent-aware memory ✅
-- **v0.11** — assistant SDK + integration examples ✅
-- **v0.12** — interactive playground + hosted demo + public screenshots ✅
-- **v1.0** — production-ready governed memory runtime ✅
-
-## Beyond v1.0
-
-- Consent *capture* at the UI/SDK edge; cross-tenant retention scheduling.
-- Hard purge / crypto-shred and pgvector index reclamation (beyond v0.7's
-  auditable compaction).
-- Optional queue/cron backend behind the orchestrator interface; auto-discovered
-  scope enumeration.
-- Observability + economics, AI PR review runtime, deployment hardening.
-- Operator step to finish the public launch: host the playground + wire the live
-  demo link and recorded GIF into the hero (see [docs/images/playground/](docs/images/playground/)).
+- Consent capture at the UI/SDK edge; cross-tenant retention scheduling.
+- Hard purge / crypto-shred and pgvector index reclamation (beyond v0.7's auditable
+  compaction).
+- Optional queue/cron backend behind the orchestrator interface; auto-discovered scope
+  enumeration.
+- Observability and economics, AI PR review runtime, deployment hardening.
 
 See [docs/rollout.md](docs/rollout.md) and the build phases in [CLAUDE.md](CLAUDE.md).
 
 ---
 
-## Agentic Engineering Layer
+## Agentic engineering layer
 
-MemoryOps AI includes an agentic engineering layer **around** the core memory
-system (never on the chat request path). It is inspired by three systems:
+MemoryOps AI includes an agentic engineering layer around the core memory system,
+never on the chat request path. It draws on three systems:
 
-1. **Hermes Agent** — used as an operator/developer assistant layer for release
-   checks, invariant audits, and guided project workflows. See
-   [`.hermes/skills/`](.hermes/skills/) and [docs/integrations/hermes-agent.md](docs/integrations/hermes-agent.md).
-2. **agentic-swe-kit** — used as a phase-gate framework for production engineering.
-   MemoryOps maps to lifecycle phases covering cognitive design, memory
-   architecture, evaluation, observability, security, reliability, governance,
-   CI/CD for AI, and continuous learning. See
+1. **Hermes Agent** — an operator/developer assistant layer for release checks,
+   invariant audits, and guided project workflows. See [`.hermes/skills/`](.hermes/skills/)
+   and [docs/integrations/hermes-agent.md](docs/integrations/hermes-agent.md).
+2. **agentic-swe-kit** — a phase-gate framework for production engineering, covering
+   cognitive design, memory architecture, evaluation, observability, security,
+   reliability, governance, CI/CD for AI, and continuous learning. See
    [docs/agentic-swe-kit-map.md](docs/agentic-swe-kit-map.md) and
    [docs/phase-gates/](docs/phase-gates/).
-3. **AI PR Review Agent** — the pattern behind the **PR Invariant Evidence Gate**.
-   Every PR that touches memory, policy, retrieval, deletion, security, migrations,
-   or API contracts must provide evidence (tests / evals / docs / ADRs). See
+3. **AI PR Review Agent** — the pattern behind the PR Invariant Evidence Gate. Every
+   PR that touches memory, policy, retrieval, deletion, security, migrations, or API
+   contracts must provide evidence (tests / evals / docs / ADRs). See
    [scripts/pr_invariant_gate.py](scripts/pr_invariant_gate.py),
    [.github/workflows/pr-invariant-evidence-gate.yml](.github/workflows/pr-invariant-evidence-gate.yml),
    and [docs/ai-pr-review-policy.md](docs/ai-pr-review-policy.md).
 
-The goal: MemoryOps is not just an AI memory feature — it is a governed engineering
-system with release discipline, review gates, and operational safety. Overview:
-[docs/integrations/README.md](docs/integrations/README.md).
+Overview: [docs/integrations/README.md](docs/integrations/README.md).
 
 ## Documentation
 

--- a/apps/playground/streamlit_app.py
+++ b/apps/playground/streamlit_app.py
@@ -96,15 +96,15 @@ def _active(repo, user_id):
 def _badges(memory) -> str:
     out = []
     if gov.is_legal_hold(memory):
-        out.append("🔒 legal hold")
+        out.append("legal hold")
     if gov.is_pinned(memory):
-        out.append("📌 pinned")
+        out.append("pinned")
     if gov.is_protected(memory):
-        out.append("🛡 protected")
+        out.append("protected")
     consent = gov.consent_status(memory)
     if consent != gov.ConsentStatus.granted:
-        out.append(f"⚠ consent:{consent}")
-    return "  ".join(out)
+        out.append(f"consent: {consent}")
+    return " · ".join(out)
 
 
 # ── pages ─────────────────────────────────────────────────────────────────────
@@ -198,7 +198,7 @@ def page_memories() -> None:
     st.divider()
     st.markdown("**Run the lifecycle workers** (decay · archive · retention · "
                 "deletion verification · compaction) over this session:")
-    if st.button("▶ Run lifecycle workers"):
+    if st.button("Run lifecycle workers"):
         report = run_jobs(repo, tenant_id=TENANT, user_id=user_id, jobs=["all"],
                           trace_id=_trace())
         st.success(f"Ran {len(report.results)} jobs · "
@@ -248,19 +248,19 @@ def page_audit() -> None:
 
 # ── shell ───────────────────────────────────────────────────────────────────
 def main() -> None:
-    st.set_page_config(page_title="MemoryOps AI — Playground", page_icon="🧠", layout="wide")
+    st.set_page_config(page_title="MemoryOps AI — Playground", layout="wide")
     repo, _, _, user_id = _session()
 
-    st.sidebar.title("🧠 MemoryOps Playground")
+    st.sidebar.title("MemoryOps Playground")
     st.sidebar.caption("Interactive public demo (v0.12) — runs the real governed "
                        "pipeline against a fresh in-memory store, per session.")
     st.sidebar.markdown(f"**Session scope:** `{TENANT} / {user_id}`")
     st.sidebar.metric("Active memories", len(_active(repo, user_id)))
-    if st.sidebar.button("🌱 Seed demo memories"):
+    if st.sidebar.button("Seed demo memories"):
         for msg in SEED_MESSAGES:
             _chat(msg)
         st.rerun()
-    if st.sidebar.button("♻ Reset session"):
+    if st.sidebar.button("Reset session"):
         _reset()
         st.rerun()
     st.sidebar.divider()

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -93,16 +93,23 @@ Query: `tenant_id` (req), `user_id` (opt), `memory_id` (opt), `limit` (opt, ≤1
 Returns `AuditEvent[]` (append-only), newest first.
 
 ## GET /api/metrics
-Query: `tenant_id` (req). Returns counts:
-`{ total_memories, by_status, audit_events, by_action }`.
+Query: `tenant_id` (req). Returns per-tenant business counts:
+`{ total_memories, by_status, audit_events, by_action }`. (Distinct from the
+process-wide Prometheus surface at `GET /metrics` — see Ops.)
 
 ## POST /api/evals/run
 Runs the invariant eval harness in-process. Returns
 `{ total, passed, failed, pass_rate, results[] }`.
 
 ## Ops
-- `GET /healthz` → `{ status, version }`
+- `GET /healthz` → `{ status, version, uptime_seconds, metrics_enabled }`
+- `GET /healthz/workers` → content-free worker run history (dead-letter / failure counts)
 - `GET /readyz` → `{ ready, storage, llm_provider, embeddings_provider, embedding_dim, detail }`
+- `GET /metrics` → **Prometheus text exposition** (v1.1; format `0.0.4`). Process-wide,
+  content-free, low-cardinality (no `tenant_id`/`user_id` labels): HTTP traffic,
+  retrieval latency/mode, policy-decision rate, worker run counts. Toggle with
+  `MEMORYOPS_METRICS_ENABLED` (returns `404` when disabled). See
+  [docs/observability.md](observability.md), ADR-015.
 - Every response carries an `x-trace-id` header.
 
 ## Loop Engineering (v0.3.1)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,76 @@
+# Observability
+
+MemoryOps AI exposes four observability streams:
+
+| Stream | Where | Shape |
+|--------|-------|-------|
+| Structured logs | stdout (`app/core/logging.py`) | JSON, secret-redacted, per-request `trace_id` |
+| Audit log | `GET /api/audit` | Append-only governance events |
+| Business metrics | `GET /api/metrics` | Per-tenant JSON counts (writes, blocks, deletes, retrievals, audit) |
+| **Prometheus metrics** | **`GET /metrics`** | **Process-wide text exposition for a Prometheus/Grafana scrape** |
+| Worker health | `GET /healthz/workers` | Content-free worker run history |
+
+This page documents the Prometheus surface (v0.13, [ADR-015](../infra/adr/ADR-015-prometheus-metrics-exposition.md)).
+
+## `GET /metrics`
+
+Returns Prometheus text exposition (format `0.0.4`). **Process-wide, content-free,
+low-cardinality** — there are no `tenant_id` / `user_id` labels and no message
+content. Dependency-free (hand-rolled in `app/observability/`), so it works with
+no infra and no API keys, like the rest of the stack.
+
+Toggle with `MEMORYOPS_METRICS_ENABLED` (default `true`; `0`/`false`/`no` disables
+and returns `404`).
+
+### Metrics
+
+| Metric | Type | Labels | Meaning |
+|--------|------|--------|---------|
+| `memoryops_http_requests_total` | counter | `route`, `method`, `status_class` | HTTP requests; `route` is the matched route *template* |
+| `memoryops_http_request_duration_ms` | histogram | `route`, `method` | Request latency (ms) |
+| `memoryops_retrieval_total` | counter | `mode` | Memory reads by mode (`hybrid`/`fallback`/`none`) |
+| `memoryops_retrieval_duration_ms` | histogram | — | Read-path latency (retrieve+rank+compose, ms) |
+| `memoryops_policy_decisions_total` | counter | `decision` | Policy broker decisions (`SAVE`/`BLOCK`/…) |
+| `memoryops_worker_runs` | gauge | `status` | Recent worker runs by status (pull-derived) |
+| `memoryops_worker_dead_letter_count` | gauge | — | Dead-lettered worker runs in recent history |
+| `memoryops_worker_failed_count` | gauge | — | Failed worker runs in recent history |
+
+### Useful derived signals
+
+- **Policy block rate** — `memoryops_policy_decisions_total{decision="BLOCK"}` ÷
+  `sum(memoryops_policy_decisions_total)`.
+- **Retrieval degradation rate** — `memoryops_retrieval_total{mode="fallback"}` ÷
+  `sum(memoryops_retrieval_total)` (invariant #4 in action).
+- **Request latency p95** — `histogram_quantile(0.95, rate(memoryops_http_request_duration_ms_bucket[5m]))`.
+
+### Design guarantees
+
+- **Graceful degradation (invariant #4)** — recording a metric is no-throw and can
+  never block a request. The scrape handler degrades to partial output (worker
+  gauges omitted) if the repository is unavailable; it never returns `500`.
+- **Worker metrics are pull-derived** — workers run in a separate process, so the
+  handler reads the content-free `summarize_runtime_health(repo)` at scrape time
+  rather than relying on in-process counters.
+- **No PII / no secrets** — labels are bounded enums and route templates only.
+
+## Scraping with Prometheus
+
+```yaml
+scrape_configs:
+  - job_name: memoryops-api
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["api:8000"]
+```
+
+## Liveness / readiness
+
+- `GET /healthz` — `{status, version, uptime_seconds, metrics_enabled}`.
+- `GET /readyz` — repository + provider readiness rollup.
+- `GET /healthz/workers` — worker run history (dead-letter / failure counts).
+
+## Not (yet) included
+
+- OpenTelemetry / distributed tracing (deferred).
+- Token/embedding cost economics.
+- An admin observability dashboard UI.

--- a/docs/phase-gates/phase-10-observability.md
+++ b/docs/phase-gates/phase-10-observability.md
@@ -3,14 +3,18 @@
 **Question:** Traces, token cost, alerts, prompt inspection.
 
 ## MemoryOps mapping
-Two streams: append-only audit log (business events) and structured JSON logs with
-a secret-redacting formatter + per-request `trace_id`. Metrics are derived and
-surfaced on the admin dashboard and `GET /api/metrics`.
+Streams: append-only audit log (business events); structured JSON logs with a
+secret-redacting formatter + per-request `trace_id`; per-tenant business metrics
+at `GET /api/metrics`; and a process-wide **Prometheus exposition** at `GET /metrics`
+(v0.13, content-free, dependency-free; see ADR-015).
 
 ## Gate (must be true to pass)
 - Every lifecycle action emits an audit event.
 - Every request log line carries `trace_id` and never leaks secrets.
 - Metrics (writes, blocks, deletes, retrievals, audit count) are queryable.
+- Operational signals are scrapeable in Prometheus format at `GET /metrics`
+  (HTTP traffic, retrieval latency/mode, policy-decision rate, worker runs),
+  content-free and low-cardinality.
 - Loop runs/events expose operational traces for memory.write, memory.read,
   memory.governance, memory.evaluation, release.gate, and learning.continuous.
 - Token/cost signals are observable: context compression emits structured
@@ -22,11 +26,13 @@ surfaced on the admin dashboard and `GET /api/metrics`.
 - `services/api/app/services/audit.py`, `routes/audit.py`
 - `services/api/app/loops/`, `routes/loops.py`
 - `services/api/app/compression/metrics.py`, `services/api/app/services/gateway.py`
+- `services/api/app/observability/` (registry + instrument), `routes/metrics_prometheus.py`,
+  `tests/test_metrics_endpoint.py`, [docs/observability.md](../observability.md)
 - [infra/observability/README.md](../../infra/observability/README.md)
-- [ADR-004 observability](../../infra/adr/ADR-004-observability.md), [ADR-007 compression](../../infra/adr/ADR-007-headroom-token-compression.md)
+- [ADR-004 observability](../../infra/adr/ADR-004-observability.md), [ADR-007 compression](../../infra/adr/ADR-007-headroom-token-compression.md), [ADR-015 Prometheus metrics](../../infra/adr/ADR-015-prometheus-metrics-exposition.md)
 
-## Gaps to close (→ v0.3+)
-- OpenTelemetry traces → Tempo/Jaeger; Prometheus/Grafana metrics; Langfuse LLM
-  traces; per-write/retrieval cost attribution.
+## Gaps to close (→ later)
+- OpenTelemetry traces → Tempo/Jaeger; Langfuse LLM traces; per-write/retrieval
+  cost attribution (economics). Prometheus/Grafana metrics: ✅ done (v0.13).
 
-## Status: 🟡 Partial (logs + audit + metrics done; OTel/Prom/Langfuse roadmap)
+## Status: 🟡 Partial (logs + audit + business + Prometheus metrics done; OTel/Langfuse/economics roadmap)

--- a/infra/adr/ADR-015-prometheus-metrics-exposition.md
+++ b/infra/adr/ADR-015-prometheus-metrics-exposition.md
@@ -1,0 +1,63 @@
+# ADR-015 — Prometheus Metrics Exposition
+
+- Status: Accepted (v0.13)
+- Date: 2026-06-24
+- Supersedes: none
+- Related: ADR-004 (observability), ADR-012 (worker runtime), ADR-014 (assistant SDK)
+
+## Context
+
+Through v1.0 MemoryOps had three observability streams: structured JSON logs with a
+secret-redacting formatter + per-request `trace_id` ([core/logging.py](../../services/api/app/core/logging.py)),
+an append-only audit log, and a **per-tenant business-metrics JSON** surface at
+`GET /api/metrics` ([routes/audit.py](../../services/api/app/routes/audit.py) →
+`Repository.metrics(tenant_id)`). Worker activity is visible at `GET /healthz/workers`.
+
+What was missing is the de-facto standard a monitoring stack scrapes: a
+**process-wide Prometheus exposition endpoint** for operational signals (HTTP
+traffic, retrieval latency, policy-decision rates, worker run counts). The
+phase-10 gate listed "Prometheus/Grafana metrics" as an open v0.3+ gap. The per-
+tenant JSON surface is the wrong shape for this — it is business-scoped, requires a
+`tenant_id`, and is not Prometheus text.
+
+## Decision
+
+Add a **dependency-free** Prometheus text exposition at `GET /metrics`.
+
+- **No new dependency.** The metrics primitives (`Counter`, `Gauge`, `Histogram`)
+  and the Prometheus 0.0.4 text renderer are hand-rolled in
+  `app/observability/registry.py`. This preserves the repo's lean, offline-first,
+  no-keys-required posture (6 runtime deps). `prometheus_client`/OpenTelemetry were
+  rejected as runtime deps for this reason.
+- **Content-free, low-cardinality labels only.** Labels are bounded enums / route
+  templates: `route` (the matched FastAPI route *template*, not the raw URL),
+  `method`, `status_class` (`2xx`/`4xx`/`5xx`), policy `decision` (the `Decision`
+  enum), retrieval `mode` (`hybrid`/`fallback`/`none`), worker run `status`. There
+  are **no `tenant_id` / `user_id` labels** and no message content — both for
+  privacy and to keep cardinality finite.
+- **Graceful degradation (invariant #4).** All recording goes through no-throw
+  helpers in `app/observability/instrument.py`; instrumenting a request can never
+  raise into the request/read/write path. The scrape handler degrades to partial
+  output (worker gauges omitted) if the repository is unavailable, never a 500.
+- **Worker metrics are pull-derived.** Workers run in a separate process, so their
+  activity is invisible to the API's in-process counters. The scrape handler reads
+  the content-free `summarize_runtime_health(repo)` at scrape time instead.
+- **Additive.** No `services/api` behavior changes. The existing per-tenant
+  `GET /api/metrics` JSON stays as-is; the new endpoint lives at root `/metrics`
+  (standard scrape path, no collision). Toggle with `MEMORYOPS_METRICS_ENABLED`.
+
+## Consequences
+
+- A Prometheus/Grafana stack can scrape MemoryOps with zero code, and
+  `memoryops_policy_decisions_total{decision="BLOCK"}` / total yields a live
+  policy-block rate, closing the metrics half of the phase-10 gap.
+- The metrics surface is intentionally minimal and dependency-free; it is **not**
+  OpenTelemetry tracing (deferred) and carries no token/cost economics (Phase 2).
+- Hand-rolled primitives mean we own the exposition-format correctness; this is
+  covered by `tests/test_metrics_endpoint.py`.
+
+## Out of scope
+
+- OpenTelemetry / distributed tracing.
+- Token/embedding cost economics.
+- An admin observability dashboard UI.

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -18,6 +18,12 @@ class Settings(BaseSettings):
     service_name: str = "memoryops-api"
     log_level: str = "INFO"
 
+    # Observability (v0.13, ADR-015). Process-wide Prometheus metrics exposition at
+    # GET /metrics. Content-free, low-cardinality, no new dependency. ON by default;
+    # toggle with MEMORYOPS_METRICS_ENABLED. Distinct from the per-tenant business
+    # metrics JSON at GET /api/metrics.
+    metrics_enabled: bool = True
+
     # Storage backend: "memory" runs with no infra (default for dev/tests),
     # "postgres" uses SQLAlchemy + pgvector.
     storage: Literal["memory", "postgres"] = "memory"
@@ -122,6 +128,8 @@ def get_settings() -> Settings:
     import os
 
     overrides = {}
+    if (val := os.getenv("MEMORYOPS_METRICS_ENABLED")) is not None:
+        overrides["metrics_enabled"] = val.lower() not in ("0", "false", "no")
     if (val := os.getenv("MEMORYOPS_STORAGE")) in ("memory", "postgres"):
         overrides["storage"] = val
     if (val := os.getenv("MEMORYOPS_EMBEDDING_PROVIDER")) in ("stub", "heuristic", "openai"):

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -16,7 +16,8 @@ from fastapi.responses import JSONResponse
 from . import __version__
 from .core.config import get_settings
 from .core.logging import clear_request_context, get_logger, set_request_context, setup_logging
-from .routes import audit, chat, evals, health, loops, memories, retention
+from .observability import observe_http
+from .routes import audit, chat, evals, health, loops, memories, metrics_prometheus, retention
 
 settings = get_settings()
 setup_logging(settings.log_level)
@@ -42,14 +43,21 @@ async def request_context(request: Request, call_next):
     request.state.trace_id = trace_id
     set_request_context(trace_id)
     start = time.monotonic()
+    status_code = 500
     try:
         response = await call_next(request)
+        status_code = response.status_code
     finally:
         latency_ms = int((time.monotonic() - start) * 1000)
         logger.info(
             f"{request.method} {request.url.path}",
             extra={"event": "http_request", "latency_ms": latency_ms, "status": "done"},
         )
+        # Record process-wide metrics with a bounded route label (the matched
+        # route *template*, not the raw URL, to keep cardinality finite). No-throw.
+        route = request.scope.get("route")
+        route_label = getattr(route, "path", None) or "__unmatched__"
+        observe_http(route_label, request.method, status_code, latency_ms)
         clear_request_context()
     response.headers["x-trace-id"] = trace_id
     return response
@@ -65,6 +73,7 @@ async def unhandled_exception(request: Request, exc: Exception):
 
 
 app.include_router(health.router)
+app.include_router(metrics_prometheus.router)
 app.include_router(chat.router)
 app.include_router(memories.router)
 app.include_router(retention.router)

--- a/services/api/app/observability/__init__.py
+++ b/services/api/app/observability/__init__.py
@@ -1,0 +1,24 @@
+"""Cross-cutting observability: a dependency-free Prometheus metrics surface.
+
+Distinct from ``app/workers/metrics.py`` (worker run-result summaries) and from
+``GET /api/metrics`` (per-tenant business-metrics JSON). This package exposes
+process-wide, content-free operational signals for a Prometheus/Grafana scrape at
+``GET /metrics``. See ADR-015.
+"""
+
+from .instrument import (
+    collect_worker_gauges,
+    observe_http,
+    observe_retrieval,
+    record_policy_decision,
+)
+from .registry import REGISTRY, render_prometheus
+
+__all__ = [
+    "REGISTRY",
+    "render_prometheus",
+    "observe_http",
+    "observe_retrieval",
+    "record_policy_decision",
+    "collect_worker_gauges",
+]

--- a/services/api/app/observability/instrument.py
+++ b/services/api/app/observability/instrument.py
@@ -1,0 +1,67 @@
+"""No-throw instrumentation helpers.
+
+Call sites use these instead of touching the registry directly. Every helper
+swallows exceptions (logged at debug) so recording a metric can never raise into
+a request, read, or write path (graceful degradation, invariant #4).
+"""
+
+from __future__ import annotations
+
+from ..core.logging import get_logger
+from . import registry as m
+
+logger = get_logger("memoryops.observability")
+
+
+def _status_class(status_code: int) -> str:
+    try:
+        return f"{status_code // 100}xx"
+    except Exception:  # noqa: BLE001
+        return "5xx"
+
+
+def observe_http(route: str, method: str, status_code: int, duration_ms: float) -> None:
+    try:
+        m.HTTP_REQUESTS_TOTAL.inc(
+            {"route": route, "method": method, "status_class": _status_class(status_code)}
+        )
+        m.HTTP_REQUEST_DURATION_MS.observe(duration_ms, {"route": route, "method": method})
+    except Exception:  # noqa: BLE001 — never break the request path
+        logger.debug("observe_http failed", extra={"event": "metric_drop"})
+
+
+def observe_retrieval(mode: str, duration_ms: float) -> None:
+    try:
+        m.RETRIEVAL_TOTAL.inc({"mode": mode})
+        m.RETRIEVAL_DURATION_MS.observe(duration_ms)
+    except Exception:  # noqa: BLE001
+        logger.debug("observe_retrieval failed", extra={"event": "metric_drop"})
+
+
+def record_policy_decision(decision: str) -> None:
+    try:
+        m.POLICY_DECISIONS_TOTAL.inc({"decision": decision})
+    except Exception:  # noqa: BLE001
+        logger.debug("record_policy_decision failed", extra={"event": "metric_drop"})
+
+
+def collect_worker_gauges(repo, limit: int = 500) -> None:
+    """Refresh pull-derived worker gauges from persisted run history at scrape time.
+
+    Workers run in a separate process, so their activity is not visible to the
+    API's in-process counters; we read the content-free run-history summary
+    instead. Best-effort — on any error (e.g. DB unavailable) the gauges are left
+    cleared so ``/metrics`` degrades to omitting worker signals, never a 500.
+    """
+    # Import here to avoid a heavy import at module load for the common path.
+    from ..workers.orchestrator import summarize_runtime_health
+
+    m.WORKER_RUNS.reset()
+    try:
+        summary = summarize_runtime_health(repo, limit=limit)
+        for status, count in summary.get("by_status", {}).items():
+            m.WORKER_RUNS.set(count, {"status": status})
+        m.WORKER_DEAD_LETTER.set(summary.get("dead_letter_count", 0))
+        m.WORKER_FAILED.set(summary.get("failed_count", 0))
+    except Exception:  # noqa: BLE001 — worker metrics are best-effort
+        logger.debug("collect_worker_gauges failed", extra={"event": "metric_drop"})

--- a/services/api/app/observability/registry.py
+++ b/services/api/app/observability/registry.py
@@ -1,0 +1,236 @@
+"""Dependency-free, in-process metrics registry + Prometheus text exposition.
+
+Deliberately hand-rolled (no ``prometheus_client`` / OpenTelemetry dependency) to
+preserve the repo's lean, offline-first posture (invariant: works with no infra,
+no keys). The registry holds process-wide, **content-free, low-cardinality**
+signals only — labels are bounded enums/route templates, never ``tenant_id`` /
+``user_id`` / message content (privacy + cardinality).
+
+All instances are process-global and thread-safe. Recording is cheap and must
+never raise into a request path — call sites should go through ``instrument.py``,
+which wraps every record in a no-throw guard (graceful degradation, invariant #4).
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import defaultdict
+
+# Latency buckets in milliseconds (cumulative "less-than-or-equal" upper bounds).
+# Tuned for in-process governed-memory latencies (sub-ms to a few seconds).
+LATENCY_BUCKETS_MS: tuple[float, ...] = (5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000)
+
+# A label set is an ordered tuple of (name, value) pairs, kept sorted so the same
+# logical labels always hash to the same key regardless of call-site order.
+LabelKey = tuple[tuple[str, str], ...]
+
+
+def _key(labels: dict[str, str] | None) -> LabelKey:
+    if not labels:
+        return ()
+    return tuple(sorted((str(k), str(v)) for k, v in labels.items()))
+
+
+class Counter:
+    """Monotonically increasing value, partitioned by label set."""
+
+    def __init__(self, name: str, help_text: str) -> None:
+        self.name = name
+        self.help_text = help_text
+        self._values: dict[LabelKey, float] = defaultdict(float)
+        self._lock = threading.Lock()
+
+    def inc(self, labels: dict[str, str] | None = None, amount: float = 1.0) -> None:
+        with self._lock:
+            self._values[_key(labels)] += amount
+
+    def samples(self) -> list[tuple[LabelKey, float]]:
+        with self._lock:
+            return list(self._values.items())
+
+
+class Gauge:
+    """Point-in-time value that can go up or down, partitioned by label set.
+
+    Used for pull-derived scrape-time values (e.g. worker run history), so it
+    supports ``set`` and a ``reset`` to clear stale label sets before a refresh.
+    """
+
+    def __init__(self, name: str, help_text: str) -> None:
+        self.name = name
+        self.help_text = help_text
+        self._values: dict[LabelKey, float] = {}
+        self._lock = threading.Lock()
+
+    def set(self, value: float, labels: dict[str, str] | None = None) -> None:
+        with self._lock:
+            self._values[_key(labels)] = value
+
+    def reset(self) -> None:
+        with self._lock:
+            self._values.clear()
+
+    def samples(self) -> list[tuple[LabelKey, float]]:
+        with self._lock:
+            return list(self._values.items())
+
+
+class Histogram:
+    """Cumulative-bucket histogram (Prometheus semantics), partitioned by labels.
+
+    Tracks per-bucket counts plus ``_sum`` and ``_count`` so quantiles/averages
+    are computable downstream. Buckets are cumulative on render (``le``).
+    """
+
+    def __init__(
+        self, name: str, help_text: str, buckets: tuple[float, ...] = LATENCY_BUCKETS_MS
+    ) -> None:
+        self.name = name
+        self.help_text = help_text
+        self.buckets = buckets
+        self._counts: dict[LabelKey, list[int]] = defaultdict(lambda: [0] * len(buckets))
+        self._sum: dict[LabelKey, float] = defaultdict(float)
+        self._total: dict[LabelKey, int] = defaultdict(int)
+        self._lock = threading.Lock()
+
+    def observe(self, value: float, labels: dict[str, str] | None = None) -> None:
+        k = _key(labels)
+        with self._lock:
+            counts = self._counts[k]
+            for i, upper in enumerate(self.buckets):
+                if value <= upper:
+                    counts[i] += 1
+            self._sum[k] += value
+            self._total[k] += 1
+
+    def samples(self) -> list[tuple[LabelKey, list[int], float, int]]:
+        """Returns (labels, per-bucket counts, sum, total) per label set."""
+        with self._lock:
+            return [
+                (k, list(self._counts[k]), self._sum[k], self._total[k])
+                for k in self._total
+            ]
+
+
+class Registry:
+    """Holds the declared metric instances and renders them as Prometheus text."""
+
+    def __init__(self) -> None:
+        self.counters: list[Counter] = []
+        self.gauges: list[Gauge] = []
+        self.histograms: list[Histogram] = []
+
+    def counter(self, name: str, help_text: str) -> Counter:
+        c = Counter(name, help_text)
+        self.counters.append(c)
+        return c
+
+    def gauge(self, name: str, help_text: str) -> Gauge:
+        g = Gauge(name, help_text)
+        self.gauges.append(g)
+        return g
+
+    def histogram(
+        self, name: str, help_text: str, buckets: tuple[float, ...] = LATENCY_BUCKETS_MS
+    ) -> Histogram:
+        h = Histogram(name, help_text, buckets)
+        self.histograms.append(h)
+        return h
+
+
+def _fmt_labels(labels: LabelKey, extra: tuple[str, str] | None = None) -> str:
+    pairs = list(labels)
+    if extra is not None:
+        pairs = pairs + [extra]
+    if not pairs:
+        return ""
+    inner = ",".join(f'{name}="{_escape(value)}"' for name, value in pairs)
+    return "{" + inner + "}"
+
+
+def _escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _fmt_num(value: float) -> str:
+    # Render integer-valued floats without a trailing ".0" for cleaner output.
+    if value == int(value):
+        return str(int(value))
+    return repr(value)
+
+
+def render_prometheus(registry: Registry) -> str:
+    """Render the registry in Prometheus text exposition format (v0.0.4)."""
+    lines: list[str] = []
+
+    for c in registry.counters:
+        lines.append(f"# HELP {c.name} {c.help_text}")
+        lines.append(f"# TYPE {c.name} counter")
+        samples = c.samples()
+        if not samples:
+            lines.append(f"{c.name} 0")
+        for labels, value in samples:
+            lines.append(f"{c.name}{_fmt_labels(labels)} {_fmt_num(value)}")
+
+    for g in registry.gauges:
+        lines.append(f"# HELP {g.name} {g.help_text}")
+        lines.append(f"# TYPE {g.name} gauge")
+        for labels, value in g.samples():
+            lines.append(f"{g.name}{_fmt_labels(labels)} {_fmt_num(value)}")
+
+    for h in registry.histograms:
+        lines.append(f"# HELP {h.name} {h.help_text}")
+        lines.append(f"# TYPE {h.name} histogram")
+        for labels, counts, total_sum, total in h.samples():
+            cumulative = 0
+            for i, upper in enumerate(h.buckets):
+                cumulative += counts[i]
+                le = "+Inf" if upper == float("inf") else _fmt_num(upper)
+                lines.append(
+                    f"{h.name}_bucket{_fmt_labels(labels, ('le', le))} {cumulative}"
+                )
+            # +Inf bucket always equals the total observation count.
+            lines.append(
+                f"{h.name}_bucket{_fmt_labels(labels, ('le', '+Inf'))} {total}"
+            )
+            lines.append(f"{h.name}_sum{_fmt_labels(labels)} {_fmt_num(total_sum)}")
+            lines.append(f"{h.name}_count{_fmt_labels(labels)} {total}")
+
+    return "\n".join(lines) + "\n"
+
+
+# ── Process-global registry + declared metrics ─────────────────────────────────
+REGISTRY = Registry()
+
+HTTP_REQUESTS_TOTAL = REGISTRY.counter(
+    "memoryops_http_requests_total",
+    "Total HTTP requests handled, by route template, method, and status class.",
+)
+HTTP_REQUEST_DURATION_MS = REGISTRY.histogram(
+    "memoryops_http_request_duration_ms",
+    "HTTP request handling latency in milliseconds, by route and method.",
+)
+RETRIEVAL_TOTAL = REGISTRY.counter(
+    "memoryops_retrieval_total",
+    "Memory retrieval attempts, by mode (hybrid|fallback|none).",
+)
+RETRIEVAL_DURATION_MS = REGISTRY.histogram(
+    "memoryops_retrieval_duration_ms",
+    "Memory read-path latency in milliseconds (retrieve+rank+compose).",
+)
+POLICY_DECISIONS_TOTAL = REGISTRY.counter(
+    "memoryops_policy_decisions_total",
+    "Policy broker decisions, by decision (SAVE|BLOCK|...). BLOCK/total = block rate.",
+)
+WORKER_RUNS = REGISTRY.gauge(
+    "memoryops_worker_runs",
+    "Recent worker runs observed in persisted history, by status (pull-derived).",
+)
+WORKER_DEAD_LETTER = REGISTRY.gauge(
+    "memoryops_worker_dead_letter_count",
+    "Dead-lettered worker runs in recent history (pull-derived).",
+)
+WORKER_FAILED = REGISTRY.gauge(
+    "memoryops_worker_failed_count",
+    "Failed worker runs in recent history (pull-derived).",
+)

--- a/services/api/app/routes/health.py
+++ b/services/api/app/routes/health.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 from fastapi import APIRouter
 
 from .. import __version__
@@ -10,10 +12,19 @@ from ..db.factory import get_repository
 
 router = APIRouter(tags=["ops"])
 
+# Captured at import so /healthz can report process uptime.
+_PROCESS_START = time.monotonic()
+
 
 @router.get("/healthz")
 def healthz() -> dict:
-    return {"status": "ok", "version": __version__}
+    settings = get_settings()
+    return {
+        "status": "ok",
+        "version": __version__,
+        "uptime_seconds": round(time.monotonic() - _PROCESS_START, 1),
+        "metrics_enabled": settings.metrics_enabled,
+    }
 
 
 @router.get("/healthz/workers")

--- a/services/api/app/routes/metrics_prometheus.py
+++ b/services/api/app/routes/metrics_prometheus.py
@@ -1,0 +1,40 @@
+"""GET /metrics — Prometheus text exposition (process-wide, content-free).
+
+The de-facto scrape endpoint for a Prometheus/Grafana stack. Distinct from
+``GET /api/metrics`` (per-tenant business-metrics JSON). Exposes operational
+signals only — HTTP traffic, retrieval, policy decisions, and pull-derived worker
+run counts — with bounded, non-PII labels. See ADR-015.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi.responses import PlainTextResponse
+
+from ..core.config import get_settings
+from ..observability import REGISTRY, collect_worker_gauges, render_prometheus
+
+router = APIRouter(tags=["ops"])
+
+# Prometheus text exposition content type (format version 0.0.4).
+PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+
+
+@router.get("/metrics")
+def metrics() -> PlainTextResponse:
+    settings = get_settings()
+    if not settings.metrics_enabled:
+        return PlainTextResponse("metrics disabled\n", status_code=404)
+
+    # Refresh pull-derived worker gauges at scrape time. Best-effort: a repository
+    # error leaves worker gauges cleared and still renders the rest (invariant #4).
+    try:
+        from ..db.factory import get_repository
+
+        collect_worker_gauges(get_repository(), limit=settings.worker_run_history_limit)
+    except Exception:  # noqa: BLE001 — scrape must never 500 on worker-metric refresh
+        pass
+
+    return PlainTextResponse(
+        render_prometheus(REGISTRY), media_type=PROMETHEUS_CONTENT_TYPE
+    )

--- a/services/api/app/services/gateway.py
+++ b/services/api/app/services/gateway.py
@@ -19,6 +19,7 @@ from ..db.repository import Repository
 from ..llm import detect_conflicts, get_llm_provider
 from ..loops.events import complete_loop_run_sync, emit_loop_event_sync, start_loop_run_sync
 from ..loops.types import LoopId, LoopState, LoopStatus
+from ..observability import observe_retrieval, record_policy_decision
 from ..schemas.memory import (
     ChatRequest,
     ChatResponse,
@@ -116,9 +117,11 @@ class Gateway:
             block, used = self._composer.compose(ranked)
             return block, used, result.mode
 
+        _read_start = time.monotonic()
         context_block, used_memories, retrieval_mode = safe_call(
             _read, default=("", [], "none"), label="retrieval"
         )
+        observe_retrieval(retrieval_mode, (time.monotonic() - _read_start) * 1000)
         emit_loop_event_sync(
             self._repo,
             read_loop,
@@ -298,6 +301,7 @@ class Gateway:
             outcome = self._policy.evaluate(
                 cand, tenant_id=req.tenant_id, user_id=req.user_id, settings=settings
             )
+            record_policy_decision(outcome.decision.value)
             emit_loop_event_sync(
                 self._repo,
                 write_loop,

--- a/services/api/tests/test_memory_read_loop.py
+++ b/services/api/tests/test_memory_read_loop.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.loops.types import LoopId, LoopStatus
+from app.observability import registry as m
 from app.schemas.memory import ChatRequest
 
 
@@ -8,6 +9,20 @@ def _chat(gateway, message, trace_id="trace-read"):
     return gateway.handle_chat(
         ChatRequest(tenant_id="t1", user_id="u1", message=message), trace_id=trace_id
     )
+
+
+def _counter_total(counter) -> float:
+    return sum(v for _labels, v in counter.samples())
+
+
+def test_memory_path_records_metrics(gateway):
+    """The gateway read/write path records Prometheus metrics (ADR-015) without
+    altering loop behavior — retrieval + policy-decision counters move."""
+    retr_before = _counter_total(m.RETRIEVAL_TOTAL)
+    policy_before = _counter_total(m.POLICY_DECISIONS_TOTAL)
+    _chat(gateway, "Remember that I prefer dark mode dashboards.", trace_id="metrics")
+    assert _counter_total(m.RETRIEVAL_TOTAL) > retr_before
+    assert _counter_total(m.POLICY_DECISIONS_TOTAL) > policy_before
 
 
 def test_memory_read_loop_emits_events(gateway, repo):

--- a/services/api/tests/test_metrics_endpoint.py
+++ b/services/api/tests/test_metrics_endpoint.py
@@ -1,0 +1,138 @@
+"""GET /metrics — Prometheus exposition, content-free + graceful (ADR-015).
+
+Metrics are process-global, so these tests assert presence and *monotonic*
+movement (snapshot before/after) rather than exact absolute values.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from app.core.config import get_settings
+
+
+def _scrape(client) -> str:
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/plain")
+    return resp.text
+
+
+def _sample(text: str, name: str, labels: dict[str, str] | None = None) -> float:
+    """Return the value of a metric sample matching name + (subset of) labels.
+
+    Returns 0.0 if no matching sample line is present.
+    """
+    total = None
+    for line in text.splitlines():
+        if line.startswith("#") or not line.startswith(name):
+            continue
+        # Split "name{labels} value" — labels optional.
+        m = re.match(rf"^{re.escape(name)}(\{{(?P<labels>[^}}]*)\}})?\s+(?P<val>[\d.eE+-]+)$", line)
+        if not m:
+            continue
+        line_labels = {}
+        if m.group("labels"):
+            for pair in m.group("labels").split(","):
+                k, _, v = pair.partition("=")
+                line_labels[k.strip()] = v.strip().strip('"')
+        if labels and not all(line_labels.get(k) == v for k, v in labels.items()):
+            continue
+        total = (total or 0.0) + float(m.group("val"))
+    return total if total is not None else 0.0
+
+
+def _chat(client, message: str, **kw):
+    payload = {"tenant_id": "t1", "user_id": "u1", "message": message, **kw}
+    return client.post("/api/chat", json=payload)
+
+
+def test_metrics_endpoint_is_prometheus_text(api_client):
+    client, _ = api_client
+    text = _scrape(client)
+    assert "# TYPE memoryops_http_requests_total counter" in text
+    assert "# TYPE memoryops_http_request_duration_ms histogram" in text
+    assert "# TYPE memoryops_policy_decisions_total counter" in text
+
+
+def test_chat_increments_http_and_retrieval_counters(api_client):
+    client, _ = api_client
+    before = _scrape(client)
+    http_before = _sample(before, "memoryops_http_requests_total")
+    retr_before = _sample(before, "memoryops_retrieval_total")
+
+    _chat(client, "Remember that I prefer dark mode dashboards.")
+
+    after = _scrape(client)
+    assert _sample(after, "memoryops_http_requests_total") > http_before
+    assert _sample(after, "memoryops_retrieval_total") > retr_before
+    # The chat write recorded at least one policy decision.
+    assert _sample(after, "memoryops_policy_decisions_total") > 0
+
+
+def test_blocked_secret_increments_block_decision(api_client):
+    client, _ = api_client
+    before = _sample(_scrape(client), "memoryops_policy_decisions_total", {"decision": "BLOCK"})
+    _chat(client, "Remember that my API key is sk-test-123456789abcdefghij.")
+    after = _sample(_scrape(client), "memoryops_policy_decisions_total", {"decision": "BLOCK"})
+    assert after > before
+
+
+def test_retrieval_fallback_mode_is_recorded(api_client, monkeypatch):
+    client, _ = api_client
+
+    def _raise(_text):
+        raise RuntimeError("embedding backend unavailable")
+
+    monkeypatch.setattr("app.services.retriever.embed", _raise)
+
+    before = _sample(_scrape(client), "memoryops_retrieval_total", {"mode": "fallback"})
+    _chat(client, "What dashboard theme do I like?")
+    after = _sample(_scrape(client), "memoryops_retrieval_total", {"mode": "fallback"})
+    assert after > before
+
+
+def test_worker_gauge_degrades_when_history_unavailable(api_client, monkeypatch):
+    """Repository/worker-history error must not 500 the scrape (invariant #4)."""
+    client, _ = api_client
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("worker history unavailable")
+
+    monkeypatch.setattr("app.workers.orchestrator.summarize_runtime_health", _boom)
+    text = _scrape(client)  # still 200
+    # HTTP metrics still render even though worker gauges were skipped.
+    assert "memoryops_http_requests_total" in text
+
+
+def test_metrics_can_be_disabled(api_client, monkeypatch):
+    client, _ = api_client
+    monkeypatch.setenv("MEMORYOPS_METRICS_ENABLED", "0")
+    get_settings.cache_clear()
+    try:
+        resp = client.get("/metrics")
+        assert resp.status_code == 404
+        # The rest of the app is unaffected.
+        assert client.get("/healthz").status_code == 200
+    finally:
+        get_settings.cache_clear()
+
+
+def test_healthz_reports_uptime_and_metrics_flag(api_client):
+    client, _ = api_client
+    body = client.get("/healthz").json()
+    assert body["status"] == "ok"
+    assert "uptime_seconds" in body
+    assert body["metrics_enabled"] is True
+
+
+@pytest.mark.parametrize("path", ["/metrics", "/healthz"])
+def test_ops_endpoints_emit_no_tenant_labels(api_client, path):
+    """Content-free guarantee: no tenant/user identifiers leak into metrics."""
+    client, _ = api_client
+    _chat(client, "Remember I work at tenant t1 as user u1.")
+    text = _scrape(client)
+    assert "tenant_id" not in text
+    assert "user_id" not in text


### PR DESCRIPTION
## What

Adds a **dependency-free Prometheus metrics surface** at `GET /metrics`, closing the metrics half of the phase-10 observability gap. No new runtime dependency (the repo stays at 6 deps, offline-first).

This is **Option B Phase 1 (metrics-only)** — OpenTelemetry tracing is deliberately deferred to a follow-up.

## Why

MemoryOps is v1.0 "production-ready," but the weakest part of that claim was operational observability: there was no Prometheus-format endpoint a monitoring stack can scrape. The phase-10 gate listed "Prometheus/Grafana metrics" as an open gap. The existing `GET /api/metrics` is per-tenant business JSON — wrong shape for a scrape.

## What's exposed

Process-wide, content-free, low-cardinality metrics:

- `memoryops_http_requests_total{route,method,status_class}` + `memoryops_http_request_duration_ms` (histogram)
- `memoryops_retrieval_total{mode}` + `memoryops_retrieval_duration_ms`
- `memoryops_policy_decisions_total{decision}` — `BLOCK`/total = live policy-block rate
- `memoryops_worker_runs{status}` + dead-letter / failed gauges (pull-derived at scrape time)

`/healthz` now also reports `uptime_seconds` + `metrics_enabled`. Toggle the whole surface with `MEMORYOPS_METRICS_ENABLED`.

## Invariants held

- **#4 graceful degradation** — all recording is no-throw; the scrape never 500s (worker gauges degrade out if the repository is unavailable).
- **Content-free / no PII** — labels are bounded enums + route *templates* only; **no `tenant_id`/`user_id` labels** and no message content (privacy + cardinality). Verified by test.
- **Additive** — no chat-path behavior change; existing `/api/metrics` JSON untouched; new endpoint at root `/metrics`.

## Design notes

- Metrics primitives + Prometheus 0.0.4 renderer hand-rolled in `app/observability/` (rejected `prometheus_client`/OTel as runtime deps to keep the stack lean/offline).
- Worker metrics are **pull-derived** — workers run in a separate process, so the scrape reads the content-free `summarize_runtime_health(repo)` rather than in-process counters.

## Verification

- **259 passed, 1 skipped**; ruff clean.
- New `tests/test_metrics_endpoint.py` (8 cases: format, counter movement, BLOCK on secret, fallback mode, disabled→404, worker-history-down degradation, no tenant/user labels) + memory-path metrics evidence in `test_memory_read_loop.py`.
- **PR invariant gate: PASS** (4 armed rules satisfied).
- Manually verified live: chat traffic increments counters; `/healthz` shows new fields.

## Docs

ADR-015, `docs/observability.md`, updated `docs/api-contracts.md`, phase-10 gate, CHANGELOG (v1.1), CLAUDE.md.

## Out of scope

OpenTelemetry tracing; token/embedding-cost economics (Phase 2); admin dashboard UI (Phase 3).