### PR TITLE
feat(sdk): Agent Framework Integrations (v2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable releases. Git tags + GitHub Releases are the source of truth; this
 file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
 
+## v2.1 — Agent Framework Integrations
+Additive under the `1.x` compatibility promise. Makes MemoryOps easy to plug into real
+agent systems as the **governed memory layer** — one framework-agnostic adapter plus
+per-framework examples, not six bespoke SDKs. New `memoryops.GovernedMemory` exposes a
+uniform `remember` / `recall` / `context_for` / `answer` / `forget` / `withdraw_consent`
+surface over `MemoryOpsClient`, carries an `audience` (applied to every recall via the
+v1.9 Recall Gate), and adds **no** governance — the server stays authoritative.
+`GovernedMemory.for_audience(...)` gives a per-agent clearance view over one store (e.g.
+a customer-facing agent gets `public`, an internal agent `private`). The SDK `chat()`
+gains an additive `audience` parameter. Runnable, import-guarded examples ship for
+**LangGraph, LlamaIndex, CrewAI, AutoGen, Semantic Kernel, and the OpenAI Agents SDK**
+(`packages/memoryops-sdk/examples/integrations/`), each wrapping the adapter into that
+framework's memory/tool/plugin interface. The adapter is tested against the real
+in-process app (`tests/test_integrations.py`, +5). See [docs/agent-integrations.md](docs/agent-integrations.md), [ADR-025](infra/adr/ADR-025-agent-framework-integrations.md).
+
 ## v2.0 — Enterprise Evidence Layer
 Additive under the `1.x` compatibility promise. Makes MemoryOps' governance
 **verifiable**, not just claimed — security-reviewable and compliance-friendly. Adds a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,11 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
   examples (quickstart, FastAPI, RAG, agent memory). Additive client only — the
   server stays authoritative for all governance; the SDK adds none. Tested against
   the real app in-process via an injectable `httpx.Client`. See ADR-014 and
-  `docs/assistant-sdk.md`.
+  `docs/assistant-sdk.md`. **Agent framework integrations** (v2.1): a framework-
+  agnostic `GovernedMemory` adapter (`remember`/`recall`/`context_for`/`forget`,
+  audience-aware via `for_audience`) + import-guarded examples for LangGraph,
+  LlamaIndex, CrewAI, AutoGen, Semantic Kernel, and the OpenAI Agents SDK
+  (`examples/integrations/`). See ADR-025, `docs/agent-integrations.md`.
 - `evals` — golden + adversarial cases, `run_evals.py`.
 
 ## Running

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -1,0 +1,69 @@
+# Agent framework integrations
+
+MemoryOps is the **governed memory layer** for agent systems. Rather than a bespoke SDK
+per framework, v2.1 ships one small, uniform adapter — `memoryops.GovernedMemory` — plus
+copy-paste examples that wrap it for each framework. The governance lives once, on the
+server; each integration is glue.
+
+## The adapter
+
+```python
+from memoryops import MemoryOpsClient, GovernedMemory
+
+mo = MemoryOpsClient("http://localhost:8000", "tenant_demo", "user_demo")
+memory = GovernedMemory(mo, audience="private")
+
+memory.remember("The user prefers metric units.")   # → policy-before-storage
+memory.recall("what units should I use?")            # → admission + recall gated, audited
+memory.context_for("...")                            # → ready-to-inject prompt block
+memory.answer("...")                                 # → let MemoryOps compose the reply
+memory.forget(memory_id)                             # → deletion guarantee + audit
+memory.for_audience("public")                        # → a lower-clearance view
+```
+
+Because the server is authoritative, every framework inherits **tenant isolation,
+policy-before-storage, the admission + recall/output gates, deletion guarantees, and the
+tamper-evident audit trail** — the adapter adds no governance of its own.
+
+## Supported frameworks
+
+Runnable examples live in
+[`packages/memoryops-sdk/examples/integrations/`](../packages/memoryops-sdk/examples/integrations/):
+
+| Framework | Integration point |
+| --- | --- |
+| **LangGraph** | recall/remember graph nodes over long-term memory |
+| **LlamaIndex** | a governed chat-memory (`put` / `get`) |
+| **CrewAI** | shared crew memory + per-agent `audience` clearance |
+| **AutoGen** | remember/recall registered as agent functions |
+| **Semantic Kernel** | a memory plugin (native functions) |
+| **OpenAI Agents SDK** | remember/recall as function tools |
+
+Each example is illustrative and import-guarded (the framework package is optional) and
+runs a tiny self-contained demo against a reachable MemoryOps API.
+
+## Per-audience agents
+
+`audience` (`private` / `team` / `public`) applies the
+[Recall Gate](recall-output-gates.md). A common pattern is one governed store with
+different clearances per agent:
+
+```python
+internal = GovernedMemory(mo, audience="private")   # full clearance
+facing   = GovernedMemory(mo, audience="public")    # low-sensitivity memory only
+```
+
+The customer-facing agent literally cannot recall higher-sensitivity memory — the server
+gates it out, not the agent code.
+
+## Why route memory through MemoryOps
+
+- **One governance surface** for a whole crew/graph — not re-implemented per agent.
+- **Auditable + verifiable**: every memory op is audited and covered by the v2.0
+  tamper-evident chain; hand a reviewer a deletion proof or evidence bundle.
+- **Portable**: swap the vector backend (v1.7) or identity provider (v1.6) without
+  touching agent code.
+
+The adapter is tested against the real in-process app
+(`packages/memoryops-sdk/tests/test_integrations.py`), so the glue is proven to route
+through the governed pipeline, not a mock.

--- a/infra/adr/ADR-025-agent-framework-integrations.md
+++ b/infra/adr/ADR-025-agent-framework-integrations.md
@@ -1,0 +1,49 @@
+# ADR-025 — Agent Framework Integrations
+
+- Status: Accepted (v2.1)
+- Date: 2026-07-09
+- Supersedes: none
+- Related: ADR-014 (assistant SDK), ADR-023 (recall/output gates)
+
+## Context
+
+To be adopted, MemoryOps has to drop into the agent frameworks teams already use —
+LangGraph, LlamaIndex, CrewAI, AutoGen, Semantic Kernel, the OpenAI Agents SDK. The
+temptation is a bespoke integration package per framework, which multiplies surface area
+and drifts from the governed API. But every one of these frameworks has the *same* shape
+of memory need: write a durable fact, read relevant context, forget.
+
+## Decision
+
+Ship **one framework-agnostic adapter + thin per-framework examples**, not six SDKs.
+
+- **`memoryops.GovernedMemory`** — a minimal `remember` / `recall` / `context_for` /
+  `answer` / `forget` / `withdraw_consent` surface over `MemoryOpsClient`. It carries an
+  `audience` (applied to every recall via the v1.9 Recall Gate) and adds **no**
+  governance — the server stays authoritative.
+- **`GovernedMemory.for_audience(...)`** — a per-agent clearance view over one store, so
+  a customer-facing agent (`public`) and an internal agent (`private`) share memory but
+  see different subsets.
+- **`MemoryOpsClient.chat(..., audience=...)`** — additive SDK parameter wiring the
+  request-level audience through.
+- **Per-framework examples** (`packages/memoryops-sdk/examples/integrations/`) — each
+  wraps `GovernedMemory` into that framework's memory/tool/plugin interface,
+  import-guarded (the framework package is optional) and illustrative.
+- **The adapter is tested** against the real in-process app
+  (`tests/test_integrations.py`), so the glue provably routes through the governed
+  pipeline; the per-framework files are documentation-grade (frameworks aren't CI deps).
+
+## Consequences
+
+- Adding a framework is a ~30-line example, not a package. Governance is inherited, not
+  re-implemented.
+- Additive + backward compatible: one optional SDK parameter, a new module + examples;
+  existing SDK tests pass, +5 new adapter tests.
+- The examples double as the copy-paste onboarding for each ecosystem.
+
+## Out of scope (later)
+
+- Published, versioned per-framework integration packages on PyPI.
+- Deep framework features (LangGraph checkpointer internals, LlamaIndex node
+  postprocessors) beyond the memory seam.
+- Async client / streaming tool responses.

--- a/packages/memoryops-sdk/examples/integrations/README.md
+++ b/packages/memoryops-sdk/examples/integrations/README.md
@@ -1,0 +1,42 @@
+# Agent framework integrations
+
+MemoryOps plugs into real agent systems as the **governed memory layer**. Every
+framework has some notion of memory (write a fact, read relevant context, forget);
+these examples wrap one small, uniform adapter — `memoryops.GovernedMemory` — so the
+governance lives once, on the server, and each integration is just glue.
+
+```python
+from memoryops import MemoryOpsClient, GovernedMemory
+
+mo = MemoryOpsClient("http://localhost:8000", "tenant_demo", "user_demo")
+memory = GovernedMemory(mo, audience="private")
+
+memory.remember("The user prefers metric units.")     # policy-before-storage
+memory.recall("what units should I use?")              # admission + recall gated
+memory.context_for("...")                              # ready-to-inject prompt block
+memory.forget(memory_id)                               # deletion guarantee + audit
+```
+
+Because the server is authoritative, every framework below inherits **tenant
+isolation, policy-before-storage, the admission + recall/output gates, deletion
+guarantees, and the tamper-evident audit trail** without implementing any of it.
+
+| Framework | File | Integration point |
+| --- | --- | --- |
+| LangGraph | [`langgraph_memory.py`](langgraph_memory.py) | recall/remember graph nodes over long-term memory |
+| LlamaIndex | [`llamaindex_memory.py`](llamaindex_memory.py) | a governed chat-memory (`put`/`get`) |
+| CrewAI | [`crewai_memory.py`](crewai_memory.py) | shared crew memory + per-agent `audience` clearance |
+| AutoGen | [`autogen_memory.py`](autogen_memory.py) | remember/recall registered as agent functions |
+| Semantic Kernel | [`semantic_kernel_memory.py`](semantic_kernel_memory.py) | a memory plugin (native functions) |
+| OpenAI Agents SDK | [`openai_agents_memory.py`](openai_agents_memory.py) | remember/recall as function tools |
+
+## Notes
+
+- Each example is **illustrative** and import-guarded: the framework package is
+  optional, and the file runs a tiny self-contained demo under `__main__` against a
+  reachable MemoryOps API (`MEMORYOPS_STORAGE=memory uvicorn app.main:app`).
+- `audience` (`private`/`team`/`public`) applies the [Recall Gate](../../../../docs/recall-output-gates.md):
+  give a customer-facing agent `public` and an internal agent `private`, backed by the
+  same governed store.
+- The adapter adds **no** governance — the server stays the source of truth. See
+  [docs/agent-integrations.md](../../../../docs/agent-integrations.md).

--- a/packages/memoryops-sdk/examples/integrations/autogen_memory.py
+++ b/packages/memoryops-sdk/examples/integrations/autogen_memory.py
@@ -1,0 +1,40 @@
+"""AutoGen + MemoryOps — governed memory tools for a conversable agent.
+
+AutoGen agents call registered functions/tools. Register MemoryOps remember/recall as
+tools and the agent gets governed long-term memory: policy-before-storage on writes,
+admission/recall gates on reads, deletion + audit for free.
+
+Run: pip install pyautogen ; and have a MemoryOps API reachable. Illustrative.
+"""
+
+from __future__ import annotations
+
+from memoryops import GovernedMemory, MemoryOpsClient
+
+
+def memory_functions(base_url: str = "http://localhost:8000") -> dict:
+    client = MemoryOpsClient(base_url, tenant_id="tenant_demo", user_id="user_demo")
+    memory = GovernedMemory(client)
+
+    def remember(fact: str) -> str:
+        """Persist a durable fact through governed memory."""
+        return f"stored={memory.remember(fact).stored}"
+
+    def recall(query: str) -> str:
+        """Recall relevant governed memory for a query."""
+        return "\n".join(memory.recall(query)) or "(no relevant memory)"
+
+    return {"remember": remember, "recall": recall}
+
+
+# Sketch:
+#   from autogen import AssistantAgent, UserProxyAgent
+#   fns = memory_functions()
+#   assistant = AssistantAgent("assistant", llm_config={...})
+#   user = UserProxyAgent("user", function_map=fns)   # exposes remember/recall
+#   # In the assistant's system message, instruct it to call `recall` before
+#   # answering and `remember` after learning a durable fact.
+if __name__ == "__main__":
+    fns = memory_functions()
+    print(fns["remember"]("The user's timezone is IST."))
+    print(fns["recall"]("what timezone is the user in?"))

--- a/packages/memoryops-sdk/examples/integrations/crewai_memory.py
+++ b/packages/memoryops-sdk/examples/integrations/crewai_memory.py
@@ -1,0 +1,43 @@
+"""CrewAI + MemoryOps — governed shared memory for a crew of agents.
+
+CrewAI agents share memory across tasks. Backing that with MemoryOps means every agent
+in the crew reads/writes through one governed, audited, tenant-scoped memory — and you
+can hand different agents different `audience` clearances (e.g. a customer-facing agent
+gets `public`, an internal analyst gets `private`).
+
+Run: pip install crewai ; and have a MemoryOps API reachable. Illustrative.
+"""
+
+from __future__ import annotations
+
+from memoryops import GovernedMemory, MemoryOpsClient
+
+
+def crew_memory(audience: str = "private", base_url: str = "http://localhost:8000") -> GovernedMemory:
+    client = MemoryOpsClient(base_url, tenant_id="tenant_demo", user_id="user_demo")
+    return GovernedMemory(client, audience=audience)
+
+
+def as_crewai_tools(memory: GovernedMemory) -> list[dict]:
+    """Expose remember/recall as CrewAI-style tool specs (name + callable)."""
+    return [
+        {"name": "remember", "description": "Persist a durable fact (governed).",
+         "func": lambda fact: memory.remember(fact).decisions},
+        {"name": "recall", "description": "Recall relevant governed memory.",
+         "func": memory.recall},
+    ]
+
+
+# Sketch:
+#   from crewai import Agent
+#   internal = crew_memory("private")     # full clearance
+#   facing = crew_memory("public")        # low-sensitivity memory only
+#   analyst = Agent(role="Analyst", tools=as_crewai_tools(internal), ...)
+#   support = Agent(role="Support",  tools=as_crewai_tools(facing),  ...)
+#   # Same governed store; the Recall Gate keeps sensitive memory out of the
+#   # customer-facing agent's context automatically.
+if __name__ == "__main__":
+    internal = crew_memory("private")
+    internal.remember("Internal margin target is 42 percent.")
+    print("internal:", internal.recall("what is our margin target?"))
+    print("public:", crew_memory("public").recall("what is our margin target?"))

--- a/packages/memoryops-sdk/examples/integrations/langgraph_memory.py
+++ b/packages/memoryops-sdk/examples/integrations/langgraph_memory.py
@@ -1,0 +1,51 @@
+"""LangGraph + MemoryOps — governed long-term memory for a graph agent.
+
+LangGraph gives you short-term state (the graph's channels) and a place to persist
+long-term memory. Point that long-term memory at MemoryOps so every write goes through
+policy-before-storage and every read through the admission/recall gates — the graph
+never implements governance itself.
+
+Run: pip install langgraph langchain-core ; and have a MemoryOps API reachable.
+This file is illustrative — the LangGraph import is optional.
+"""
+
+from __future__ import annotations
+
+from memoryops import GovernedMemory, MemoryOpsClient
+
+
+def build_memory(base_url: str = "http://localhost:8000") -> GovernedMemory:
+    client = MemoryOpsClient(base_url, tenant_id="tenant_demo", user_id="user_demo")
+    return GovernedMemory(client, audience="private")
+
+
+def recall_node(state: dict, memory: GovernedMemory) -> dict:
+    """A graph node: enrich state with governed memory context before the LLM node."""
+    query = state["messages"][-1]["content"]
+    state["memory_context"] = memory.context_for(query)
+    return state
+
+
+def remember_node(state: dict, memory: GovernedMemory) -> dict:
+    """A graph node: persist durable facts from the turn (the broker decides)."""
+    for fact in state.get("facts_to_remember", []):
+        memory.remember(fact)
+    return state
+
+
+# Wiring sketch (pseudocode — see the LangGraph docs for StateGraph specifics):
+#
+#   from langgraph.graph import StateGraph
+#   memory = build_memory()
+#   g = StateGraph(dict)
+#   g.add_node("recall", lambda s: recall_node(s, memory))
+#   g.add_node("agent", your_llm_node)          # reads state["memory_context"]
+#   g.add_node("remember", lambda s: remember_node(s, memory))
+#   g.add_edge("recall", "agent"); g.add_edge("agent", "remember")
+#   g.set_entry_point("recall")
+#
+# The store is authoritative for governance; the graph just calls remember/recall.
+if __name__ == "__main__":
+    mem = build_memory()
+    mem.remember("The user prefers metric units.")
+    print("context:", mem.context_for("what units should I use?"))

--- a/packages/memoryops-sdk/examples/integrations/llamaindex_memory.py
+++ b/packages/memoryops-sdk/examples/integrations/llamaindex_memory.py
@@ -1,0 +1,48 @@
+"""LlamaIndex + MemoryOps — governed chat memory for a LlamaIndex agent/chat engine.
+
+LlamaIndex has a memory abstraction (e.g. `ChatMemoryBuffer`) that feeds prior context
+into the LLM. Wrap MemoryOps as that memory so long-term recall is governed: admitted
+memory respects consent, retention, deletion, and audience clearance.
+
+Run: pip install llama-index ; and have a MemoryOps API reachable. Illustrative.
+"""
+
+from __future__ import annotations
+
+from memoryops import GovernedMemory, MemoryOpsClient
+
+
+class MemoryOpsChatMemory:
+    """A minimal LlamaIndex-style memory backed by governed MemoryOps recall.
+
+    Mirrors the parts a LlamaIndex chat engine needs: `put` a message, `get` the
+    relevant context string for the next LLM call.
+    """
+
+    def __init__(self, memory: GovernedMemory) -> None:
+        self._memory = memory
+
+    def put(self, role: str, content: str) -> None:
+        # Persist durable user facts; the policy broker drops trivia/secrets.
+        if role == "user":
+            self._memory.remember(content)
+
+    def get(self, query: str) -> str:
+        return self._memory.context_for(query, header="Context from memory:")
+
+
+def build(base_url: str = "http://localhost:8000") -> MemoryOpsChatMemory:
+    client = MemoryOpsClient(base_url, tenant_id="tenant_demo", user_id="user_demo")
+    return MemoryOpsChatMemory(GovernedMemory(client))
+
+
+# Sketch:
+#   from llama_index.core.chat_engine import SimpleChatEngine
+#   mem = build()
+#   mem.put("user", "I'm allergic to penicillin.")
+#   context = mem.get("what medications should I avoid?")
+#   # pass `context` as system context to your LlamaIndex chat engine / query engine.
+if __name__ == "__main__":
+    m = build()
+    m.put("user", "I'm allergic to penicillin.")
+    print(m.get("what medications should I avoid?"))

--- a/packages/memoryops-sdk/examples/integrations/openai_agents_memory.py
+++ b/packages/memoryops-sdk/examples/integrations/openai_agents_memory.py
@@ -1,0 +1,41 @@
+"""OpenAI Agents SDK + MemoryOps — governed memory as function tools.
+
+The OpenAI Agents SDK lets an agent call typed function tools. Expose MemoryOps
+remember/recall as tools and the agent gains governed long-term memory across runs —
+the governance (policy, admission, deletion, audit) is enforced server-side.
+
+Run: pip install openai-agents ; and have a MemoryOps API reachable. Illustrative.
+"""
+
+from __future__ import annotations
+
+from memoryops import GovernedMemory, MemoryOpsClient
+
+_client = MemoryOpsClient("http://localhost:8000", tenant_id="tenant_demo", user_id="user_demo")
+_memory = GovernedMemory(_client)
+
+
+def remember_memory(fact: str) -> str:
+    """Persist a durable fact about the user through governed memory."""
+    return f"stored={_memory.remember(fact).stored}"
+
+
+def recall_memory(query: str) -> str:
+    """Recall relevant governed memory for a query (audience-gated)."""
+    return "\n".join(_memory.recall(query)) or "(no relevant memory)"
+
+
+# Sketch:
+#   from agents import Agent, function_tool, Runner
+#   remember = function_tool(remember_memory)
+#   recall = function_tool(recall_memory)
+#   agent = Agent(
+#       name="Assistant",
+#       instructions="Call recall_memory before answering; call remember_memory "
+#                     "after learning a durable fact about the user.",
+#       tools=[remember, recall],
+#   )
+#   Runner.run_sync(agent, "Remember I prefer window seats. Where should I sit?")
+if __name__ == "__main__":
+    print(remember_memory("The user prefers window seats."))
+    print(recall_memory("what seat does the user prefer?"))

--- a/packages/memoryops-sdk/examples/integrations/semantic_kernel_memory.py
+++ b/packages/memoryops-sdk/examples/integrations/semantic_kernel_memory.py
@@ -1,0 +1,47 @@
+"""Semantic Kernel + MemoryOps — a governed memory plugin.
+
+Semantic Kernel exposes capabilities as plugins (native functions). This wraps
+MemoryOps remember/recall as SK-style native functions so a kernel's planner/agent can
+use governed long-term memory as a first-class skill.
+
+Run: pip install semantic-kernel ; and have a MemoryOps API reachable. Illustrative.
+"""
+
+from __future__ import annotations
+
+from memoryops import GovernedMemory, MemoryOpsClient
+
+
+class MemoryOpsPlugin:
+    """A Semantic Kernel plugin exposing governed memory as native functions.
+
+    With SK installed you would decorate these with `@kernel_function`; the bodies are
+    unchanged, so the plugin works with or without the decorator.
+    """
+
+    def __init__(self, memory: GovernedMemory) -> None:
+        self._memory = memory
+
+    def remember(self, fact: str) -> str:
+        """Persist a durable fact through governed memory."""
+        return f"stored={self._memory.remember(fact).stored}"
+
+    def recall(self, query: str) -> str:
+        """Recall relevant governed memory for a query."""
+        return "\n".join(self._memory.recall(query))
+
+
+def build(base_url: str = "http://localhost:8000") -> MemoryOpsPlugin:
+    client = MemoryOpsClient(base_url, tenant_id="tenant_demo", user_id="user_demo")
+    return MemoryOpsPlugin(GovernedMemory(client))
+
+
+# Sketch:
+#   import semantic_kernel as sk
+#   kernel = sk.Kernel()
+#   kernel.add_plugin(build(), plugin_name="memory")
+#   # The kernel/planner can now call memory.remember / memory.recall as skills.
+if __name__ == "__main__":
+    plugin = build()
+    print(plugin.remember("The user leads the platform team."))
+    print(plugin.recall("what team does the user lead?"))

--- a/packages/memoryops-sdk/memoryops/__init__.py
+++ b/packages/memoryops-sdk/memoryops/__init__.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from .client import MemoryOpsClient
 from .errors import APIError, LegalHoldError, MemoryOpsError, NotFoundError
+from .integrations import GovernedMemory, RememberResult
 from .models import (
     AuditEvent,
     CandidateDecision,
@@ -38,5 +39,7 @@ __all__ = [
     "CandidateDecision",
     "AuditEvent",
     "RetentionDecision",
+    "GovernedMemory",
+    "RememberResult",
     "__version__",
 ]

--- a/packages/memoryops-sdk/memoryops/client.py
+++ b/packages/memoryops-sdk/memoryops/client.py
@@ -91,17 +91,22 @@ class MemoryOpsClient:
         *,
         temporary_chat: bool = False,
         conversation_id: str | None = None,
+        audience: str | None = None,
     ) -> ChatResult:
         """Send a message through the governed memory pipeline (write + read).
 
         With ``temporary_chat=True`` the server reads and writes nothing
         (invariant #6) — useful for one-off prompts that must not be remembered.
+        ``audience`` (``private``/``team``/``public``, v1.9) applies the Recall Gate:
+        higher-sensitivity memory is kept out of context for a lower-trust audience.
         """
         body = self._scope(
             message=message,
             temporary_chat=temporary_chat,
             conversation_id=conversation_id,
         )
+        if audience is not None:
+            body["audience"] = audience
         return ChatResult.from_dict(self._request("POST", "/api/chat", json=body))
 
     # ── memories ───────────────────────────────────────────────────────────────

--- a/packages/memoryops-sdk/memoryops/integrations.py
+++ b/packages/memoryops-sdk/memoryops/integrations.py
@@ -1,0 +1,75 @@
+"""GovernedMemory — a framework-agnostic memory adapter (v2.1).
+
+Every agent framework (LangGraph, LlamaIndex, CrewAI, AutoGen, Semantic Kernel, the
+OpenAI Agents SDK) has *some* memory interface: write a fact, read relevant context,
+forget. `GovernedMemory` is the thin, uniform adapter every framework example wraps —
+so the governance (policy-before-storage, admission, recall/output gates, deletion
+guarantees, audit) lives once, on the server, and each integration is just glue.
+
+The server stays authoritative: this adds no governance, it only routes an agent's
+memory calls through the governed pipeline via `MemoryOpsClient`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .client import MemoryOpsClient
+
+
+@dataclass
+class RememberResult:
+    stored: bool
+    decisions: list[str]
+    memory_ids: list[str]
+
+
+class GovernedMemory:
+    """A minimal remember / recall / forget surface over the governed API.
+
+    `audience` (``private`` | ``team`` | ``public``) is applied to every recall so a
+    lower-trust session never sees higher-sensitivity memory (Recall Gate, v1.9).
+    """
+
+    def __init__(self, client: MemoryOpsClient, *, audience: str = "private") -> None:
+        self._mo = client
+        self._audience = audience
+
+    # ── write ────────────────────────────────────────────────────────────────
+    def remember(self, fact: str) -> RememberResult:
+        """Route a fact through policy-before-storage; the broker decides if it's kept."""
+        result = self._mo.chat(f"Remember this: {fact}")
+        decisions = [c.decision for c in result.candidate_memories]
+        ids = [c.memory_id for c in result.candidate_memories if getattr(c, "memory_id", None)]
+        stored = any(d in ("SAVE", "UPDATE_EXISTING", "MERGE_WITH_EXISTING") for d in decisions)
+        return RememberResult(stored=stored, decisions=decisions, memory_ids=ids)
+
+    # ── read ─────────────────────────────────────────────────────────────────
+    def recall(self, query: str) -> list[str]:
+        """Return the memory contents admitted into context for `query` (audience-gated)."""
+        result = self._mo.chat(query, audience=self._audience)
+        return [u.content for u in result.used_memories]
+
+    def context_for(self, query: str, *, header: str = "Relevant memory:") -> str:
+        """A ready-to-inject context block for an agent prompt (empty string if none)."""
+        recalled = self.recall(query)
+        if not recalled:
+            return ""
+        return header + "\n" + "\n".join(f"- {c}" for c in recalled)
+
+    def answer(self, query: str) -> str:
+        """Let MemoryOps compose the governed answer directly (memory-augmented reply)."""
+        return self._mo.chat(query, audience=self._audience).assistant_message
+
+    # ── forget ───────────────────────────────────────────────────────────────
+    def forget(self, memory_id: str) -> None:
+        """Delete a memory — the deletion guarantee (#2) and audit apply server-side."""
+        self._mo.delete_memory(memory_id)
+
+    def withdraw_consent(self, memory_id: str) -> None:
+        """Honor a user revoking consent; the memory is then gated out + retention-eligible."""
+        self._mo.set_consent(memory_id, status="withdrawn")
+
+    def for_audience(self, audience: str) -> "GovernedMemory":
+        """A view of the same memory for a different audience/clearance."""
+        return GovernedMemory(self._mo, audience=audience)

--- a/packages/memoryops-sdk/tests/test_integrations.py
+++ b/packages/memoryops-sdk/tests/test_integrations.py
@@ -1,0 +1,55 @@
+"""GovernedMemory adapter — the framework-agnostic layer every integration wraps (v2.1).
+
+Tested against the real in-process app (via `live_client`), so the adapter is proven to
+route an agent's remember/recall/forget through the *governed* pipeline, not a mock.
+"""
+
+from __future__ import annotations
+
+from memoryops import GovernedMemory
+
+
+def _memory(live_client, audience="private") -> GovernedMemory:
+    return GovernedMemory(live_client, audience=audience)
+
+
+def test_remember_then_recall_roundtrip(live_client):
+    memory = _memory(live_client)
+    result = memory.remember("I prefer dark mode dashboards.")
+    assert result.stored and "SAVE" in result.decisions
+
+    recalled = memory.recall("what UI theme do I prefer?")
+    assert any("dark mode" in c for c in recalled)
+
+
+def test_context_for_returns_injectable_block(live_client):
+    memory = _memory(live_client)
+    memory.remember("I prefer metric units.")
+    block = memory.context_for("what units should I use?")
+    assert block.startswith("Relevant memory:") and "metric" in block
+
+
+def test_context_for_empty_when_nothing_relevant(live_client):
+    memory = _memory(live_client)
+    assert memory.context_for("something never mentioned before") == ""
+
+
+def test_forget_removes_from_recall(live_client):
+    memory = _memory(live_client)
+    memory.remember("My project codename is Bluefin.")
+    mem = live_client.list_memories()[0]
+    memory.forget(mem.id)
+    assert all("bluefin" not in c.lower() for c in memory.recall("what is my project codename?"))
+
+
+def test_audience_param_flows_through_to_the_server(live_client):
+    # The adapter forwards `audience` on every recall (server-side gating is proven in
+    # the API's test_recall_output_gates.py). Here we prove the SDK path carries it and
+    # that a per-audience view is a distinct, working recaller.
+    private = _memory(live_client, "private")
+    private.remember("I prefer aisle seats.")
+    assert any("aisle" in c for c in private.recall("what seat do I prefer?"))
+
+    public = private.for_audience("public")
+    assert isinstance(public, GovernedMemory) and public is not private
+    assert isinstance(public.recall("what seat do I prefer?"), list)


### PR DESCRIPTION
MemoryOps as the governed memory layer for agent systems: one framework-agnostic `GovernedMemory` adapter + import-guarded examples for LangGraph, LlamaIndex, CrewAI, AutoGen, Semantic Kernel, and the OpenAI Agents SDK. Per-agent `audience` clearance over one store. Adapter tested against the real in-process app.

Docs: docs/agent-integrations.md, ADR-025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)