### PR TITLE
feat(governance): Recall Gate + Output Gate (v1.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable releases. Git tags + GitHub Releases are the source of truth; this
 file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
 
+## v1.9 — Recall Gate + Output Gate
+Additive under the `1.x` compatibility promise; on by default but no-op unless there is
+something to protect (default `private` audience + an honest model → unchanged). Adds
+governance on **both** edges of generation. The **Recall Gate**
+(`app/services/recall_gate.py`) makes context entry *audience-aware*: each request
+carries an `audience` (`private` | `team` | `public`) and a memory is recalled only if
+its `sensitivity` is within that clearance (`private`=low+med+high, `team`=low+med,
+`public`=low) — withheld memories surface in the Memory Usage Trace with a new
+`BLOCK_AUDIENCE` decision, reusing the existing trace/metrics/audit path. The **Output
+Gate** (`app/services/output_gate.py`) is the mirror on the way out: it inspects the
+generated answer and, when it shares a distinctive contiguous phrase (≥4 significant
+words) with a memory the gates blocked, **redacts** the spans (default) or **refuses**
+with a safe message — deterministic, no-throw, audited (`output_gate_blocked`), and
+surfaced as an optional `output_gate` block. `ChatRequest.audience` +
+`ChatResponse.output_gate` are additive. Toggles `MEMORYOPS_RECALL_GATE`,
+`MEMORYOPS_OUTPUT_GATE`, `MEMORYOPS_OUTPUT_GATE_MODE`. +9 tests
+(`tests/test_recall_output_gates.py`); full suite 344 passed. See [docs/recall-output-gates.md](docs/recall-output-gates.md), [ADR-023](infra/adr/ADR-023-recall-output-gates.md).
+
 ## v1.8 — Full Memory Observability (Distributed Tracing)
 Additive under the `1.x` compatibility promise; on by default but content-free and
 dependency-free. Metrics (v1.1) tell you *how much*; v1.8 tracing tells you *what

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,15 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
   reindex-rebuild), `expiry_leakage` (retention-expired / consent-withdrawn active
   memory is gated out without deletion), and a transitive `derived_tombstone`
   (`chain_depth`) — all release-gating (`_CRITICAL_KINDS`), each carrying its own
-  "teeth". See ADR-019, `docs/deleted-memory-leakage-evals.md`.
+  "teeth". See ADR-019, `docs/deleted-memory-leakage-evals.md`. **Recall Gate +
+  Output Gate** (`recall_gate.py` / `output_gate.py`, v1.9) govern both edges of
+  generation: the Recall Gate makes context entry *audience-aware* (`ChatRequest.audience`
+  = private|team|public → sensitivity clearance; withheld memory gets `BLOCK_AUDIENCE`
+  in the trace), and the Output Gate inspects the generated answer and redacts/refuses
+  content that would disclose a blocked memory (deterministic, no-throw, audited
+  `output_gate_blocked`, `output_gate` response block). On by default but no-op for the
+  default `private` audience + honest model. `MEMORYOPS_RECALL_GATE` /
+  `MEMORYOPS_OUTPUT_GATE` / `MEMORYOPS_OUTPUT_GATE_MODE`. See ADR-023, `docs/recall-output-gates.md`.
 - `services/api/app/embeddings` — swappable `EmbeddingProvider` (stub default + optional OpenAI).
   `MEMORYOPS_EMBEDDING_PROVIDER=stub|openai`. `app/core/embeddings.py` is a back-compat shim.
 - `services/api/app/auth` — identity-neutral auth + authorization adapters (v1.6).

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -28,8 +28,12 @@ Request:
 ```json
 { "tenant_id": "tenant_demo", "user_id": "user_demo",
   "message": "Remember that I prefer enterprise-style explanations.",
-  "temporary_chat": false, "conversation_id": null }
+  "temporary_chat": false, "conversation_id": null, "audience": "private" }
 ```
+`audience ∈ {private (default), team, public}` (v1.9) — the Recall Gate recalls a
+memory only if its sensitivity is within the audience's clearance (`private`=all,
+`team`=low+medium, `public`=low). A withheld memory appears in `trace.memories_blocked`
+with `admission_decision: "BLOCK_AUDIENCE"`.
 Response:
 ```json
 { "assistant_message": "...",
@@ -53,10 +57,15 @@ Response:
       "admission_decision": "ALLOW", "admission_reason": "...", "retrieval_score": 0.42,
       "score_breakdown": { "vector_similarity": 0.84 } }],
     "memories_blocked": [] },
+  "output_gate": null,
   "loop_evidence": { "memory.read": "completed", "memory.write": "completed" },
   "trace_id": "..." }
 ```
 `decision ∈ {SAVE, PENDING_APPROVAL, BLOCK, DROP_LOW_UTILITY, UPDATE_EXISTING, MERGE_WITH_EXISTING}`.
+`output_gate` (v1.9) is present only when the Output Gate acted:
+`{ "action": "redacted"|"refused", "disclosures": n, "escalated": true }` — the answer
+would have disclosed a memory the Recall/Admission gates blocked. `admission_decision`
+gains `BLOCK_AUDIENCE` (Recall Gate).
 
 **Context Admission Gate + Memory Usage Trace (v1.3).** A memory enters context
 only if it is relevant **and** allowed. The optional `trace` block is the

--- a/docs/recall-output-gates.md
+++ b/docs/recall-output-gates.md
@@ -1,0 +1,89 @@
+# Recall Gate + Output Gate
+
+Governance has two edges around the model, not one. The
+[Context Admission Gate](context-admission-gate.md) decides what memory *enters* the
+prompt. v1.9 ([ADR-023](../infra/adr/ADR-023-recall-output-gates.md)) adds the missing
+audience dimension on the way in — the **Recall Gate** — and a second control on the
+way out — the **Output Gate**.
+
+```
+retrieve → rank → admission → RECALL → compose → LLM → OUTPUT GATE → answer
+                              (v1.9)                     (v1.9)
+```
+
+Both are **on by default but no-op** unless there is something to protect: the default
+`private` audience clears every sensitivity, and an honest model discloses nothing, so
+existing behavior is unchanged.
+
+## Recall Gate — audience-aware entry
+
+Admission answers "is this memory allowed at all?" (deleted / expired / consent /
+tombstone / relevance). The Recall Gate answers "should it be recalled for **this**
+session?" A memory that is perfectly admissible for a private session must not be
+recalled into a shared or public one.
+
+Each request carries an `audience`; a memory is recalled only if its `sensitivity` is
+within that audience's clearance:
+
+| `audience` | recalls sensitivities |
+| --- | --- |
+| `private` (default) | low + medium + high |
+| `team` | low + medium |
+| `public` | low only |
+
+A memory the gate withholds shows up in the [Memory Usage Trace](context-admission-gate.md)
+as `memories_blocked` with decision **`BLOCK_AUDIENCE`** — same trace, metrics, and
+audit machinery as every other block. The gate only ever *removes* memory
+(defense-in-depth; tenant isolation and the deletion guarantee are untouched).
+
+```jsonc
+// POST /api/chat  { …, "audience": "public" }
+// a high-sensitivity memory is blocked from context:
+"trace": { "memories_blocked": [
+  { "memory_id": "…", "sensitivity": "high",
+    "admission_decision": "BLOCK_AUDIENCE",
+    "admission_reason": "sensitivity 'high' exceeds 'public' audience clearance" }
+]}
+```
+
+## Output Gate — disclosure control after generation
+
+The pre-composition gates can't see what the model *says*. A real LLM can ignore
+instructions and echo withheld context, be coaxed by prompt injection, or infer and
+restate blocked material. The Output Gate inspects the generated answer and catches
+content that would disclose a memory the Recall/Admission gates blocked.
+
+It is **deterministic and no-throw**: it flags a disclosure when the answer shares a
+distinctive contiguous phrase (≥ 4 significant words) with a *protected* (blocked)
+memory, then:
+
+- `redact` (default) — replaces the offending spans with `[redacted]`;
+- `refuse` — returns a safe refusal message instead of the answer.
+
+Either way it sets an escalation flag, appends an `output_gate_blocked` audit event,
+and surfaces an `output_gate` block on the response. On any internal error it returns
+the original answer unchanged — the gate never fails a request.
+
+```jsonc
+// when the model would have leaked a blocked memory:
+"output_gate": { "action": "redacted", "disclosures": 1, "escalated": true }
+```
+
+## Toggles
+
+| Env | Default | Effect |
+| --- | --- | --- |
+| `MEMORYOPS_RECALL_GATE` | `true` | audience-aware recall (no-op for `private`) |
+| `MEMORYOPS_OUTPUT_GATE` | `true` | post-generation disclosure control |
+| `MEMORYOPS_OUTPUT_GATE_MODE` | `redact` | `redact` or `refuse` |
+| request `audience` | `private` | `private` / `team` / `public` |
+
+## Where this sits
+
+- Recall/Admission are **before** the prompt (what may enter context); the Output Gate
+  is **after** generation (what the answer may reveal). Together they close the loop
+  the deletion-leakage evals (v1.5) measure: not just "deleted memory isn't retrieved"
+  but "withheld memory isn't disclosed."
+- The Output Gate is a deterministic backstop, not a semantic classifier — it catches
+  echoed/near-verbatim disclosure. Paraphrase-level inference is out of scope (and is
+  where a future LLM-judge output check would go).

--- a/infra/adr/ADR-023-recall-output-gates.md
+++ b/infra/adr/ADR-023-recall-output-gates.md
@@ -1,0 +1,57 @@
+# ADR-023 — Recall Gate + Output Gate
+
+- Status: Accepted (v1.9)
+- Date: 2026-07-09
+- Supersedes: none
+- Related: ADR-017 (admission gate + usage trace), ADR-018 (tombstone lineage),
+  ADR-013 (governance / sensitivity)
+
+## Context
+
+The Context Admission Gate (v1.3) governs one edge: what memory enters the prompt. It
+decides admissibility (deleted / expired / consent / tombstone / relevance) but is
+**audience-blind** — a high-sensitivity memory that is fine for a private session is
+admitted identically into a shared or public one. And nothing governs the *other* edge:
+once the prompt is built, a real LLM may ignore instructions, be prompt-injected, or
+infer and restate memory that governance deliberately withheld. "Not admitted" is not
+the same as "not disclosed."
+
+## Decision
+
+Add two gates that bracket generation.
+
+- **Recall Gate (`app/services/recall_gate.py`)** — audience-aware entry. Each request
+  carries an `audience` (`private` | `team` | `public`); the gate re-blocks any
+  *admitted* memory whose `sensitivity` exceeds that audience's clearance
+  (`private` = low+medium+high, `team` = low+medium, `public` = low). It runs after
+  admission / before compose, consumes the admitted `AdmissionRecord`s, and emits a
+  `BLOCK_AUDIENCE` decision — reusing the existing Memory Usage Trace, metrics, and
+  audit path. Default `private` clears everything, so behavior is unchanged.
+- **Output Gate (`app/services/output_gate.py`)** — disclosure control after
+  generation. It inspects the answer and flags a disclosure when it shares a
+  distinctive contiguous phrase (≥ 4 significant words) with a *protected* (blocked)
+  memory, then `redact`s the offending spans (default) or `refuse`s with a safe
+  message. Deterministic + no-throw: on any error it returns the answer unchanged; it
+  only ever removes information, never adds. Acting is audited (`output_gate_blocked`)
+  and surfaced as an `output_gate` block on the response.
+- **Additive schema.** `ChatRequest.audience` (default `private`) and an optional
+  `ChatResponse.output_gate` — no breaking change. Toggles `MEMORYOPS_RECALL_GATE`,
+  `MEMORYOPS_OUTPUT_GATE`, `MEMORYOPS_OUTPUT_GATE_MODE`.
+
+## Consequences
+
+- Governance now controls both edges: what enters context (recall/admission) *and*
+  what the answer may reveal (output) — closing the loop the deletion-leakage evals
+  (v1.5) measure.
+- On by default but no-op for the default `private` audience + an honest model, so all
+  prior tests pass unchanged (+9 new). Defense-in-depth: both gates only remove.
+- The Recall Gate's blocks flow through the same trace/metrics/audit as admission, so
+  they are explainable for free.
+
+## Out of scope (later)
+
+- Semantic / paraphrase-level disclosure detection (an LLM-judge output check) — the
+  deterministic gate catches echoed/near-verbatim disclosure only.
+- Per-memory ACLs / named audiences beyond the three clearance tiers.
+- Coupling `audience` to the v1.6 authenticated principal (e.g. deriving clearance
+  from a JWT claim) — the hook exists; wiring it is a later enhancement.

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -53,6 +53,16 @@ class Settings(BaseSettings):
     admission_block_sensitive: bool = False  # block sensitivity='high' from context
     admission_min_score: float = 0.0  # block ranked score below this (0 = disabled)
 
+    # Recall Gate + Output Gate (v1.9, ADR-023). The Recall Gate admits a memory into
+    # context only if its sensitivity is permitted for the request's `audience`
+    # (default "private" = full clearance → no behavior change). The Output Gate
+    # inspects the generated answer and redacts/refuses content that would disclose a
+    # memory the gates blocked. Both ON by default but no-op unless there is something
+    # to protect. `output_gate_mode` = redact | refuse.
+    recall_gate_enabled: bool = True
+    output_gate_enabled: bool = True
+    output_gate_mode: Literal["redact", "refuse"] = "redact"
+
     # Storage backend: "memory" runs with no infra (default for dev/tests),
     # "postgres" uses SQLAlchemy + pgvector.
     storage: Literal["memory", "postgres"] = "memory"
@@ -200,6 +210,13 @@ def get_settings() -> Settings:
     if (val := os.getenv("MEMORYOPS_ADMISSION_MIN_SCORE")) is not None:
         with contextlib.suppress(ValueError):
             overrides["admission_min_score"] = float(val)
+    # v1.9 Recall Gate + Output Gate knobs (ADR-023). Public operator toggles.
+    if (val := os.getenv("MEMORYOPS_RECALL_GATE")) is not None:
+        overrides["recall_gate_enabled"] = val.lower() not in ("0", "false", "no")
+    if (val := os.getenv("MEMORYOPS_OUTPUT_GATE")) is not None:
+        overrides["output_gate_enabled"] = val.lower() not in ("0", "false", "no")
+    if (val := os.getenv("MEMORYOPS_OUTPUT_GATE_MODE")) in ("redact", "refuse"):
+        overrides["output_gate_mode"] = val
     if (val := os.getenv("MEMORYOPS_STORAGE")) in ("memory", "postgres"):
         overrides["storage"] = val
     # v1.7 pluggable vector index (ADR-021). Public operator toggles; default "memory".

--- a/services/api/app/schemas/memory.py
+++ b/services/api/app/schemas/memory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -146,6 +146,25 @@ class ChatRequest(BaseModel):
     message: str
     temporary_chat: bool = False
     conversation_id: str | None = None
+    # Audience/clearance for this session (v1.9, ADR-023). The Recall Gate admits a
+    # memory into context only if its sensitivity is permitted for this audience:
+    #   private (default) → low + medium + high   (full clearance; no behavior change)
+    #   team              → low + medium
+    #   public            → low only
+    audience: Literal["private", "team", "public"] = "private"
+
+
+class OutputGateResult(BaseModel):
+    """Post-generation disclosure control (v1.9, ADR-023).
+
+    The Output Gate inspects the final answer *after* generation and redacts (or
+    refuses) content that would disclose memory the Recall/Admission gates blocked —
+    catching leakage the pre-composition gates cannot see.
+    """
+
+    action: str  # allow | redacted | refused
+    disclosures: int = 0  # number of protected memories whose content was caught
+    escalated: bool = False
 
 
 class Compression(BaseModel):
@@ -198,6 +217,9 @@ class ChatResponse(BaseModel):
     # Optional memory usage trace: the permissioned, explainable memory trail
     # behind this answer (v1.3, ADR-017). Present when the trace is enabled.
     trace: MemoryUsageTrace | None = None
+    # Optional Output Gate result (v1.9, ADR-023). Present only when the gate acted
+    # (redacted / refused) — i.e. it caught a would-be disclosure post-generation.
+    output_gate: OutputGateResult | None = None
     loop_evidence: dict[str, str] = Field(default_factory=dict)
     trace_id: str
 

--- a/services/api/app/services/admission_gate.py
+++ b/services/api/app/services/admission_gate.py
@@ -60,6 +60,7 @@ class AdmissionDecision(str, Enum):
     BLOCK_TOMBSTONED_ANCESTOR = "BLOCK_TOMBSTONED_ANCESTOR"  # derived from deleted memory
     BLOCK_SENSITIVE = "BLOCK_SENSITIVE"  # opt-in
     BLOCK_LOW_CONFIDENCE = "BLOCK_LOW_CONFIDENCE"  # opt-in
+    BLOCK_AUDIENCE = "BLOCK_AUDIENCE"  # recall gate: sensitivity exceeds audience clearance (v1.9)
 
 
 @dataclass

--- a/services/api/app/services/gateway.py
+++ b/services/api/app/services/gateway.py
@@ -36,6 +36,7 @@ from ..schemas.memory import (
     Compression,
     Economics,
     MemoryUsageTrace,
+    OutputGateResult,
     Source,
     UsedMemory,
 )
@@ -43,8 +44,10 @@ from .admission_gate import AdmissionGate, AdmissionResult
 from .audit import AuditService
 from .context_composer import ContextComposer
 from .extractor import Extractor
+from .output_gate import OutputGate
 from .policy_broker import PolicyBroker
 from .ranker import Ranker
+from .recall_gate import RecallGate
 from .retriever import Retriever
 from .write_service import WriteService
 
@@ -61,6 +64,7 @@ class Gateway:
         self._retriever = Retriever(repo)
         self._ranker = Ranker()
         self._admission_gate = AdmissionGate()
+        self._recall_gate = RecallGate()  # v1.9 audience-aware recall (ADR-023)
         self._composer = ContextComposer()
         self._compressor = get_compressor()
         self._llm = get_llm()
@@ -142,9 +146,9 @@ class Gateway:
             evidence={"tenant_scoped": True, "user_scoped": True, "active_only": True},
         )
 
-        def _read() -> tuple[str, list[UsedMemory], str, AdmissionResult | None]:
+        def _read():
             # v1.8: each read stage is a span under this turn's correlation id, so a
-            # trace shows retrieve → rank → admission → compose end to end (ADR-022).
+            # trace shows retrieve → rank → admission → recall → compose (ADR-022/023).
             with span("memory.read"):
                 with span("retrieve") as sp:
                     result = self._retriever.retrieve(req.tenant_id, req.user_id, req.message)
@@ -173,13 +177,28 @@ class Gateway:
                             admitted=len(admission.admitted),
                             blocked=len(admission.blocked_records),
                         )
+                # Recall Gate (v1.9, ADR-023): audience-aware entry — re-blocks any
+                # admitted memory whose sensitivity exceeds this session's clearance.
+                admitted_records = admission.admitted_records
+                recall_blocked: list = []
+                if get_app_settings().recall_gate_enabled:
+                    with span("recall") as sp:
+                        recall = self._recall_gate.evaluate(
+                            admitted_records, audience=req.audience
+                        )
+                        admitted_records = recall.allowed
+                        recall_blocked = recall.blocked
+                        if sp is not None:
+                            sp.attributes.update(
+                                audience=req.audience, blocked=len(recall_blocked)
+                            )
                 with span("compose"):
-                    block, used = self._composer.compose(admission.admitted)
-            return block, used, result.mode, admission
+                    block, used = self._composer.compose([r.ranked for r in admitted_records])
+            return block, used, result.mode, admission, admitted_records, recall_blocked
 
         _read_start = time.monotonic()
-        context_block, used_memories, retrieval_mode, admission = safe_call(
-            _read, default=("", [], "none", None), label="retrieval"
+        context_block, used_memories, retrieval_mode, admission, admitted_records, recall_blocked = (
+            safe_call(_read, default=("", [], "none", None, [], []), label="retrieval")
         )
         observe_retrieval(retrieval_mode, (time.monotonic() - _read_start) * 1000)
 
@@ -188,8 +207,15 @@ class Gateway:
         if admission is not None:
             for record in admission.records:
                 record_admission_decision(record.decision.value)
-            blocked = admission.blocked_records
+            # v1.9: the Recall Gate's audience blocks join the admission blocks, so
+            # the trace, metrics, and audit explain them uniformly (ADR-023).
+            for record in recall_blocked:
+                record_admission_decision(record.decision.value)
+            blocked = admission.blocked_records + recall_blocked
             if blocked:
+                counts = admission.counts()
+                if recall_blocked:
+                    counts["BLOCK_AUDIENCE"] = counts.get("BLOCK_AUDIENCE", 0) + len(recall_blocked)
                 self._audit.record(
                     tenant_id=req.tenant_id,
                     user_id=req.user_id,
@@ -198,16 +224,19 @@ class Gateway:
                     trace_id=trace_id,
                     metadata={
                         "blocked_count": len(blocked),
-                        "decisions": admission.counts(),
+                        "decisions": counts,
                         "blocked_memory_ids": [r.memory.id for r in blocked],
                     },
                 )
             if get_app_settings().memory_trace_enabled:
+                counts = admission.counts()
+                if recall_blocked:
+                    counts["BLOCK_AUDIENCE"] = counts.get("BLOCK_AUDIENCE", 0) + len(recall_blocked)
                 trace = MemoryUsageTrace(
                     response_id=trace_id,
-                    memories_used=[r.to_trace_entry() for r in admission.admitted_records],
+                    memories_used=[r.to_trace_entry() for r in admitted_records],
                     memories_blocked=[r.to_trace_entry() for r in blocked],
-                    admission_counts=admission.counts(),
+                    admission_counts=counts,
                 )
         emit_loop_event_sync(
             self._repo,
@@ -368,6 +397,39 @@ class Gateway:
         # ── Response generation ────────────────────────────────────────────────
         answer = self._llm.complete(system=llm_context, user=req.message)
 
+        # ── Output Gate (v1.9, ADR-023): the mirror of the Recall/Admission gates on
+        # the way out — inspect the generated answer and redact/refuse any content
+        # that would disclose a memory those gates blocked. No-throw; only ever
+        # removes information from the answer, never adds.
+        output_gate_result: OutputGateResult | None = None
+        if get_app_settings().output_gate_enabled and admission is not None:
+            protected = admission.blocked_records + recall_blocked
+            with span("output_gate") as _sp:
+                review = OutputGate(mode=get_app_settings().output_gate_mode).review(
+                    answer, protected=protected
+                )
+                if _sp is not None:
+                    _sp.attributes.update(action=review.action, disclosures=review.disclosures)
+            if review.action != "allow":
+                answer = review.answer
+                output_gate_result = OutputGateResult(
+                    action=review.action,
+                    disclosures=review.disclosures,
+                    escalated=review.escalated,
+                )
+                self._audit.record(
+                    tenant_id=req.tenant_id,
+                    user_id=req.user_id,
+                    action="output_gate_blocked",
+                    reason=f"output gate {review.action}: {review.disclosures} disclosure(s) caught",
+                    trace_id=trace_id,
+                    metadata={
+                        "action": review.action,
+                        "disclosures": review.disclosures,
+                        "protected_memory_ids": review.protected_ids,
+                    },
+                )
+
         # ── WRITE path (policy before storage) ─────────────────────────────────
         write_loop = start_loop_run_sync(
             self._repo,
@@ -522,6 +584,7 @@ class Gateway:
             compression=compression,
             economics=economics,
             trace=trace,
+            output_gate=output_gate_result,
             loop_evidence={
                 "memory.read": read_status.value,
                 "memory.write": LoopStatus.COMPLETED.value,

--- a/services/api/app/services/output_gate.py
+++ b/services/api/app/services/output_gate.py
@@ -1,0 +1,122 @@
+"""Output Gate — post-generation disclosure control (v1.9, ADR-023).
+
+The Recall/Admission gates decide what memory enters the prompt. The **Output Gate**
+is the mirror on the way out: it inspects the *generated answer* and catches content
+that would disclose memory those gates deliberately withheld — a real LLM that ignores
+instructions and echoes withheld context, prompt-injection that coaxes it out, or a
+model that infers and restates blocked material.
+
+Deterministic + no-throw (invariant #4): it flags a disclosure when the answer shares a
+distinctive contiguous phrase with a *protected* (blocked) memory, then either redacts
+those spans or refuses. It never fabricates content and never blocks on error — on any
+failure it returns the original answer unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+_WORD = re.compile(r"[a-z0-9]+")
+_MIN_PHRASE_WORDS = 4  # a shared run this long is a disclosure, not a coincidence
+_REDACTION = "[redacted]"
+
+
+def _words(text: str) -> list[str]:
+    return _WORD.findall(text.lower())
+
+
+def _ngrams(words: list[str], n: int) -> set[tuple[str, ...]]:
+    return {tuple(words[i : i + n]) for i in range(len(words) - n + 1)} if len(words) >= n else set()
+
+
+@dataclass
+class OutputReview:
+    answer: str
+    action: str = "allow"  # allow | redacted | refused
+    disclosures: int = 0
+    escalated: bool = False
+    protected_ids: list[str] = field(default_factory=list)
+
+
+class OutputGate:
+    """Catch memory-derived disclosure in the final answer.
+
+    `mode` = "redact" (default) replaces the offending spans; "refuse" returns a safe
+    refusal message when any disclosure is found.
+    """
+
+    _REFUSAL = (
+        "I can't share that — it would disclose information that isn't permitted in "
+        "this context."
+    )
+
+    def __init__(self, *, mode: str = "redact", min_phrase_words: int = _MIN_PHRASE_WORDS) -> None:
+        self._mode = mode
+        self._n = max(2, min_phrase_words)
+
+    def review(self, answer: str, *, protected: list) -> OutputReview:
+        """`protected` = memories that must NOT be disclosed (the blocked records)."""
+        if not answer or not protected:
+            return OutputReview(answer=answer)
+        try:
+            return self._review(answer, protected)
+        except Exception:  # noqa: BLE001 - never let the gate break a response
+            return OutputReview(answer=answer)
+
+    def _review(self, answer: str, protected: list) -> OutputReview:
+        # Token spans over the original answer (positions are identical on the
+        # lowercased copy since casefolding preserves length here).
+        tokens = list(_WORD.finditer(answer.lower()))
+        words = [t.group() for t in tokens]
+        answer_ngrams = _ngrams(words, self._n)
+
+        # Union of all protected phrases, plus which memory each came from.
+        hit_ids: list[str] = []
+        protected_phrases: set[tuple[str, ...]] = set()
+        for rec in protected:
+            memory = getattr(rec, "memory", rec)
+            phrases = _ngrams(_words(getattr(memory, "content", "") or ""), self._n)
+            if phrases & answer_ngrams:
+                hit_ids.append(getattr(memory, "id", "?"))
+                protected_phrases |= phrases
+        if not hit_ids:
+            return OutputReview(answer=answer)
+
+        # Mark every word index covered by any shared phrase, then redact each
+        # maximal covered run in one pass — order-independent, no leftover fragments.
+        covered: set[int] = set()
+        for i in range(len(words) - self._n + 1):
+            if tuple(words[i : i + self._n]) in protected_phrases:
+                covered.update(range(i, i + self._n))
+        redacted = self._redact_runs(answer, tokens, covered)
+        if self._mode == "refuse":
+            return OutputReview(
+                answer=self._REFUSAL, action="refused",
+                disclosures=len(hit_ids), escalated=True, protected_ids=hit_ids,
+            )
+        return OutputReview(
+            answer=redacted, action="redacted",
+            disclosures=len(hit_ids), escalated=True, protected_ids=hit_ids,
+        )
+
+    @staticmethod
+    def _redact_runs(answer: str, tokens: list, covered: set[int]) -> str:
+        """Replace each maximal run of covered word-spans with a single [redacted]."""
+        out: list[str] = []
+        cursor = 0
+        i = 0
+        n = len(tokens)
+        while i < n:
+            if i in covered:
+                j = i
+                while j + 1 < n and (j + 1) in covered:
+                    j += 1
+                out.append(answer[cursor : tokens[i].start()])
+                out.append(_REDACTION)
+                cursor = tokens[j].end()
+                i = j + 1
+            else:
+                i += 1
+        out.append(answer[cursor:])
+        return "".join(out)

--- a/services/api/app/services/recall_gate.py
+++ b/services/api/app/services/recall_gate.py
@@ -1,0 +1,60 @@
+"""Recall Gate — audience-aware entry into context (v1.9, ADR-023).
+
+The Context Admission Gate (v1.3) decides whether a memory is *allowed* at all
+(deleted / expired / consent / tombstone / relevance). The **Recall Gate** adds the
+missing dimension: *should this memory be recalled for **this** session/audience?* A
+high-sensitivity memory that is perfectly admissible for a private session must not be
+recalled into a shared/public one.
+
+It runs after admission / before composition, consumes the already-admitted records,
+and re-blocks any whose sensitivity exceeds the audience's clearance — reusing the
+`AdmissionRecord` shape (decision `BLOCK_AUDIENCE`) so the existing Memory Usage Trace,
+metrics, and audit machinery explain it for free. Defense-in-depth: it only ever
+*removes* memory, never adds (invariants #1/#2 stay intact).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from ..schemas.memory import Sensitivity
+from .admission_gate import AdmissionDecision, AdmissionRecord
+
+# Which sensitivities each audience is cleared to recall.
+_CLEARANCE: dict[str, set[Sensitivity]] = {
+    "private": {Sensitivity.low, Sensitivity.medium, Sensitivity.high},
+    "team": {Sensitivity.low, Sensitivity.medium},
+    "public": {Sensitivity.low},
+}
+
+
+@dataclass
+class RecallResult:
+    allowed: list[AdmissionRecord]
+    blocked: list[AdmissionRecord]  # newly blocked by audience clearance
+
+    @property
+    def admitted_ranked(self):
+        return [r.ranked for r in self.allowed]
+
+
+class RecallGate:
+    def evaluate(self, admitted: list[AdmissionRecord], *, audience: str) -> RecallResult:
+        cleared = _CLEARANCE.get(audience, _CLEARANCE["private"])
+        allowed: list[AdmissionRecord] = []
+        blocked: list[AdmissionRecord] = []
+        for record in admitted:
+            if record.memory.sensitivity in cleared:
+                allowed.append(record)
+            else:
+                blocked.append(
+                    replace(
+                        record,
+                        decision=AdmissionDecision.BLOCK_AUDIENCE,
+                        reason=(
+                            f"sensitivity '{record.memory.sensitivity.value}' exceeds "
+                            f"'{audience}' audience clearance"
+                        ),
+                    )
+                )
+        return RecallResult(allowed=allowed, blocked=blocked)

--- a/services/api/tests/test_memory_read_loop.py
+++ b/services/api/tests/test_memory_read_loop.py
@@ -41,6 +41,29 @@ def test_read_path_emits_tracing_spans(gateway):
     )
 
 
+def test_read_path_recall_gate_blocks_by_audience(gateway, repo):
+    """v1.9: the read path runs the Recall Gate — a high-sensitivity memory is kept
+    out of context for a `public` audience without changing loop behavior."""
+    from app.db.entities import StoredMemory
+    from app.schemas.memory import ChatRequest, MemoryType, Sensitivity, Source, Status
+
+    seed = repo.create_memory(
+        StoredMemory(
+            tenant_id="t1", user_id="u1", memory_type=MemoryType.preference,
+            content="my confidential diagnosis is condition X", importance=7,
+            confidence=0.9, sensitivity=Sensitivity.high, status=Status.active,
+            source=Source(kind="chat", excerpt="diagnosis"), embedding=[1.0, 0.0, 0.0],
+        )
+    )
+    resp = gateway.handle_chat(
+        ChatRequest(tenant_id="t1", user_id="u1", message="what is my diagnosis", audience="public"),
+        trace_id="recall",
+    )
+    assert seed.id not in {u.memory_id for u in resp.used_memories}
+    blocked = {b.memory_id: b for b in resp.trace.memories_blocked} if resp.trace else {}
+    assert blocked.get(seed.id) and blocked[seed.id].admission_decision == "BLOCK_AUDIENCE"
+
+
 def test_memory_path_attaches_economics(gateway):
     """The read path attaches an advisory economics estimate (ADR-016) without
     altering loop behavior; token counters move and cost is 0 under stub providers."""

--- a/services/api/tests/test_recall_output_gates.py
+++ b/services/api/tests/test_recall_output_gates.py
@@ -1,0 +1,117 @@
+"""Recall Gate + Output Gate — audience-aware recall and disclosure control (v1.9, ADR-023).
+
+The Recall Gate keeps sensitive memory out of context for an under-cleared audience;
+the Output Gate catches memory-derived disclosure in the generated answer that the
+pre-composition gates couldn't see. Both are additive: with the default `private`
+audience and an honest (stub) model, behavior is unchanged.
+"""
+
+from __future__ import annotations
+
+from app.db.entities import StoredMemory
+from app.schemas.memory import ChatRequest, MemoryType, Sensitivity, Source, Status
+from app.services.admission_gate import AdmissionDecision, AdmissionRecord
+from app.services.output_gate import OutputGate
+from app.services.ranker import RankedMemory
+from app.services.recall_gate import RecallGate
+from app.services.retriever import ScoredCandidate
+
+
+def _record(sensitivity: Sensitivity, content: str = "secret plan", mem_id: str = "m1") -> AdmissionRecord:
+    mem = StoredMemory(
+        id=mem_id, tenant_id="t1", user_id="u1", memory_type=MemoryType.semantic,
+        content=content, importance=6, confidence=0.9, sensitivity=sensitivity,
+        status=Status.active, source=Source(kind="chat"),
+    )
+    ranked = RankedMemory(
+        candidate=ScoredCandidate(memory=mem, semantic=0.8, keyword=0.5),
+        score=0.8, score_breakdown={"vector_similarity": 0.8},
+    )
+    return AdmissionRecord(
+        ranked=ranked, decision=AdmissionDecision.ALLOW, reason="ok",
+        consent_status="granted", retention_status="none",
+    )
+
+
+# ── Recall Gate ──────────────────────────────────────────────────────────────────
+def test_recall_gate_private_allows_all():
+    recs = [_record(Sensitivity.high), _record(Sensitivity.medium), _record(Sensitivity.low)]
+    result = RecallGate().evaluate(recs, audience="private")
+    assert len(result.allowed) == 3 and not result.blocked
+
+
+def test_recall_gate_public_blocks_medium_and_high():
+    recs = [_record(Sensitivity.high, mem_id="h"), _record(Sensitivity.medium, mem_id="m"),
+            _record(Sensitivity.low, mem_id="l")]
+    result = RecallGate().evaluate(recs, audience="public")
+    assert {r.memory.id for r in result.allowed} == {"l"}
+    assert {r.memory.id for r in result.blocked} == {"h", "m"}
+    assert all(r.decision is AdmissionDecision.BLOCK_AUDIENCE for r in result.blocked)
+
+
+def test_recall_gate_team_allows_medium_blocks_high():
+    recs = [_record(Sensitivity.high, mem_id="h"), _record(Sensitivity.medium, mem_id="m")]
+    result = RecallGate().evaluate(recs, audience="team")
+    assert {r.memory.id for r in result.allowed} == {"m"}
+    assert {r.memory.id for r in result.blocked} == {"h"}
+
+
+# ── Output Gate ──────────────────────────────────────────────────────────────────
+def test_output_gate_allows_when_no_protected_content_leaks():
+    protected = [_record(Sensitivity.high, content="the launch date is next tuesday")]
+    review = OutputGate().review("Here is a general answer about scheduling.", protected=protected)
+    assert review.action == "allow" and review.answer.startswith("Here is a general")
+
+
+def test_output_gate_redacts_disclosed_phrase():
+    protected = [_record(Sensitivity.high, content="the launch date is next tuesday")]
+    answer = "Sure — the launch date is next tuesday, don't tell anyone."
+    review = OutputGate(mode="redact").review(answer, protected=protected)
+    assert review.action == "redacted" and review.escalated
+    assert "next tuesday" not in review.answer.lower()
+    assert "[redacted]" in review.answer
+
+
+def test_output_gate_refuse_mode_returns_safe_message():
+    protected = [_record(Sensitivity.high, content="the launch date is next tuesday")]
+    review = OutputGate(mode="refuse").review("the launch date is next tuesday", protected=protected)
+    assert review.action == "refused" and "launch date" not in review.answer.lower()
+
+
+def test_output_gate_is_noop_without_protected():
+    review = OutputGate().review("anything at all here", protected=[])
+    assert review.action == "allow"
+
+
+# ── End-to-end through the gateway ───────────────────────────────────────────────
+def _seed(repo, content, sensitivity):
+    m = StoredMemory(
+        tenant_id="t1", user_id="u1", memory_type=MemoryType.preference,
+        content=content, importance=7, confidence=0.9, sensitivity=sensitivity,
+        status=Status.active, source=Source(kind="chat", excerpt=content),
+        embedding=[1.0, 0.0, 0.0],
+    )
+    return repo.create_memory(m)
+
+
+def test_public_audience_blocks_high_sensitivity_from_context(gateway, repo):
+    seed = _seed(repo, "my private diagnosis is condition X", Sensitivity.high)
+    resp = gateway.handle_chat(
+        ChatRequest(tenant_id="t1", user_id="u1", message="what is my diagnosis", audience="public"),
+        trace_id="pub",
+    )
+    # The high-sensitivity memory is recall-blocked for a public audience.
+    assert seed.id not in {u.memory_id for u in resp.used_memories}
+    blocked = {b.memory_id: b for b in resp.trace.memories_blocked} if resp.trace else {}
+    assert blocked.get(seed.id) and blocked[seed.id].admission_decision == "BLOCK_AUDIENCE"
+
+
+def test_private_audience_is_unchanged(gateway, repo):
+    seed = _seed(repo, "my private diagnosis is condition X", Sensitivity.high)
+    resp = gateway.handle_chat(
+        ChatRequest(tenant_id="t1", user_id="u1", message="what is my diagnosis", audience="private"),
+        trace_id="priv",
+    )
+    # Default private clearance recalls it as before.
+    assert seed.id in {u.memory_id for u in resp.used_memories}
+    assert resp.output_gate is None  # nothing to redact


### PR DESCRIPTION
Governance on both edges of generation. **Recall Gate**: audience-aware context entry (`ChatRequest.audience` = private|team|public → sensitivity clearance; withheld memory gets `BLOCK_AUDIENCE` in the trace). **Output Gate**: inspects the generated answer and redacts/refuses content that would disclose a blocked memory (deterministic, no-throw, audited, `output_gate` response block). On by default but no-op for default `private` audience + honest model.

Full suite 345 passed. Docs: docs/recall-output-gates.md, ADR-023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)