### PR TITLE
chore: add benchmark Docker profile and live benchmark badge

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,42 @@
+name: Benchmark
+
+# Public memory-governance benchmark, in its own workflow so its status badge
+# reflects the scorecard specifically (not the whole CI matrix). Reproducible +
+# offline — the critical suites (deletion/leakage + tenant isolation) must be
+# perfect or `run_benchmark.py` exits non-zero and this workflow fails.
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: benchmark-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Memory-governance scorecard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install API deps
+        working-directory: services/api
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run public benchmark (critical suites must be perfect)
+        env:
+          MEMORYOPS_STORAGE: memory
+        run: python benchmark/run_benchmark.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,28 +46,8 @@ jobs:
           MEMORYOPS_STORAGE: memory
         run: python evals/run_evals.py
 
-  benchmark:
-    name: Benchmark — memory-governance scorecard
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install API deps
-        working-directory: services/api
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-
-      - name: Run public benchmark (critical suites must be perfect)
-        env:
-          MEMORYOPS_STORAGE: memory
-        run: python benchmark/run_benchmark.py
+  # The memory-governance benchmark runs in its own workflow (benchmark.yml) so it
+  # has a dedicated status badge; it is not duplicated here.
 
   sdk:
     name: SDK — tests

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ influenced an answer, and what evidence proves each decision** — treating memo
 governed state, not just a vector database.
 
 [![CI](https://github.com/patibandlavenkatamanideep/memoryops-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/patibandlavenkatamanideep/memoryops-ai/actions/workflows/ci.yml)
-&nbsp;![Benchmark](https://img.shields.io/badge/governance%20benchmark-100%25-brightgreen)
+&nbsp;[![Benchmark](https://github.com/patibandlavenkatamanideep/memoryops-ai/actions/workflows/benchmark.yml/badge.svg)](https://github.com/patibandlavenkatamanideep/memoryops-ai/actions/workflows/benchmark.yml)
 &nbsp;![Python](https://img.shields.io/badge/python-3.10%2B-blue)
 &nbsp;![License](https://img.shields.io/badge/license-MIT-green)
 &nbsp;![Release](https://img.shields.io/badge/release-v2.2-blue)
@@ -63,7 +63,7 @@ New to integrating? Start with the **[LangGraph tutorial](docs/tutorials/langgra
 MemoryOps **measures** governance rather than claiming it. `python benchmark/run_benchmark.py`
 scores the eval harness into named suites; the two critical suites (deletion/leakage +
 tenant isolation) must be perfect or the benchmark fails. Current scorecard
-([benchmark/SCORECARD.md](benchmark/SCORECARD.md)):
+([benchmark/SCORECARD.md](benchmark/SCORECARD.md)) — **32/32 (100%), critical suites perfect ✅**:
 
 | Suite | Pass rate |
 | --- | --- |

--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -1,0 +1,21 @@
+# Reproducible, offline runner for the public memory-governance benchmark.
+#
+#   docker compose --profile benchmark run --rm benchmark
+#
+# Runs `benchmark/run_benchmark.py` against the deterministic in-memory stub stack
+# (no DB, no Redis, no API keys). Exits non-zero if a critical suite is not perfect.
+FROM python:3.12-slim
+
+WORKDIR /repo
+
+# Only the API runtime deps are needed to score the eval harness.
+COPY services/api/requirements.txt services/api/requirements.txt
+RUN pip install --no-cache-dir -r services/api/requirements.txt
+
+# The benchmark reuses the eval harness (services/api) and the cases (evals/).
+COPY . .
+
+ENV MEMORYOPS_STORAGE=memory \
+    PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["python", "benchmark/run_benchmark.py"]

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -15,6 +15,18 @@ python benchmark/run_benchmark.py --md benchmark/SCORECARD.md
 
 No API keys, no infra — the cases run against the deterministic stub stack (`evals/`).
 
+### Run it in Docker
+
+If you'd rather not set up Python locally, the repo ships an opt-in Compose profile
+that runs the same scorecard in an isolated container (offline, in-memory, no DB/Redis):
+
+```bash
+docker compose --profile benchmark run --rm benchmark
+```
+
+The `benchmark` profile keeps it out of the default `docker compose up` stack — it's a
+one-shot run that exits non-zero if a critical suite isn't perfect.
+
 ## Suites
 
 | Suite | What it proves | Critical |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,5 +70,17 @@ services:
     depends_on:
       - api
 
+  # Public memory-governance benchmark. Opt-in via the `benchmark` profile so it
+  # never starts with the default `docker compose up` stack — it's a one-shot,
+  # offline scorecard run, not a long-lived service:
+  #   docker compose --profile benchmark run --rm benchmark
+  benchmark:
+    profiles: ["benchmark"]
+    build:
+      context: .
+      dockerfile: benchmark/Dockerfile
+    environment:
+      MEMORYOPS_STORAGE: memory
+
 volumes:
   pgdata:


### PR DESCRIPTION
Developer-experience / adoption polish for the public memory-governance benchmark. Closes #29, #31, #32.

## Changes
- **Docker Compose benchmark profile** — added a `benchmark` service under `profiles: ["benchmark"]`, so it never starts with the default `docker compose up` stack. Run with `docker compose --profile benchmark run --rm benchmark`.
- **Benchmark Dockerfile** — `benchmark/Dockerfile`, an offline, in-memory one-shot runner (no DB/Redis, no API keys).
- **Benchmark README instructions** — documented the Docker run path.
- **Benchmark workflow split** — moved the memory-governance benchmark into its own `.github/workflows/benchmark.yml` and removed the duplicate job from `ci.yml`, so each badge maps to a distinct workflow.
- **Live README benchmark badge** — replaced the static `100%` shield with the live `benchmark.yml` Actions badge.
- **Scorecard headline** — updated the README scorecard to `32/32, critical suites perfect ✅` to match `benchmark/SCORECARD.md`.
- **SDK publish workflow verified** — built the SDK (sdist + wheel) and ran `twine check`: both pass. `publish-sdk.yml` is correct as-is; **no repo change needed** (only the `PYPI_API_TOKEN` secret + trigger remain, which are out-of-repo).

## Validation
- All workflow + compose YAML parse; `ci.yml` jobs are now `api, sdk, web`, and `benchmark.yml` owns `benchmark`.
- Ran `benchmark/run_benchmark.py` end-to-end: **32/32 (100%), critical suites perfect, exit 0**.
- SDK sdist + wheel build clean and pass `twine check`.

## Caveat
- Docker itself was **not available in this environment**, so the image was not built. The compose config and the identical `run_benchmark.py` run were validated; recommend a local `docker compose --profile benchmark run --rm benchmark` to confirm the image build.