### PR TITLE
feat(economics): advisory per-request token + cost estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable releases. Git tags + GitHub Releases are the source of truth; this
 file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
 
+## v1.2 — Advisory Economics: Token + Cost Estimation
+Additive under the `1.x` compatibility promise. Every chat response gains an
+optional `economics` block — advisory per-request token counts (embedding, context,
+compressed, saved, LLM input) and estimated USD cost — and the same signals roll up
+as content-free Prometheus counters (`memoryops_tokens_total`,
+`memoryops_estimated_cost_usd_total`) on `GET /metrics`. Costs are list-price
+*estimates*, never billing: unknown/stub models are unpriced ($0) while token counts
+stay real; override prices with `MEMORYOPS_PRICING_OVERRIDES`. Reuses the
+deterministic token estimator; estimation is no-throw and never affects the chat
+path. SDK exposes `result.economics`. No DB migration; per-tenant budgets remain a
+later item. See [docs/economics.md](docs/economics.md), [ADR-016](infra/adr/ADR-016-economics-cost-estimation.md).
+
 ## v1.1 — Prometheus Metrics Exposition
 Additive under the `1.x` compatibility promise. Process-wide, content-free
 Prometheus text metrics at `GET /metrics` (HTTP traffic, retrieval latency/mode,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,12 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
   (no tenant/user labels); recording is no-throw (invariant #4); worker gauges are
   pull-derived at scrape time. Distinct from the per-tenant `GET /api/metrics` JSON.
   Toggle `MEMORYOPS_METRICS_ENABLED`. See ADR-015, `docs/observability.md`.
+- `services/api/app/economics` — advisory per-request token + cost estimation
+  (v1.2). Reuses the deterministic token estimator + a configurable price table
+  (`MEMORYOPS_PRICING_OVERRIDES`); unknown/stub models are unpriced ($0). Surfaced
+  as an optional `economics` block on the chat response and content-free Prometheus
+  counters. No-throw (invariant #4), advisory not billing. See ADR-016,
+  `docs/economics.md`.
 - `services/api/app/compression` — optional context compression at the LLM boundary
   (`MEMORYOPS_CONTEXT_COMPRESSION=none|headroom`). `NoopCompressor` is the default;
   `HeadroomCompressor` is optional and degrades to no-op. Runs **after** policy/governance/

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -30,10 +30,20 @@ Response:
     "confidence": 0.92, "importance": 8, "sensitivity": "low", "reason": "...", "memory_id": "..." }],
   "audit_event_ids": ["..."], "temporary_chat": false,
   "retrieval_mode": "hybrid",
+  "economics": { "embedding_model": "", "llm_model": "", "embedding_tokens": 6,
+    "context_tokens": 0, "compressed_tokens": 0, "tokens_saved": 0,
+    "llm_input_tokens": 18, "estimated_cost_usd": 0.0, "cost_saved_usd": 0.0,
+    "priced": false },
   "loop_evidence": { "memory.read": "completed", "memory.write": "completed" },
   "trace_id": "..." }
 ```
 `decision ∈ {SAVE, PENDING_APPROVAL, BLOCK, DROP_LOW_UTILITY, UPDATE_EXISTING, MERGE_WITH_EXISTING}`.
+
+**Economics (v1.2).** The optional `economics` block carries an *advisory* token +
+cost estimate for the request. Costs are list-price estimates (never billing);
+`priced=false` ⇒ the active model is unpriced (e.g. the stub provider) so costs are
+`0` while token counts stay real. Override prices with `MEMORYOPS_PRICING_OVERRIDES`.
+See [docs/economics.md](economics.md), ADR-016.
 
 **Retrieval (v0.3).** `retrieval_mode ∈ {hybrid, fallback, none}` — `hybrid` blends
 pgvector cosine similarity with keyword overlap; `fallback` is keyword-only after

--- a/docs/economics.md
+++ b/docs/economics.md
@@ -1,0 +1,86 @@
+# Economics — token + cost estimation
+
+MemoryOps AI attaches an **advisory** token + cost estimate to every chat request
+(v1.2, [ADR-016](../infra/adr/ADR-016-economics-cost-estimation.md)). It builds on
+the deterministic token estimator used for compression savings and the v1.1
+Prometheus surface ([docs/observability.md](observability.md)).
+
+> **Advisory, not billing.** Token counts are deterministic estimates
+> (≈4 chars/token); costs are list-price *estimates*. MemoryOps never asserts a
+> fixed headline cost. With the default `stub` providers there is no real cost, so
+> estimates are `$0` (`priced=false`) while token counts stay real.
+
+## On the chat response
+
+`POST /api/chat` responses include an optional `economics` block:
+
+```json
+{
+  "economics": {
+    "embedding_model": "",
+    "llm_model": "",
+    "embedding_tokens": 6,
+    "context_tokens": 0,
+    "compressed_tokens": 0,
+    "tokens_saved": 0,
+    "llm_input_tokens": 18,
+    "estimated_cost_usd": 0.0,
+    "cost_saved_usd": 0.0,
+    "priced": false
+  }
+}
+```
+
+- `embedding_tokens` — estimated tokens to embed the query (only when the read path
+  embedded it, i.e. `retrieval_mode == "hybrid"`).
+- `context_tokens` / `compressed_tokens` / `tokens_saved` — from the compression
+  result; equal context/compressed and `0` saved when compression is off.
+- `llm_input_tokens` — advisory prompt size (composed context + user message).
+- `estimated_cost_usd` — embedding + LLM-input cost; `0.0` when unpriced.
+- `cost_saved_usd` — `tokens_saved` valued at the LLM input rate.
+- `priced` — whether the active model resolved to a price.
+
+The Python SDK exposes this as `result.economics` on the chat result.
+
+## Prometheus metrics
+
+Two content-free counters appear on `GET /metrics` (labels: `kind`, `model`; **no
+tenant/user labels**):
+
+| Metric | Labels | Meaning |
+|--------|--------|---------|
+| `memoryops_tokens_total` | `kind` (embedding\|context\|compressed\|saved\|llm_input), `model` | Estimated tokens processed |
+| `memoryops_estimated_cost_usd_total` | `kind` (request\|saved), `model` | Advisory estimated USD cost |
+
+Useful: `rate(memoryops_estimated_cost_usd_total{kind="request"}[1h])` for spend
+rate; `memoryops_estimated_cost_usd_total{kind="saved"}` for compression savings.
+
+## Pricing
+
+Default advisory list prices (USD per 1M tokens) live in
+[app/economics/pricing.py](../services/api/app/economics/pricing.py) for the models
+the runtime names (`text-embedding-3-small`, `gpt-4o-mini`,
+`claude-haiku-4-5-20251001`, `gemini-1.5-flash`). Unknown / stub models are
+unpriced ($0).
+
+Override per-model prices with `MEMORYOPS_PRICING_OVERRIDES` (JSON, USD/1M):
+
+```bash
+export MEMORYOPS_PRICING_OVERRIDES='{"gpt-4o-mini":{"input":0.15,"output":0.60}}'
+```
+
+A malformed value is ignored (logged), never fatal.
+
+## Guarantees
+
+- **Graceful degradation (invariant #4)** — estimation is no-throw; a failure skips
+  the `economics` block but never affects the chat response.
+- **Content-free** — metrics carry no PII; bounded labels only.
+- **Additive** — `economics` is an optional response field under the `1.x`
+  additive-compatibility promise.
+
+## Not included
+
+- Persisted per-tenant economics ledger / `GET /api/economics` / budgets +
+  enforcement (the phase-16 "→ later" gap).
+- Real provider token-usage readback.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -34,6 +34,8 @@ and returns `404`).
 | `memoryops_worker_runs` | gauge | `status` | Recent worker runs by status (pull-derived) |
 | `memoryops_worker_dead_letter_count` | gauge | — | Dead-lettered worker runs in recent history |
 | `memoryops_worker_failed_count` | gauge | — | Failed worker runs in recent history |
+| `memoryops_tokens_total` | counter | `kind`, `model` | Estimated tokens processed (advisory; see [economics.md](economics.md)) |
+| `memoryops_estimated_cost_usd_total` | counter | `kind`, `model` | Advisory estimated USD cost (not billing) |
 
 ### Useful derived signals
 
@@ -69,8 +71,13 @@ scrape_configs:
 - `GET /readyz` — repository + provider readiness rollup.
 - `GET /healthz/workers` — worker run history (dead-letter / failure counts).
 
+## Related
+
+- **Economics** — advisory per-request token + cost estimation (v1.2) is documented
+  separately in [economics.md](economics.md); its `memoryops_tokens_total` and
+  `memoryops_estimated_cost_usd_total` counters appear on this same `/metrics`.
+
 ## Not (yet) included
 
 - OpenTelemetry / distributed tracing (deferred).
-- Token/embedding cost economics.
 - An admin observability dashboard UI.

--- a/docs/phase-gates/phase-16-economics.md
+++ b/docs/phase-gates/phase-16-economics.md
@@ -25,8 +25,22 @@ default and never weakens an invariant. See ADR-007,
 - [ADR-007 Headroom compression](../../infra/adr/ADR-007-headroom-token-compression.md)
 
 ## Gaps to close (→ later)
-- Per-tenant token budgets + cost dashboards.
-- Cost-per-write / cost-per-retrieval rollups (v0.7 observability + economics).
+- Per-tenant token budgets + cost dashboards (persisted ledger + enforcement).
 - Quality A/B evals with a real compression provider.
+- Real provider token-usage readback (vs. deterministic estimates).
 
-## Status: ✅ Implemented (v0.2.1 — optional compression + savings instrumentation)
+## Gate (additional, v1.2)
+- Per-request token + cost estimates (embedding + context + LLM input + savings)
+  are reported on the chat response and as content-free Prometheus counters.
+- Costs are advisory/estimated and configurable; unknown/stub models are unpriced.
+- Estimation is no-throw and never affects the chat path.
+
+## Evidence (v1.2)
+- `services/api/app/economics/` (`pricing`, `estimator`); `app/observability/`
+  (`memoryops_tokens_total`, `memoryops_estimated_cost_usd_total`);
+  `app/services/gateway.py` (per-request economics); `app/schemas/memory.py`
+  (`Economics` block); `services/api/tests/test_economics.py`;
+  [docs/economics.md](../economics.md);
+  [ADR-016](../../infra/adr/ADR-016-economics-cost-estimation.md)
+
+## Status: ✅ Implemented (v0.2.1 compression savings + v1.2 per-request token/cost economics)

--- a/infra/adr/ADR-016-economics-cost-estimation.md
+++ b/infra/adr/ADR-016-economics-cost-estimation.md
@@ -1,0 +1,57 @@
+# ADR-016 — Advisory Economics: Token + Cost Estimation
+
+- Status: Accepted (v1.2)
+- Date: 2026-06-25
+- Supersedes: none
+- Related: ADR-015 (Prometheus metrics), ADR-007 (Headroom compression), ADR-008 (LLM providers)
+
+## Context
+
+Phase 16's per-request **compression savings** instrumentation already ships
+(`Compression` block on `ChatResponse`, ADR-007). The phase-16 gate's own
+"→ later" list still named **token/cost estimation across the whole request** and
+**cost-per-request rollups**. With the v1.1 Prometheus surface (ADR-015) now
+present, there is a natural substrate to expose cost economics.
+
+## Decision
+
+Add a small, **advisory** economics layer (`app/economics/`) that estimates token
+usage and USD cost per chat request, surfaces it on the response and as Prometheus
+counters, and reuses existing primitives.
+
+- **Advisory, not billing.** Token counts reuse the deterministic
+  `compression.metrics.estimate_tokens` (≈4 chars/token). Costs are *list-price
+  estimates* from a configurable table; no fixed headline number is asserted
+  (consistent with ADR-007 / `docs/token-compression.md`).
+- **Default price table + override.** `pricing.py` ships advisory USD/1M-token
+  prices for the models `core/config.py` already names (embeddings
+  `text-embedding-3-small`; LLMs `gpt-4o-mini`, `claude-haiku-4-5-20251001`,
+  `gemini-1.5-flash`). Unknown / stub models are **unpriced** ($0) — tokens are
+  still counted. Operators override per-model prices via
+  `MEMORYOPS_PRICING_OVERRIDES` (JSON).
+- **Graceful degradation (invariant #4).** Estimation + recording is wrapped
+  no-throw in the gateway; it can never block or fail a chat. A malformed override
+  is ignored, not fatal.
+- **Content-free metrics.** New `memoryops_tokens_total{kind,model}` and
+  `memoryops_estimated_cost_usd_total{kind,model}` counters use bounded labels
+  only — no `tenant_id`/`user_id`, no content (extends ADR-015's guarantees).
+- **Additive.** Optional `economics` block on `ChatResponse` (responses only gain
+  fields, per the `1.x` promise) and a parsed `economics` accessor in the SDK.
+  No behavior change; the LLM/policy/governance paths are untouched.
+- **Lean scope.** No DB migration and **no persisted per-tenant economics ledger**
+  — per-tenant budgets/dashboards remain the phase-16 "→ later" gap.
+
+## Consequences
+
+- Every chat carries a token + (advisory) cost estimate, and an operator can graph
+  process-wide token/cost on the existing Prometheus scrape — closing the
+  cost-per-request half of the phase-16 gap.
+- Estimates are deterministic and offline-safe: with the default stub providers,
+  token counts are real and cost is `$0`/unpriced, so tests need no keys.
+- We own price-table freshness; prices are documented as advisory and overridable.
+
+## Out of scope
+
+- Persisted per-tenant economics ledger / `GET /api/economics` / budget enforcement.
+- Real provider token-usage readback (providers' `usage` is optional/advisory).
+- OpenTelemetry tracing.

--- a/packages/memoryops-sdk/memoryops/models.py
+++ b/packages/memoryops-sdk/memoryops/models.py
@@ -59,6 +59,9 @@ class ChatResult:
     retrieval_mode: str
     trace_id: str
     temporary_chat: bool = False
+    # Advisory per-request token + cost estimate (server v1.2, ADR-016). None when
+    # the server predates economics; otherwise the parsed `economics` block.
+    economics: dict[str, Any] | None = None
     raw: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -72,6 +75,7 @@ class ChatResult:
             retrieval_mode=d.get("retrieval_mode", "none"),
             trace_id=d.get("trace_id", ""),
             temporary_chat=d.get("temporary_chat", False),
+            economics=d.get("economics"),
             raw=d,
         )
 

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -24,6 +24,13 @@ class Settings(BaseSettings):
     # metrics JSON at GET /api/metrics.
     metrics_enabled: bool = True
 
+    # Economics (v1.2, ADR-016). Advisory per-request token + cost estimation,
+    # surfaced on the chat response + Prometheus counters. Costs are list-price
+    # estimates, never billing; unknown/stub models are unpriced ($0). Operators
+    # override per-model prices with MEMORYOPS_PRICING_OVERRIDES (JSON, e.g.
+    # '{"gpt-4o-mini":{"input":0.15,"output":0.6}}'). USD per 1M tokens.
+    pricing_overrides_json: str = ""
+
     # Storage backend: "memory" runs with no infra (default for dev/tests),
     # "postgres" uses SQLAlchemy + pgvector.
     storage: Literal["memory", "postgres"] = "memory"
@@ -130,6 +137,8 @@ def get_settings() -> Settings:
     overrides = {}
     if (val := os.getenv("MEMORYOPS_METRICS_ENABLED")) is not None:
         overrides["metrics_enabled"] = val.lower() not in ("0", "false", "no")
+    if (val := os.getenv("MEMORYOPS_PRICING_OVERRIDES")) is not None:
+        overrides["pricing_overrides_json"] = val
     if (val := os.getenv("MEMORYOPS_STORAGE")) in ("memory", "postgres"):
         overrides["storage"] = val
     if (val := os.getenv("MEMORYOPS_EMBEDDING_PROVIDER")) in ("stub", "heuristic", "openai"):

--- a/services/api/app/economics/__init__.py
+++ b/services/api/app/economics/__init__.py
@@ -1,0 +1,19 @@
+"""Advisory economics: per-request token + cost estimation (v1.2, ADR-016).
+
+Builds on the deterministic token estimator (`compression.metrics.estimate_tokens`)
+and a configurable advisory price table. Costs are *estimates* for instrumentation,
+never billing; unknown/stub models are unpriced ($0). Surfaced per-request on the
+chat response and as content-free Prometheus counters on `GET /metrics`.
+"""
+
+from .estimator import RequestEconomics, build_request_economics, estimate_cost_usd
+from .pricing import DEFAULT_PRICES, ModelPrice, price_per_1m
+
+__all__ = [
+    "RequestEconomics",
+    "build_request_economics",
+    "estimate_cost_usd",
+    "price_per_1m",
+    "ModelPrice",
+    "DEFAULT_PRICES",
+]

--- a/services/api/app/economics/estimator.py
+++ b/services/api/app/economics/estimator.py
@@ -1,0 +1,100 @@
+"""Per-request economics estimation (advisory).
+
+Pure functions over deterministic token estimates (reusing
+`compression.metrics.estimate_tokens`) and the advisory price table. Nothing here
+does I/O or can block a request; the gateway calls it inside a no-throw guard.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+from ..compression.metrics import estimate_tokens
+from .pricing import price_per_1m
+
+
+def estimate_cost_usd(model: str, tokens: int, *, kind: str, overrides_json: str = "") -> float:
+    """Estimated USD cost of ``tokens`` for ``model``. 0.0 when unpriced.
+
+    ``kind`` selects which price applies: "embedding" | "input" | "output".
+    """
+    price = price_per_1m(model, overrides_json=overrides_json)
+    if price is None or tokens <= 0:
+        return 0.0
+    rate = {"embedding": price.embedding, "input": price.input, "output": price.output}.get(
+        kind, 0.0
+    )
+    return round(tokens / 1_000_000 * rate, 8)
+
+
+@dataclass(frozen=True)
+class RequestEconomics:
+    """Advisory token + cost rollup for a single chat request."""
+
+    embedding_model: str = ""
+    llm_model: str = ""
+    embedding_tokens: int = 0
+    context_tokens: int = 0
+    compressed_tokens: int = 0
+    tokens_saved: int = 0
+    llm_input_tokens: int = 0
+    estimated_cost_usd: float = 0.0
+    cost_saved_usd: float = 0.0
+    priced: bool = False  # True when at least one model resolved to a price
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+def build_request_economics(
+    *,
+    embedding_model: str,
+    llm_model: str,
+    query_text: str,
+    context_tokens: int,
+    compressed_tokens: int,
+    tokens_saved: int,
+    llm_context_text: str,
+    embedded: bool,
+    overrides_json: str = "",
+) -> RequestEconomics:
+    """Assemble a ``RequestEconomics`` from values the gateway already has.
+
+    ``embedded`` is True when the read path actually embedded the query (i.e.
+    retrieval ran in a non-fallback, non-bypassed mode). Compression token counts
+    come from the existing ``Compression`` result; pass equal context/compressed
+    and 0 saved when compression is off.
+    """
+    embedding_tokens = estimate_tokens(query_text) if embedded else 0
+    # The LLM "input" is the composed (possibly compressed) context plus the user
+    # message — an advisory estimate of prompt size.
+    llm_input_tokens = estimate_tokens(llm_context_text) + estimate_tokens(query_text)
+
+    embedding_cost = estimate_cost_usd(
+        embedding_model, embedding_tokens, kind="embedding", overrides_json=overrides_json
+    )
+    llm_input_cost = estimate_cost_usd(
+        llm_model, llm_input_tokens, kind="input", overrides_json=overrides_json
+    )
+    # Savings are valued at the LLM input rate (compression shrinks the prompt).
+    cost_saved = estimate_cost_usd(
+        llm_model, tokens_saved, kind="input", overrides_json=overrides_json
+    )
+
+    priced = (
+        price_per_1m(embedding_model, overrides_json=overrides_json) is not None
+        or price_per_1m(llm_model, overrides_json=overrides_json) is not None
+    )
+
+    return RequestEconomics(
+        embedding_model=embedding_model,
+        llm_model=llm_model,
+        embedding_tokens=embedding_tokens,
+        context_tokens=context_tokens,
+        compressed_tokens=compressed_tokens,
+        tokens_saved=tokens_saved,
+        llm_input_tokens=llm_input_tokens,
+        estimated_cost_usd=round(embedding_cost + llm_input_cost, 8),
+        cost_saved_usd=cost_saved,
+        priced=priced,
+    )

--- a/services/api/app/economics/pricing.py
+++ b/services/api/app/economics/pricing.py
@@ -1,0 +1,74 @@
+"""Advisory model price table (USD per 1M tokens).
+
+These are *estimates* for cost instrumentation, not billing. Prices are list
+prices for the models the repo names by default; unknown models (including the
+deterministic `stub` providers) are **unpriced** — token counts are still tracked
+but estimated cost is `$0`. Operators override per-model prices via
+`MEMORYOPS_PRICING_OVERRIDES` (JSON); see `docs/economics.md`.
+
+Consistent with ADR-007 / `docs/token-compression.md`: MemoryOps reports
+measured/estimated numbers and never asserts a fixed headline cost.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from ..core.logging import get_logger
+
+logger = get_logger("memoryops.economics")
+
+
+@dataclass(frozen=True)
+class ModelPrice:
+    """USD per 1,000,000 tokens. ``output`` applies to generated tokens;
+    ``embedding`` to embedded tokens. Unused fields stay 0.0."""
+
+    input: float = 0.0
+    output: float = 0.0
+    embedding: float = 0.0
+
+
+# Default advisory list prices (USD / 1M tokens) for the models referenced in
+# core/config.py. Update as providers change pricing; operators can override.
+DEFAULT_PRICES: dict[str, ModelPrice] = {
+    "text-embedding-3-small": ModelPrice(embedding=0.02),
+    "gpt-4o-mini": ModelPrice(input=0.15, output=0.60),
+    "claude-haiku-4-5-20251001": ModelPrice(input=1.00, output=5.00),
+    "gemini-1.5-flash": ModelPrice(input=0.075, output=0.30),
+}
+
+
+def _parse_overrides(raw: str) -> dict[str, ModelPrice]:
+    """Parse the MEMORYOPS_PRICING_OVERRIDES JSON. Malformed input is ignored
+    (logged) so a bad env var can never break economics or the chat path."""
+    if not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+        out: dict[str, ModelPrice] = {}
+        for model, fields in data.items():
+            if isinstance(fields, dict):
+                out[str(model)] = ModelPrice(
+                    input=float(fields.get("input", 0.0)),
+                    output=float(fields.get("output", 0.0)),
+                    embedding=float(fields.get("embedding", 0.0)),
+                )
+        return out
+    except Exception:  # noqa: BLE001 — advisory config; never fatal
+        logger.debug("invalid MEMORYOPS_PRICING_OVERRIDES; ignoring", extra={"event": "economics"})
+        return {}
+
+
+def price_per_1m(model: str, *, overrides_json: str = "") -> ModelPrice | None:
+    """Resolve the price for ``model``; returns None when unpriced (e.g. stub).
+
+    Operator overrides take precedence over the default table.
+    """
+    if not model:
+        return None
+    overrides = _parse_overrides(overrides_json)
+    if model in overrides:
+        return overrides[model]
+    return DEFAULT_PRICES.get(model)

--- a/services/api/app/observability/__init__.py
+++ b/services/api/app/observability/__init__.py
@@ -8,6 +8,7 @@ process-wide, content-free operational signals for a Prometheus/Grafana scrape a
 
 from .instrument import (
     collect_worker_gauges,
+    observe_economics,
     observe_http,
     observe_retrieval,
     record_policy_decision,
@@ -20,5 +21,6 @@ __all__ = [
     "observe_http",
     "observe_retrieval",
     "record_policy_decision",
+    "observe_economics",
     "collect_worker_gauges",
 ]

--- a/services/api/app/observability/instrument.py
+++ b/services/api/app/observability/instrument.py
@@ -45,6 +45,37 @@ def record_policy_decision(decision: str) -> None:
         logger.debug("record_policy_decision failed", extra={"event": "metric_drop"})
 
 
+def observe_economics(econ) -> None:
+    """Record advisory token + cost estimates for a request (no-throw).
+
+    ``econ`` is a ``app.economics.RequestEconomics``. Labels are bounded
+    (kind + model); no tenant/user/content ever reaches a metric.
+    """
+    try:
+        emb_model = econ.embedding_model or "stub"
+        llm_model = econ.llm_model or "stub"
+        if econ.embedding_tokens:
+            m.TOKENS_TOTAL.inc({"kind": "embedding", "model": emb_model}, econ.embedding_tokens)
+        if econ.context_tokens:
+            m.TOKENS_TOTAL.inc({"kind": "context", "model": llm_model}, econ.context_tokens)
+        if econ.compressed_tokens:
+            m.TOKENS_TOTAL.inc({"kind": "compressed", "model": llm_model}, econ.compressed_tokens)
+        if econ.tokens_saved:
+            m.TOKENS_TOTAL.inc({"kind": "saved", "model": llm_model}, econ.tokens_saved)
+        if econ.llm_input_tokens:
+            m.TOKENS_TOTAL.inc({"kind": "llm_input", "model": llm_model}, econ.llm_input_tokens)
+        if econ.estimated_cost_usd:
+            m.ESTIMATED_COST_USD_TOTAL.inc(
+                {"kind": "request", "model": llm_model}, econ.estimated_cost_usd
+            )
+        if econ.cost_saved_usd:
+            m.ESTIMATED_COST_USD_TOTAL.inc(
+                {"kind": "saved", "model": llm_model}, econ.cost_saved_usd
+            )
+    except Exception:  # noqa: BLE001 — never break the chat path
+        logger.debug("observe_economics failed", extra={"event": "metric_drop"})
+
+
 def collect_worker_gauges(repo, limit: int = 500) -> None:
     """Refresh pull-derived worker gauges from persisted run history at scrape time.
 

--- a/services/api/app/observability/registry.py
+++ b/services/api/app/observability/registry.py
@@ -222,6 +222,14 @@ POLICY_DECISIONS_TOTAL = REGISTRY.counter(
     "memoryops_policy_decisions_total",
     "Policy broker decisions, by decision (SAVE|BLOCK|...). BLOCK/total = block rate.",
 )
+TOKENS_TOTAL = REGISTRY.counter(
+    "memoryops_tokens_total",
+    "Estimated tokens processed, by kind (embedding|context|compressed|saved|llm_input) and model.",
+)
+ESTIMATED_COST_USD_TOTAL = REGISTRY.counter(
+    "memoryops_estimated_cost_usd_total",
+    "Advisory estimated USD cost, by kind (embedding|llm_input|saved) and model. Not billing.",
+)
 WORKER_RUNS = REGISTRY.gauge(
     "memoryops_worker_runs",
     "Recent worker runs observed in persisted history, by status (pull-derived).",

--- a/services/api/app/schemas/memory.py
+++ b/services/api/app/schemas/memory.py
@@ -123,6 +123,26 @@ class Compression(BaseModel):
     fallback: bool = False
 
 
+class Economics(BaseModel):
+    """Advisory per-request token + cost estimate (v1.2, ADR-016).
+
+    Costs are list-price *estimates* for instrumentation, never billing.
+    `priced=false` means the active model is unpriced (e.g. the stub provider) and
+    costs are 0 even though token counts are real.
+    """
+
+    embedding_model: str = ""
+    llm_model: str = ""
+    embedding_tokens: int = 0
+    context_tokens: int = 0
+    compressed_tokens: int = 0
+    tokens_saved: int = 0
+    llm_input_tokens: int = 0
+    estimated_cost_usd: float = 0.0
+    cost_saved_usd: float = 0.0
+    priced: bool = False
+
+
 class ChatResponse(BaseModel):
     assistant_message: str
     used_memories: list[UsedMemory] = Field(default_factory=list)
@@ -136,6 +156,8 @@ class ChatResponse(BaseModel):
     # Optional context compression metrics (present only when compression is
     # configured and there was a context block to compress).
     compression: Compression | None = None
+    # Optional advisory token + cost estimate for this request (v1.2, ADR-016).
+    economics: Economics | None = None
     loop_evidence: dict[str, str] = Field(default_factory=dict)
     trace_id: str
 

--- a/services/api/app/services/gateway.py
+++ b/services/api/app/services/gateway.py
@@ -12,18 +12,22 @@ from __future__ import annotations
 import time
 
 from ..compression import get_compressor
+from ..compression.metrics import estimate_tokens
+from ..core.config import get_settings as get_app_settings
 from ..core.llm import get_llm
 from ..core.logging import get_logger
 from ..core.reliability import safe_call
 from ..db.repository import Repository
+from ..economics import build_request_economics
 from ..llm import detect_conflicts, get_llm_provider
 from ..loops.events import complete_loop_run_sync, emit_loop_event_sync, start_loop_run_sync
 from ..loops.types import LoopId, LoopState, LoopStatus
-from ..observability import observe_retrieval, record_policy_decision
+from ..observability import observe_economics, observe_retrieval, record_policy_decision
 from ..schemas.memory import (
     ChatRequest,
     ChatResponse,
     Compression,
+    Economics,
     Source,
     UsedMemory,
 )
@@ -53,6 +57,20 @@ class Gateway:
         # v0.4: provider-neutral LLM used for advisory conflict detection on the
         # write path. Stub by default; never overrides the policy broker (ADR-008).
         self._llm_provider = get_llm_provider()
+
+    @staticmethod
+    def _embedding_model(settings) -> str:
+        """Model name for embedding-cost estimation; "" (unpriced) for stub."""
+        return settings.openai_embedding_model if settings.embeddings_provider == "openai" else ""
+
+    @staticmethod
+    def _llm_model(settings) -> str:
+        """Model name for LLM-cost estimation; "" (unpriced) for stub/heuristic."""
+        return {
+            "openai": settings.openai_model,
+            "anthropic": settings.anthropic_model,
+            "gemini": settings.gemini_model,
+        }.get(settings.llm_provider, "")
 
     def handle_chat(self, req: ChatRequest, trace_id: str) -> ChatResponse:
         start = time.monotonic()
@@ -196,6 +214,37 @@ class Gateway:
                     compression_ratio=result.compression_ratio,
                     fallback=result.failed,
                 )
+        # ── Economics (advisory token + cost estimate, v1.2, ADR-016) ───────────
+        # Reuses the deterministic token estimator + compression result; no-throw
+        # so it can never affect the chat path (invariant #4). Records content-free
+        # Prometheus counters and attaches an economics block to the response.
+        economics: Economics | None = None
+        try:
+            if compression is not None:
+                ctx_tokens = compression.original_tokens_estimate
+                comp_tokens = compression.compressed_tokens_estimate
+                saved = compression.tokens_saved_estimate
+            else:
+                ctx_tokens = estimate_tokens(context_block)
+                comp_tokens = ctx_tokens
+                saved = 0
+            app_settings = get_app_settings()
+            req_econ = build_request_economics(
+                embedding_model=self._embedding_model(app_settings),
+                llm_model=self._llm_model(app_settings),
+                query_text=req.message,
+                context_tokens=ctx_tokens,
+                compressed_tokens=comp_tokens,
+                tokens_saved=saved,
+                llm_context_text=llm_context,
+                embedded=(retrieval_mode == "hybrid"),
+                overrides_json=app_settings.pricing_overrides_json,
+            )
+            observe_economics(req_econ)
+            economics = Economics(**req_econ.as_dict())
+        except Exception:  # noqa: BLE001 — economics is advisory, never fatal
+            logger.debug("economics estimate skipped", extra={"event": "economics"})
+
         if retrieval_mode == "fallback" or compression_failed:
             emit_loop_event_sync(
                 self._repo,
@@ -390,6 +439,7 @@ class Gateway:
             temporary_chat=False,
             retrieval_mode=retrieval_mode,
             compression=compression,
+            economics=economics,
             loop_evidence={
                 "memory.read": read_status.value,
                 "memory.write": LoopStatus.COMPLETED.value,

--- a/services/api/tests/test_economics.py
+++ b/services/api/tests/test_economics.py
@@ -1,0 +1,145 @@
+"""Advisory economics: token + cost estimation (v1.2, ADR-016).
+
+Estimates are deterministic and work offline. Costs are advisory: unknown/stub
+models are unpriced ($0); priced models use the default table or an env override.
+"""
+
+from __future__ import annotations
+
+import re
+
+from app.economics import build_request_economics, estimate_cost_usd, price_per_1m
+
+
+def _chat(client, message: str, **kw):
+    return client.post(
+        "/api/chat", json={"tenant_id": "t1", "user_id": "u1", "message": message, **kw}
+    )
+
+
+# ── pricing + estimator (pure) ─────────────────────────────────────────────────
+
+
+def test_stub_and_unknown_models_are_unpriced():
+    assert price_per_1m("") is None
+    assert price_per_1m("some-unknown-model") is None
+    assert estimate_cost_usd("", 1000, kind="input") == 0.0
+    assert estimate_cost_usd("some-unknown-model", 1000, kind="embedding") == 0.0
+
+
+def test_known_model_is_priced():
+    # text-embedding-3-small default = $0.02 / 1M tokens.
+    assert estimate_cost_usd("text-embedding-3-small", 1_000_000, kind="embedding") == 0.02
+    # gpt-4o-mini default input = $0.15 / 1M.
+    assert estimate_cost_usd("gpt-4o-mini", 1_000_000, kind="input") == 0.15
+
+
+def test_env_override_takes_precedence():
+    override = '{"gpt-4o-mini": {"input": 1.0}}'
+    assert estimate_cost_usd("gpt-4o-mini", 1_000_000, kind="input", overrides_json=override) == 1.0
+
+
+def test_malformed_override_is_ignored():
+    # Falls back to the default table rather than raising.
+    assert (
+        estimate_cost_usd("gpt-4o-mini", 1_000_000, kind="input", overrides_json="not json")
+        == 0.15
+    )
+
+
+def test_build_request_economics_values_and_savings():
+    econ = build_request_economics(
+        embedding_model="text-embedding-3-small",
+        llm_model="gpt-4o-mini",
+        query_text="x" * 40,  # ~10 tokens
+        context_tokens=100,
+        compressed_tokens=60,
+        tokens_saved=40,
+        llm_context_text="y" * 400,  # ~100 tokens
+        embedded=True,
+        overrides_json="",
+    )
+    assert econ.priced is True
+    assert econ.embedding_tokens == 10
+    assert econ.llm_input_tokens == 110  # 100 context + 10 query
+    assert econ.estimated_cost_usd > 0
+    assert econ.cost_saved_usd > 0  # 40 saved tokens valued at the input rate
+
+
+def test_unpriced_keeps_tokens_zero_cost():
+    econ = build_request_economics(
+        embedding_model="",  # stub
+        llm_model="",  # stub
+        query_text="hello there",
+        context_tokens=50,
+        compressed_tokens=50,
+        tokens_saved=0,
+        llm_context_text="some composed context block",
+        embedded=True,
+        overrides_json="",
+    )
+    assert econ.priced is False
+    assert econ.estimated_cost_usd == 0.0
+    assert econ.llm_input_tokens > 0  # tokens still tracked
+
+
+# ── end-to-end through the chat path ───────────────────────────────────────────
+
+
+def test_chat_response_carries_economics_block(api_client):
+    client, _ = api_client
+    _chat(client, "Remember that I prefer dark mode dashboards.")
+    resp = _chat(client, "Which theme do I like?")
+    body = resp.json()
+    econ = body["economics"]
+    assert econ is not None
+    assert econ["llm_input_tokens"] >= 0
+    # Default stub providers ⇒ unpriced ⇒ zero cost but real token counts.
+    assert econ["priced"] is False
+    assert econ["estimated_cost_usd"] == 0.0
+
+
+def _sample(text: str, name: str, labels: dict[str, str] | None = None) -> float:
+    total = None
+    for line in text.splitlines():
+        if line.startswith("#") or not line.startswith(name):
+            continue
+        pattern = rf"^{re.escape(name)}(\{{(?P<labels>[^}}]*)\}})?\s+(?P<val>[\d.eE+-]+)$"
+        mm = re.match(pattern, line)
+        if not mm:
+            continue
+        line_labels = {}
+        if mm.group("labels"):
+            for pair in mm.group("labels").split(","):
+                k, _, v = pair.partition("=")
+                line_labels[k.strip()] = v.strip().strip('"')
+        if labels and not all(line_labels.get(k) == v for k, v in labels.items()):
+            continue
+        total = (total or 0.0) + float(mm.group("val"))
+    return total if total is not None else 0.0
+
+
+def test_metrics_expose_token_counters_without_pii(api_client):
+    client, _ = api_client
+    before = _sample(client.get("/metrics").text, "memoryops_tokens_total")
+    _chat(client, "Remember that I prefer dark mode dashboards and concise summaries.")
+    text = client.get("/metrics").text
+    assert "# TYPE memoryops_tokens_total counter" in text
+    assert "# TYPE memoryops_estimated_cost_usd_total counter" in text
+    assert _sample(text, "memoryops_tokens_total") > before
+    # Content-free: no tenant/user labels leak into economics metrics.
+    assert "tenant_id" not in text
+    assert "user_id" not in text
+
+
+def test_economics_failure_is_non_fatal(api_client, monkeypatch):
+    """If estimation raises, the chat still succeeds (invariant #4)."""
+    client, _ = api_client
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("estimator exploded")
+
+    monkeypatch.setattr("app.services.gateway.build_request_economics", _boom)
+    resp = _chat(client, "Remember that I like dark mode.")
+    assert resp.status_code == 200
+    assert resp.json()["economics"] is None  # skipped, but chat unaffected

--- a/services/api/tests/test_memory_read_loop.py
+++ b/services/api/tests/test_memory_read_loop.py
@@ -25,6 +25,17 @@ def test_memory_path_records_metrics(gateway):
     assert _counter_total(m.POLICY_DECISIONS_TOTAL) > policy_before
 
 
+def test_memory_path_attaches_economics(gateway):
+    """The read path attaches an advisory economics estimate (ADR-016) without
+    altering loop behavior; token counters move and cost is 0 under stub providers."""
+    tokens_before = _counter_total(m.TOKENS_TOTAL)
+    resp = _chat(gateway, "Remember that I prefer dark mode dashboards.", trace_id="econ")
+    assert resp.economics is not None
+    assert resp.economics.llm_input_tokens >= 0
+    assert resp.economics.priced is False  # stub providers ⇒ unpriced
+    assert _counter_total(m.TOKENS_TOTAL) > tokens_before
+
+
 def test_memory_read_loop_emits_events(gateway, repo):
     _chat(gateway, "Remember that I prefer dark mode dashboards.", trace_id="seed")
     resp = _chat(gateway, "Which dashboard theme do I like?")


### PR DESCRIPTION
> **Stacked on #16** (Prometheus metrics). Base is `feat/observability-prometheus-metrics`; retarget to `main` once #16 merges.

## What

Adds a small, **advisory** economics layer (`app/economics/`) that estimates token usage + USD cost per chat request, surfaces it on the response and as Prometheus counters, and exposes it in the SDK. **No new dependency, no DB migration.**

This is **Option B Phase 2 (economics)**, lean scope.

## Why

Phase-16's per-request *compression savings* already shipped; the gate's own "→ later" list still named **token/cost estimation** and **cost-per-request rollups**. With the v1.1 Prometheus surface (#16) in place, there's now a natural substrate for cost economics.

## What's exposed

- **`economics` block on `POST /api/chat`** — `embedding_tokens`, `context_tokens`, `compressed_tokens`, `tokens_saved`, `llm_input_tokens`, `estimated_cost_usd`, `cost_saved_usd`, `priced`.
- **Prometheus counters** on `GET /metrics` — `memoryops_tokens_total{kind,model}`, `memoryops_estimated_cost_usd_total{kind,model}` (content-free, bounded labels).
- **SDK** — `result.economics` on the chat result.

## Principles

- **Advisory, not billing.** Token counts reuse the deterministic `estimate_tokens` (≈4 chars/token); costs are list-price *estimates*. Unknown/stub models are **unpriced** ($0) while token counts stay real. Override with `MEMORYOPS_PRICING_OVERRIDES` (JSON).
- **Graceful degradation (invariant #4).** Estimation + recording is no-throw; it can never block or fail a chat. Malformed override → ignored, not fatal.
- **Content-free.** No `tenant_id`/`user_id` labels, no content (extends #16's guarantee).
- **Additive.** Optional response field under the `1.x` promise; LLM/policy/governance paths untouched.

## Verification

- New `tests/test_economics.py` (pricing/estimator units, env override, end-to-end economics block, token counters without PII, no-throw failure path) + economics evidence in `test_memory_read_loop.py`. Full suite green; ruff clean.
- **PR invariant gate: PASS** (3 armed rules satisfied).
- Verified live (TestClient, `MEMORYOPS_LLM_PROVIDER=anthropic`): response carries `economics` with `priced: true`, `estimated_cost_usd: 1.3e-05`; `/metrics` shows the new counters; no tenant/user labels.

## Docs

ADR-016, `docs/economics.md`, updated `docs/observability.md`, `docs/api-contracts.md`, phase-16 gate, CHANGELOG (v1.2), CLAUDE.md.

## Out of scope

Persisted per-tenant economics ledger / `GET /api/economics` / budgets (heavier path); real provider token-usage readback; OpenTelemetry tracing.