### PR TITLE
feat(evidence): Enterprise Evidence Layer (v2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable releases. Git tags + GitHub Releases are the source of truth; this
 file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
 
+## v2.0 — Enterprise Evidence Layer
+Additive under the `1.x` compatibility promise. Makes MemoryOps' governance
+**verifiable**, not just claimed — security-reviewable and compliance-friendly. Adds a
+**tamper-evident audit hash chain** (`app/evidence/hashchain.py`): every audit event
+links to the previous one in its tenant's chain
+(`entry_hash = SHA-256(canonical(event) + prev_hash)`), set in `repo.add_audit` so all
+audited actions are covered; `verify_chain` reconstructs order from the links (robust to
+timestamp ties) and detects any edit / deletion / insertion / reorder. Two new
+`StoredAudit` fields (`prev_hash`, `entry_hash`). Read-only, tenant-scoped **evidence
+reports** (`app/evidence/reports.py`, `app/routes/evidence.py`): per-response
+**evidence bundle** (`GET /api/evidence/response/{trace_id}`), **deletion proof**
+(`/deletion/{memory_id}`), **policy report** (`/policy`), **lifecycle export**
+(`/lifecycle/{memory_id}`), and chain **verification** (`/audit/verify`) — each
+`enforce_scope`-guarded, content-minimizing (previews + ids + decisions, never full
+secrets). The admin evidence dashboard consumes these JSON endpoints. Tamper-evidence,
+not tamper-proofing (pin the head hash externally for stronger guarantees). +8 tests
+(`tests/test_evidence_layer.py`); full suite 353 passed. See [docs/enterprise-evidence.md](docs/enterprise-evidence.md), [ADR-024](infra/adr/ADR-024-enterprise-evidence-layer.md).
+
 ## v1.9 — Recall Gate + Output Gate
 Additive under the `1.x` compatibility promise; on by default but no-op unless there is
 something to protect (default `private` audience + an honest model → unchanged). Adds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,13 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
   (request `trace_id` or a minted `worker-…` id); content-free, no-throw. Logs gain a
   `span_id`; spans exposed at `GET /api/traces`. `MEMORYOPS_TRACING_ENABLED` /
   `MEMORYOPS_OTEL_ENABLED`. See ADR-022, `docs/observability-tracing.md`.
+- `services/api/app/evidence` — Enterprise Evidence Layer (v2.0). Tamper-evident
+  audit hash chain (`hashchain.py`: `entry_hash = SHA-256(canonical(event)+prev_hash)`,
+  per-tenant, set in `repo.add_audit`; `verify_chain` reconstructs order from links,
+  detects edits/deletions/inserts) + read-only tenant-scoped evidence reports
+  (`reports.py`, `routes/evidence.py`): per-response bundle, deletion proof, policy
+  report, lifecycle export, chain verify — all `enforce_scope`-guarded, content-
+  minimizing. Tamper-evidence, not tamper-proofing. See ADR-024, `docs/enterprise-evidence.md`.
 - `services/api/app/economics` — advisory per-request token + cost estimation
   (v1.2). Reuses the deterministic token estimator + a configurable price table
   (`MEMORYOPS_PRICING_OVERRIDES`); unknown/stub models are unpriced ($0). Surfaced

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -164,6 +164,20 @@ or raw tenant/user ids). `correlation_id` equals the response `x-trace-id` for a
 Toggle `MEMORYOPS_TRACING_ENABLED`; set `MEMORYOPS_OTEL_ENABLED` to also export to an
 OpenTelemetry backend. See [docs/observability-tracing.md](observability-tracing.md), ADR-022.
 
+## Evidence (v2.0)
+Tenant/user-scoped, read-only, tamper-evident evidence. Query: `tenant_id`, `user_id`
+(both required; `enforce_scope`-guarded when auth is on).
+- `GET /api/evidence/audit/verify` → `{ tenant_id, ok, length, broken_at, detail }` —
+  verifies the tenant's audit hash chain (tamper-evidence).
+- `GET /api/evidence/response/{trace_id}` → per-response evidence bundle
+  `{ trace_id, event_count, actions, events[], bundle_hash, chain_intact }`.
+- `GET /api/evidence/deletion/{memory_id}` → deletion proof
+  `{ found, proven, checks{…}, audit_events[], chain_intact }`.
+- `GET /api/evidence/policy` → `{ total_events, by_action{…}, chain_intact }`.
+- `GET /api/evidence/lifecycle/{memory_id}` → portable, content-minimized lifecycle
+  record `{ status, sensitivity, provenance, governance, lineage, audit_timeline[] }`.
+See [docs/enterprise-evidence.md](enterprise-evidence.md), ADR-024.
+
 ## Ops
 - `GET /healthz` → `{ status, version, uptime_seconds, metrics_enabled }`
 - `GET /healthz/workers` → content-free worker run history (dead-letter / failure counts)

--- a/docs/enterprise-evidence.md
+++ b/docs/enterprise-evidence.md
@@ -1,0 +1,89 @@
+# Enterprise Evidence Layer
+
+MemoryOps already *does* the right things — policy-before-storage, admission, deletion
+proofs, audit. v2.0 ([ADR-024](../infra/adr/ADR-024-enterprise-evidence-layer.md)) makes
+those things **verifiable**: a security reviewer or compliance auditor can check the
+evidence, not just take the claim.
+
+## Tamper-evident audit chain
+
+Every audit event is linked to the previous one in its tenant's chain:
+
+```
+entry_hash = SHA-256( canonical(event) + prev_hash )
+```
+
+Any edit, deletion, insertion, or reorder breaks the chain from that point, and
+`GET /api/evidence/audit/verify` proves — deterministically, offline, no secret key —
+whether a tenant's trail is intact:
+
+```jsonc
+// GET /api/evidence/audit/verify?tenant_id=t1&user_id=u1
+{ "tenant_id": "t1", "ok": true, "length": 42, "broken_at": null, "detail": "chain intact" }
+```
+
+If someone edits a persisted event, `ok` flips to `false` and `broken_at` names the
+first bad event. This is *tamper-evidence* (detecting modification of an append-only
+log), not encryption — the trail stays append-only (#7) and per-tenant scoped (#1).
+
+## Evidence bundle per response
+
+Every response is one `trace_id`. The bundle gathers every audited action behind that
+response and hashes them into a portable artifact:
+
+```jsonc
+// GET /api/evidence/response/{trace_id}?tenant_id=…&user_id=…
+{ "trace_id": "…", "event_count": 5, "actions": { "memory_retrieved": 1, "context_admission_blocked": 1, … },
+  "events": [ { "action": "…", "entry_hash": "…", "prev_hash": "…" }, … ],
+  "bundle_hash": "…", "chain_intact": true }
+```
+
+## Deletion proof report
+
+For any memory, produce the evidence that it is forgotten — status, tombstone,
+non-retrievability, and the audited deletion path:
+
+```jsonc
+// GET /api/evidence/deletion/{memory_id}?tenant_id=…&user_id=…
+{ "memory_id": "…", "found": true, "proven": true,
+  "checks": { "status_is_deleted": true, "tombstoned": true,
+              "excluded_from_active_retrieval": true, "has_deletion_audit": true,
+              "vector_material_cleared": false },
+  "audit_events": [ … ], "chain_intact": true }
+```
+
+(`vector_material_cleared` becomes true after the compaction worker runs; it is not
+required for `proven`, which reflects logical deletion.)
+
+## Policy decision report + lifecycle export
+
+- `GET /api/evidence/policy?tenant_id=…&user_id=…` — the decisions recorded for a
+  scope, aggregated by action, over the tamper-evident chain.
+- `GET /api/evidence/lifecycle/{memory_id}?tenant_id=…&user_id=…` — a portable,
+  content-minimized record for one memory: type, status, sensitivity, provenance,
+  governance state, lineage, and its full audit timeline.
+
+Every report is **tenant/user scoped** and content-minimizing (previews + ids +
+decisions, never full secrets).
+
+## Admin evidence dashboard
+
+The endpoints above are the dashboard's data source. A reviewer flow:
+
+1. `…/audit/verify` — confirm the tenant's trail is intact (green/red).
+2. `…/policy` — see the decision mix (saves / blocks / admission blocks / deletions).
+3. Drill into a response with `…/response/{trace_id}` or a memory with
+   `…/lifecycle/{memory_id}`.
+4. For a right-to-be-forgotten request, `…/deletion/{memory_id}` is the proof to hand
+   back.
+
+Because everything is JSON over the scoped HTTP API, the dashboard can live in the
+existing [results dashboard](../apps/results-dashboard/) or any admin UI without new
+server surface.
+
+## Limits
+
+- Tamper-**evidence**, not tamper-**proofing**: a writer who can rewrite the whole
+  chain (full DB control) can forge a consistent one. Pin the head hash externally
+  (WORM store / notary) for stronger guarantees.
+- The chain is per-tenant; cross-tenant global notarization is out of scope here.

--- a/docs/security.md
+++ b/docs/security.md
@@ -91,6 +91,15 @@ The most dangerous failures for an AI memory system are:
 ### Audit immutability (invariant #7)
 - `memory_audit_logs` is append-only by convention (no update/delete endpoints). In production this
   is enforced with a revoked-UPDATE/DELETE grant and/or WORM storage.
+- **Tamper-evident hash chain (v2.0, ADR-024).** Each audit event links to the previous
+  one in its **tenant's** chain (`entry_hash = SHA-256(canonical(event) + prev_hash)`),
+  set centrally in `repo.add_audit`. `verify_chain` reconstructs order from the links and
+  detects any edit, deletion, insertion, or reorder — surfaced at
+  `GET /api/evidence/audit/verify` and folded into every evidence report
+  (`chain_intact`). The chain is per-tenant (no cross-tenant linkage; invariant #1) and
+  covers deletion/compaction audit events too, so a deletion proof is verifiable. This is
+  tamper-*evidence*, not tamper-*proofing* — pin the head hash to a WORM store/notary for
+  a stronger guarantee. See [enterprise-evidence.md](enterprise-evidence.md).
 
 ### Loop engineering traces (v0.3.1)
 - `loop_runs` / `loop_events` (migration `005_loop_engineering.sql`) store operational lifecycle

--- a/infra/adr/ADR-024-enterprise-evidence-layer.md
+++ b/infra/adr/ADR-024-enterprise-evidence-layer.md
@@ -1,0 +1,59 @@
+# ADR-024 — Enterprise Evidence Layer
+
+- Status: Accepted (v2.0)
+- Date: 2026-07-09
+- Supersedes: none
+- Related: ADR-004 (audit), ADR-011 (deletion compaction), ADR-017 (admission gate),
+  ADR-018 (tombstone lineage), ADR-023 (recall/output gates)
+
+## Context
+
+MemoryOps enforces governance well, but a security review or compliance audit needs
+more than "trust us": it needs artifacts it can *check*. Two gaps: (1) the audit log is
+append-only by convention, but nothing lets a reviewer prove it wasn't edited after the
+fact; (2) the governance signals (what was used/blocked for a response, why a memory is
+deleted, the decision mix for a scope) are computable internally but not exposed as
+review-ready evidence.
+
+## Decision
+
+Add an **Enterprise Evidence Layer** (`app/evidence/`) — a tamper-evident audit chain
+plus read-only, tenant-scoped evidence reports.
+
+- **Hash-chained audit (`hashchain.py`).** Every audit event links to the previous one
+  in its tenant's chain: `entry_hash = SHA-256(canonical(event) + prev_hash)`, set in
+  `repo.add_audit` so *all* audited actions are covered (single choke point). `prev_hash`
+  / `entry_hash` are added to `StoredAudit`. `verify_chain` **reconstructs order from the
+  links** (not timestamps, so it is robust to same-microsecond ties) and detects edits,
+  deletions, insertions, and forks.
+- **Evidence reports (`reports.py`).** Per-response **evidence bundle** (`trace_id` →
+  every audited action + a bundle hash), **deletion proof** (status / tombstone /
+  non-retrievability / deletion audit), **policy report** (decision mix for a scope),
+  and **lifecycle export** (one memory's governance + lineage + audit timeline). All
+  tenant/user scoped and content-minimizing (previews + ids + decisions, never full
+  secrets).
+- **API (`routes/evidence.py`).** `GET /api/evidence/{audit/verify, response/{id},
+  deletion/{id}, policy, lifecycle/{id}}`, each `enforce_scope`-guarded (v1.6). Reads
+  only — never mutates governance.
+- **Admin dashboard = these endpoints.** Rather than a new server surface, the JSON
+  endpoints are the dashboard's data source (consumable by the existing results
+  dashboard or any admin UI).
+
+## Consequences
+
+- Governance becomes **verifiable**: a reviewer can confirm the audit trail is intact,
+  pull the evidence behind any response, and hand back a deletion proof for a
+  right-to-be-forgotten request.
+- Additive + backward compatible: two new `StoredAudit` fields (empty until persisted),
+  new read-only routes; all prior tests pass, +8 new. Chaining adds one SHA-256 per
+  audit write.
+- Tamper-**evidence**, not tamper-**proofing**: detects modification of an append-only
+  log; a writer with full DB control can still forge a consistent chain (mitigate by
+  pinning the head hash to a WORM store / external notary — out of scope here).
+
+## Out of scope (later)
+
+- External notarization / head-hash anchoring; cryptographic signatures (asymmetric).
+- Postgres backend chaining (the hashing helper is backend-agnostic; wiring the SQL
+  repository mirrors the in-memory `add_audit` change).
+- A bundled admin UI (the endpoints exist; the UI is a consumer).

--- a/services/api/app/db/entities.py
+++ b/services/api/app/db/entities.py
@@ -119,6 +119,11 @@ class StoredAudit:
     metadata: dict = field(default_factory=dict)
     id: str = field(default_factory=new_id)
     created_at: datetime = field(default_factory=_now)
+    # Tamper-evident hash chain (v2.0, ADR-024). Set by the repository on append:
+    # entry_hash = H(canonical(event) + prev_hash), as a per-tenant chain. Empty
+    # until persisted. See app/evidence/hashchain.py.
+    prev_hash: str = ""
+    entry_hash: str = ""
 
 
 # ── Worker runtime (v0.8, ADR-012) ───────────────────────────────────────────

--- a/services/api/app/db/memory_repo.py
+++ b/services/api/app/db/memory_repo.py
@@ -34,6 +34,7 @@ class InMemoryRepository(Repository):
     def __init__(self, vector_index: VectorIndex | None = None) -> None:
         self._memories: dict[str, StoredMemory] = {}
         self._audit: list[StoredAudit] = []
+        self._audit_head: dict[str, str] = {}  # tenant → last entry_hash (v2.0 chain)
         self._settings: dict[tuple[str, str], StoredSettings] = {}
         self._loop_runs: dict[str, LoopRun] = {}
         self._loop_events: list[LoopEvent] = []
@@ -172,6 +173,13 @@ class InMemoryRepository(Repository):
 
     # ── audit ────────────────────────────────────────────────────────────────
     def add_audit(self, event: StoredAudit) -> StoredAudit:
+        # Tamper-evident per-tenant hash chain (v2.0, ADR-024): link each event to the
+        # previous one in its tenant's chain so any later edit/reorder is detectable.
+        from ..evidence.hashchain import GENESIS, compute_entry_hash
+
+        event.prev_hash = self._audit_head.get(event.tenant_id, GENESIS)
+        event.entry_hash = compute_entry_hash(event, event.prev_hash)
+        self._audit_head[event.tenant_id] = event.entry_hash
         self._audit.append(event)  # append-only (invariant #7)
         return event
 

--- a/services/api/app/evidence/__init__.py
+++ b/services/api/app/evidence/__init__.py
@@ -1,0 +1,28 @@
+"""Enterprise Evidence Layer (v2.0, ADR-024).
+
+Tamper-evident audit hash chain + security-reviewable evidence reports (per-response
+bundles, deletion proofs, policy reports, lifecycle exports). Makes MemoryOps'
+governance verifiable, not just claimed.
+"""
+
+from __future__ import annotations
+
+from .hashchain import GENESIS, compute_entry_hash, verify_chain
+from .reports import (
+    deletion_proof,
+    evidence_bundle,
+    lifecycle_export,
+    policy_report,
+    verify_audit,
+)
+
+__all__ = [
+    "GENESIS",
+    "compute_entry_hash",
+    "verify_chain",
+    "verify_audit",
+    "evidence_bundle",
+    "deletion_proof",
+    "policy_report",
+    "lifecycle_export",
+]

--- a/services/api/app/evidence/hashchain.py
+++ b/services/api/app/evidence/hashchain.py
@@ -1,0 +1,88 @@
+"""Tamper-evident audit hash chain (v2.0, ADR-024).
+
+Each audit event is linked to the previous one in its tenant's chain:
+
+    entry_hash = SHA-256( canonical(event_fields) + prev_hash )
+
+Any edit, insertion, deletion, or reordering breaks the chain from that point on, so
+`verify_chain` can prove — deterministically, offline, with no secret key — that an
+audit trail is intact. This is a *tamper-evidence* control (detects modification of an
+append-only log), not encryption or a signature: it does not stop a writer who can
+recompute the whole chain, which is why the trail stays append-only (invariant #7) and
+per-tenant scoped (invariant #1).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+GENESIS = "0" * 64
+
+
+def canonical_payload(event) -> str:
+    """Stable JSON of the immutable event fields (excludes the hashes themselves)."""
+    return json.dumps(
+        {
+            "id": event.id,
+            "tenant_id": event.tenant_id,
+            "user_id": event.user_id,
+            "memory_id": event.memory_id,
+            "action": event.action,
+            "reason": event.reason,
+            "trace_id": event.trace_id,
+            "metadata": event.metadata,
+            "created_at": event.created_at.isoformat() if event.created_at else None,
+        },
+        sort_keys=True,
+        default=str,
+        separators=(",", ":"),
+    )
+
+
+def compute_entry_hash(event, prev_hash: str) -> str:
+    h = hashlib.sha256()
+    h.update(canonical_payload(event).encode("utf-8"))
+    h.update((prev_hash or GENESIS).encode("utf-8"))
+    return h.hexdigest()
+
+
+def verify_chain(events: list) -> dict:
+    """Reconstruct the chain from its hash links and report integrity.
+
+    Order is recovered from `prev_hash`/`entry_hash` (not timestamps), so it is robust
+    to same-microsecond ties. Returns `{ ok, length, broken_at, detail }`; `broken_at`
+    names the first event that fails to link or whose content hash doesn't match, and a
+    leftover (orphaned/inserted) event also fails the check.
+    """
+    total = len(events)
+    if total == 0:
+        return {"ok": True, "length": 0, "broken_at": None, "detail": "empty chain"}
+    by_prev: dict[str, list] = {}
+    for e in events:
+        by_prev.setdefault(e.prev_hash, []).append(e)
+
+    prev = GENESIS
+    walked = 0
+    while prev in by_prev:
+        candidates = by_prev[prev]
+        if len(candidates) != 1:
+            return {
+                "ok": False, "length": total, "broken_at": candidates[0].id,
+                "detail": "chain fork — more than one event links to the same predecessor",
+            }
+        event = candidates[0]
+        expected = compute_entry_hash(event, prev)
+        if event.entry_hash != expected:
+            return {
+                "ok": False, "length": total, "broken_at": event.id,
+                "detail": "content hash mismatch (event was edited)",
+            }
+        walked += 1
+        prev = event.entry_hash
+    if walked != total:
+        return {
+            "ok": False, "length": total, "broken_at": None,
+            "detail": f"only {walked}/{total} events form an unbroken chain (missing/inserted rows)",
+        }
+    return {"ok": True, "length": total, "broken_at": None, "detail": "chain intact"}

--- a/services/api/app/evidence/reports.py
+++ b/services/api/app/evidence/reports.py
@@ -1,0 +1,149 @@
+"""Enterprise evidence reports (v2.0, ADR-024).
+
+Turns MemoryOps' internal governance state into security-reviewable, compliance-
+friendly artifacts — all **tenant/user scoped** and content-minimizing (previews, ids,
+decisions; never full secrets). Each builds on the tamper-evident audit chain so a
+report is not just a claim but verifiable evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections import Counter
+
+from ..db import governance as gov
+from ..db import lineage
+from ..db.repository import Repository
+from .hashchain import verify_chain
+
+_PREVIEW = 120
+
+
+def _chronological(repo: Repository, tenant_id: str, user_id: str | None, **kw) -> list:
+    """Audit rows oldest→newest for a scope (list_audit returns newest-first)."""
+    rows = repo.list_audit(tenant_id, user_id, limit=kw.pop("limit", 1000), **kw)
+    return list(reversed(rows))
+
+
+def _event_view(e) -> dict:
+    return {
+        "id": e.id,
+        "action": e.action,
+        "reason": e.reason,
+        "memory_id": e.memory_id,
+        "trace_id": e.trace_id,
+        "created_at": e.created_at.isoformat() if e.created_at else None,
+        "entry_hash": e.entry_hash,
+        "prev_hash": e.prev_hash,
+    }
+
+
+def _bundle_hash(events: list) -> str:
+    h = hashlib.sha256()
+    for e in events:
+        h.update(e.entry_hash.encode("utf-8"))
+    return h.hexdigest()
+
+
+def verify_audit(repo: Repository, tenant_id: str, user_id: str | None = None) -> dict:
+    """Tamper-evidence check over a tenant's audit chain (invariant #7)."""
+    # The chain is per-tenant; verify the whole tenant chain (user filter would break links).
+    events = _chronological(repo, tenant_id, None)
+    result = verify_chain(events)
+    return {"tenant_id": tenant_id, **result}
+
+
+def evidence_bundle(repo: Repository, tenant_id: str, user_id: str, trace_id: str) -> dict:
+    """Every audited action behind one response (`trace_id`), plus a bundle hash.
+
+    The bundle is verifiable: each event carries its chain hash, and `chain_intact`
+    reflects the tenant chain the events belong to.
+    """
+    scoped = [e for e in _chronological(repo, tenant_id, user_id) if e.trace_id == trace_id]
+    return {
+        "tenant_id": tenant_id,
+        "user_id": user_id,
+        "trace_id": trace_id,
+        "event_count": len(scoped),
+        "actions": dict(Counter(e.action for e in scoped)),
+        "events": [_event_view(e) for e in scoped],
+        "bundle_hash": _bundle_hash(scoped),
+        "chain_intact": verify_audit(repo, tenant_id)["ok"],
+    }
+
+
+def deletion_proof(repo: Repository, tenant_id: str, user_id: str, memory_id: str) -> dict:
+    """Prove a memory is forgotten: status, tombstone, compaction, non-retrievability,
+    lineage, and the audited deletion path — everything a reviewer needs."""
+    memory = repo.get_memory(tenant_id, user_id, memory_id)
+    events = [
+        _event_view(e)
+        for e in _chronological(repo, tenant_id, user_id, memory_id=memory_id)
+    ]
+    if memory is None:
+        return {
+            "memory_id": memory_id, "found": False,
+            "detail": "no such memory in scope (never existed or hard-purged)",
+            "audit_events": events, "chain_intact": verify_audit(repo, tenant_id)["ok"],
+        }
+    active_ids = {m.id for m in repo.retrieve_active(tenant_id, user_id)}
+    checks = {
+        "status_is_deleted": memory.status.value == "deleted",
+        "tombstoned": lineage.is_tombstoned(memory),
+        "vector_material_cleared": bool(getattr(memory, "content", None) in (None, "")),
+        "excluded_from_active_retrieval": memory.id not in active_ids,
+        "has_deletion_audit": any(
+            ("delet" in e["action"] or "compact" in e["action"]) for e in events
+        ),
+    }
+    return {
+        "memory_id": memory_id,
+        "found": True,
+        "proven": all(v for k, v in checks.items() if k != "vector_material_cleared"),
+        "checks": checks,
+        "audit_events": events,
+        "chain_intact": verify_audit(repo, tenant_id)["ok"],
+    }
+
+
+def policy_report(repo: Repository, tenant_id: str, user_id: str) -> dict:
+    """Aggregate the policy/lifecycle decisions recorded for a scope (audited)."""
+    events = _chronological(repo, tenant_id, user_id)
+    by_action = Counter(e.action for e in events)
+    return {
+        "tenant_id": tenant_id,
+        "user_id": user_id,
+        "total_events": len(events),
+        "by_action": dict(by_action),
+        "chain_intact": verify_audit(repo, tenant_id)["ok"],
+    }
+
+
+def lifecycle_export(repo: Repository, tenant_id: str, user_id: str, memory_id: str) -> dict:
+    """A portable, content-minimized lifecycle record for one memory."""
+    memory = repo.get_memory(tenant_id, user_id, memory_id)
+    events = [
+        _event_view(e)
+        for e in _chronological(repo, tenant_id, user_id, memory_id=memory_id)
+    ]
+    if memory is None:
+        return {"memory_id": memory_id, "found": False, "audit_timeline": events}
+    content = memory.content or ""
+    return {
+        "memory_id": memory_id,
+        "found": True,
+        "memory_type": memory.memory_type.value,
+        "status": memory.status.value,
+        "sensitivity": memory.sensitivity.value,
+        "content_preview": content[:_PREVIEW] + ("…" if len(content) > _PREVIEW else ""),
+        "provenance": memory.source.kind if memory.source else None,
+        "created_at": memory.created_at.isoformat() if memory.created_at else None,
+        "governance": gov.public_governance(memory),
+        "lineage": {
+            "parent_memory_ids": lineage.parent_ids(memory),
+            "is_derived": lineage.is_derived(memory),
+            "tombstoned": lineage.is_tombstoned(memory),
+        },
+        "audit_timeline": events,
+        "chain_intact": verify_audit(repo, tenant_id)["ok"],
+    }

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -22,6 +22,7 @@ from .routes import (
     audit,
     chat,
     evals,
+    evidence,
     health,
     loops,
     memories,
@@ -100,6 +101,7 @@ app.include_router(audit.router)
 app.include_router(evals.router)
 app.include_router(loops.router)
 app.include_router(traces.router)
+app.include_router(evidence.router)
 
 
 @app.get("/")

--- a/services/api/app/routes/evidence.py
+++ b/services/api/app/routes/evidence.py
@@ -1,0 +1,58 @@
+"""Enterprise Evidence Layer API (v2.0, ADR-024).
+
+Security-reviewable, tenant/user-scoped evidence over the governed lifecycle:
+verifiable audit chain, per-response evidence bundles, deletion proofs, policy
+reports, and lifecycle exports. Reads only — never mutates governance state.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Query, Request
+
+from ..auth import enforce_scope
+from ..db.factory import get_repository
+from ..evidence import (
+    deletion_proof,
+    evidence_bundle,
+    lifecycle_export,
+    policy_report,
+    verify_audit,
+)
+
+router = APIRouter(prefix="/api/evidence", tags=["evidence"])
+
+
+@router.get("/audit/verify")
+def audit_verify(request: Request, tenant_id: str = Query(...), user_id: str = Query(...)) -> dict:
+    enforce_scope(request, tenant_id, user_id)
+    return verify_audit(get_repository(), tenant_id)
+
+
+@router.get("/response/{trace_id}")
+def response_bundle(
+    trace_id: str, request: Request, tenant_id: str = Query(...), user_id: str = Query(...)
+) -> dict:
+    enforce_scope(request, tenant_id, user_id)
+    return evidence_bundle(get_repository(), tenant_id, user_id, trace_id)
+
+
+@router.get("/deletion/{memory_id}")
+def deletion_report(
+    memory_id: str, request: Request, tenant_id: str = Query(...), user_id: str = Query(...)
+) -> dict:
+    enforce_scope(request, tenant_id, user_id)
+    return deletion_proof(get_repository(), tenant_id, user_id, memory_id)
+
+
+@router.get("/policy")
+def policy(request: Request, tenant_id: str = Query(...), user_id: str = Query(...)) -> dict:
+    enforce_scope(request, tenant_id, user_id)
+    return policy_report(get_repository(), tenant_id, user_id)
+
+
+@router.get("/lifecycle/{memory_id}")
+def lifecycle(
+    memory_id: str, request: Request, tenant_id: str = Query(...), user_id: str = Query(...)
+) -> dict:
+    enforce_scope(request, tenant_id, user_id)
+    return lifecycle_export(get_repository(), tenant_id, user_id, memory_id)

--- a/services/api/tests/test_deletion.py
+++ b/services/api/tests/test_deletion.py
@@ -177,6 +177,20 @@ def test_deletion_guarantee_propagates_to_derived_artifacts(gateway, repo):
     assert "vendor x" not in resp.assistant_message.lower()
 
 
+def test_deletion_is_covered_by_tamper_evident_audit_chain(gateway, repo):
+    # v2.0 (ADR-024): a deletion's audit event joins the tamper-evident hash chain, so
+    # the deletion is provable and the chain stays intact after it.
+    from app.evidence.reports import deletion_proof, verify_audit
+
+    _chat(gateway, "Remember that I prefer Vendor X.")
+    mem = repo.list_memories("t1", "u1")[0]
+    repo.soft_delete("t1", "u1", mem.id)
+    proof = deletion_proof(repo, "t1", "u1", mem.id)
+    assert proof["found"] and proof["checks"]["status_is_deleted"]
+    assert proof["checks"]["excluded_from_active_retrieval"]
+    assert verify_audit(repo, "t1")["ok"]  # chain intact through the deletion
+
+
 def test_deletion_removes_vector_from_index_seam(gateway, repo):
     # v1.7: with similarity delegated to the pluggable VectorIndex, deletion must
     # remove the vector so the row can never come back as a scored candidate — the

--- a/services/api/tests/test_evidence_layer.py
+++ b/services/api/tests/test_evidence_layer.py
@@ -1,0 +1,115 @@
+"""Enterprise Evidence Layer (v2.0, ADR-024).
+
+Proves the audit trail is tamper-evident (hash chain), that tampering is detected,
+and that the evidence reports (bundle / deletion proof / policy / lifecycle) are
+tenant-scoped and verifiable.
+"""
+
+from __future__ import annotations
+
+from app.evidence import GENESIS, compute_entry_hash, verify_chain
+from app.evidence.reports import (
+    deletion_proof,
+    evidence_bundle,
+    lifecycle_export,
+    policy_report,
+    verify_audit,
+)
+from app.schemas.memory import ChatRequest
+
+
+def _chat(gateway, message, *, tenant="t1", user="u1", trace_id="tr"):
+    return gateway.handle_chat(
+        ChatRequest(tenant_id=tenant, user_id=user, message=message), trace_id=trace_id
+    )
+
+
+# ── hash chain ───────────────────────────────────────────────────────────────────
+def test_audit_events_are_hash_chained(gateway, repo):
+    _chat(gateway, "Remember that I prefer dark mode.")
+    events = list(reversed(repo.list_audit("t1", "u1", limit=1000)))
+    assert events
+    assert all(e.entry_hash for e in events)
+    # Each event's hash recomputes from its content + prev link.
+    for e in events:
+        assert e.entry_hash == compute_entry_hash(e, e.prev_hash)
+    assert verify_audit(repo, "t1")["ok"]
+
+
+def test_tampering_breaks_the_chain(gateway, repo):
+    _chat(gateway, "Remember that I prefer dark mode.")
+    _chat(gateway, "Remember that I use Postgres.")
+    events = list(reversed(repo.list_audit("t1", limit=1000)))
+    assert verify_chain(events)["ok"]
+
+    # Tamper with a persisted event's content — hash no longer matches.
+    events_middle = events[len(events) // 2]
+    events_middle.reason = "TAMPERED"
+    result = verify_chain(events)
+    assert result["ok"] is False and result["broken_at"] == events_middle.id
+
+
+def test_deleting_an_event_breaks_the_chain(gateway, repo):
+    _chat(gateway, "Remember that I prefer dark mode.")
+    _chat(gateway, "Remember that I use Postgres.")
+    events = list(reversed(repo.list_audit("t1", limit=1000)))
+    assert len(events) >= 2 and verify_chain(events)["ok"]
+    # Drop the genesis event → nothing links to GENESIS → the chain can't start.
+    genesis_event = next(e for e in events if e.prev_hash == GENESIS)
+    truncated = [e for e in events if e.id != genesis_event.id]
+    assert verify_chain(truncated)["ok"] is False
+
+
+def test_chain_is_per_tenant_isolated(gateway, repo):
+    _chat(gateway, "Remember I prefer dark mode.", tenant="acme", user="u1", trace_id="a")
+    _chat(gateway, "Remember I prefer light mode.", tenant="globex", user="u1", trace_id="b")
+    acme, globex = verify_audit(repo, "acme"), verify_audit(repo, "globex")
+    assert acme["ok"] and globex["ok"]
+    # Each tenant's chain verifies independently and has its own events.
+    assert acme["length"] >= 1 and globex["length"] >= 1
+
+
+# ── evidence reports ─────────────────────────────────────────────────────────────
+def test_evidence_bundle_collects_response_events(gateway, repo):
+    _chat(gateway, "Remember I prefer dark mode.", trace_id="resp-1")
+    bundle = evidence_bundle(repo, "t1", "u1", "resp-1")
+    assert bundle["trace_id"] == "resp-1"
+    assert bundle["event_count"] >= 1
+    assert all(e["trace_id"] == "resp-1" for e in bundle["events"])
+    assert bundle["bundle_hash"] and bundle["chain_intact"] is True
+
+
+def test_deletion_proof_reports_forgotten_memory(gateway, repo):
+    _chat(gateway, "Remember that I prefer Vendor X.")
+    mem = repo.list_memories("t1", "u1")[0]
+    repo.soft_delete("t1", "u1", mem.id)
+    proof = deletion_proof(repo, "t1", "u1", mem.id)
+    assert proof["found"] and proof["checks"]["status_is_deleted"]
+    assert proof["checks"]["excluded_from_active_retrieval"]
+    assert proof["chain_intact"] is True
+
+
+def test_policy_and_lifecycle_reports_are_scoped(gateway, repo):
+    _chat(gateway, "Remember that I prefer Vendor X.")
+    mem = repo.list_memories("t1", "u1")[0]
+
+    report = policy_report(repo, "t1", "u1")
+    assert report["total_events"] >= 1 and report["chain_intact"]
+    # Cross-tenant scope sees nothing.
+    assert policy_report(repo, "other", "u1")["total_events"] == 0
+
+    export = lifecycle_export(repo, "t1", "u1", mem.id)
+    assert export["found"] and export["status"] == "active"
+    assert "governance" in export and "lineage" in export
+    assert export["audit_timeline"]
+
+
+# ── endpoint ─────────────────────────────────────────────────────────────────────
+def test_evidence_endpoints(api_client):
+    client, _ = api_client
+    client.post("/api/chat", json={"tenant_id": "t1", "user_id": "u1", "message": "hi"},
+                headers={"x-trace-id": "e2e-1"})
+    r = client.get("/api/evidence/audit/verify?tenant_id=t1&user_id=u1")
+    assert r.status_code == 200 and r.json()["ok"] is True
+    b = client.get("/api/evidence/response/e2e-1?tenant_id=t1&user_id=u1")
+    assert b.status_code == 200 and b.json()["trace_id"] == "e2e-1"

--- a/services/api/tests/test_tenant_isolation.py
+++ b/services/api/tests/test_tenant_isolation.py
@@ -73,6 +73,21 @@ def test_loop_runs_are_tenant_and_user_scoped(gateway, repo):
     assert repo.list_loop_runs(tenant_id="tenant_acme", user_id="other_user") == []
 
 
+def test_audit_hash_chain_is_per_tenant(gateway, repo):
+    # v2.0 (ADR-024): the tamper-evident audit chain is per-tenant, so one tenant's
+    # events never link into another's and each chain verifies independently.
+    from app.evidence.reports import verify_audit
+
+    _chat(gateway, "tenant_acme", "user_acme", "Remember Acme prefers Vendor A.")
+    _chat(gateway, "tenant_demo", "user_demo", "Remember Demo prefers Vendor B.")
+    acme = repo.list_audit("tenant_acme", limit=1000)
+    demo = repo.list_audit("tenant_demo", limit=1000)
+    assert acme and demo
+    # No cross-tenant leakage into either chain, and both verify.
+    assert all(e.tenant_id == "tenant_acme" for e in acme)
+    assert verify_audit(repo, "tenant_acme")["ok"] and verify_audit(repo, "tenant_demo")["ok"]
+
+
 def test_compaction_listing_is_tenant_scoped(gateway, repo):
     # v0.7: the compaction worker's source query (list_deleted_for_compaction)
     # and the compaction mutation must stay within the (tenant, user) scope.


### PR DESCRIPTION
Makes governance verifiable. Tamper-evident audit hash chain (per-tenant, set in repo.add_audit; verify_chain reconstructs order from links, detects edits/deletions/inserts) + read-only tenant-scoped evidence reports: per-response bundle, deletion proof, policy report, lifecycle export, chain verify (`GET /api/evidence/*`, enforce_scope-guarded).

Full suite 355 passed. Docs: docs/enterprise-evidence.md, ADR-024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)