### PR TITLE
fix(write-loop): multi-memory writes 500 on invalid loop transition

### DIFF
--- a/services/api/app/services/gateway.py
+++ b/services/api/app/services/gateway.py
@@ -485,25 +485,43 @@ class Gateway:
                 "types": [c.type.value for c in candidates],
             },
         )
-        decisions = []
-        audit_ids: list[str] = []
+        # Pass 1 — evaluate the policy broker for every candidate. The loop state
+        # machine models a *single* policy gate per write loop, so POLICY_CHECKED is
+        # emitted exactly once (below), independent of how many memories a single
+        # message extracts. Emitting it per candidate produced an invalid
+        # policy_checked -> policy_checked transition that 500-d any multi-memory
+        # write (reachable since multi-memory extraction, P1.3).
+        outcomes = []
+        policy_decisions = []
         for cand in candidates:
             outcome = self._policy.evaluate(
                 cand, tenant_id=req.tenant_id, user_id=req.user_id, settings=settings
             )
             record_policy_decision(outcome.decision.value)
-            emit_loop_event_sync(
-                self._repo,
-                write_loop,
-                LoopState.POLICY_CHECKED,
-                event_type="memory_write_policy_checked",
-                reason="policy broker decision made",
-                evidence={
+            outcomes.append(outcome)
+            policy_decisions.append(
+                {
                     "decision": outcome.decision.value,
                     "type": cand.type.value,
                     "sensitivity": outcome.candidate.sensitivity.value,
-                },
+                }
             )
+        emit_loop_event_sync(
+            self._repo,
+            write_loop,
+            LoopState.POLICY_CHECKED,
+            event_type="memory_write_policy_checked",
+            reason=(
+                "policy broker decision made"
+                if candidates
+                else "no candidate memory required policy action"
+            ),
+            evidence={"candidate_count": len(candidates), "decisions": policy_decisions},
+        )
+        # Pass 2 — commit each policy outcome.
+        decisions = []
+        audit_ids: list[str] = []
+        for outcome in outcomes:
             with span("memory.write.commit") as _sp:
                 decision_view, ids = self._writer.commit(
                     outcome, tenant_id=req.tenant_id, user_id=req.user_id, trace_id=trace_id
@@ -512,15 +530,6 @@ class Gateway:
                     _sp.attributes.update(decision=outcome.decision.value)
             decisions.append(decision_view)
             audit_ids.extend(ids)
-        if not candidates:
-            emit_loop_event_sync(
-                self._repo,
-                write_loop,
-                LoopState.POLICY_CHECKED,
-                event_type="memory_write_policy_checked",
-                reason="no candidate memory required policy action",
-                evidence={"candidate_count": 0},
-            )
         emit_loop_event_sync(
             self._repo,
             write_loop,

--- a/services/api/tests/test_memory_write_loop.py
+++ b/services/api/tests/test_memory_write_loop.py
@@ -18,3 +18,32 @@ def test_memory_write_loop_emits_events(gateway, repo):
     assert "policy_checked" in states
     assert "audited" in states
     assert "completed" in states
+
+
+def test_multi_memory_write_emits_single_policy_checked(gateway, repo):
+    """A message that extracts *several* memories must not 500.
+
+    Regression: the write loop emitted POLICY_CHECKED once per candidate, so a
+    multi-memory extraction (P1.3) produced an invalid
+    policy_checked -> policy_checked transition and a 500. The loop models one
+    policy gate per run, so exactly one POLICY_CHECKED event must be emitted no
+    matter how many memories the turn yields.
+    """
+    resp = gateway.handle_chat(
+        ChatRequest(
+            tenant_id="t1",
+            user_id="u1",
+            message="Remember that I prefer metric units. I work in the Pacific timezone.",
+        ),
+        trace_id="trace-multi",
+    )
+    # Genuinely a multi-memory turn.
+    assert len(resp.candidate_memories) >= 2
+
+    runs = repo.list_loop_runs(loop_id=LoopId.MEMORY_WRITE.value, trace_id="trace-multi")
+    assert runs and runs[0].status == LoopStatus.COMPLETED
+    assert resp.loop_evidence[LoopId.MEMORY_WRITE.value] == "completed"
+
+    states = [e.state_to.value for e in repo.list_loop_events(loop_run_id=runs[0].id)]
+    assert states.count("policy_checked") == 1, states
+    assert states.count("executed") == 1, states


### PR DESCRIPTION
## The bug (live on `main`)

Any chat message that extracts **more than one memory** returned **HTTP 500**.

```
ValueError: invalid loop transition policy_checked -> policy_checked;
allowed next states: executed, failed, safe_degraded
```

The write loop (`gateway.py`) emitted `POLICY_CHECKED` **once per candidate memory**, inside the per-candidate loop. The loop state machine models a *single* policy gate per run (`CLASSIFIED → POLICY_CHECKED → EXECUTED`), so the second candidate drove `policy_checked → policy_checked` and raised. This became reachable when **multi-memory extraction (P1.3)** landed — a single message can now yield several memories.

## Why CI didn't catch it

Extraction and loop transitions were each tested *in isolation*. No test drove a genuine multi-memory turn through the full loop-tracked write path, so the interaction was invisible.

## How it was found

The **P4.3 HTTP load harness** (separate perf work) showed the write path returning a **40% 500 rate** — exactly the fraction of benchmark messages that extract ≥2 memories.

## The fix

Two-pass write loop: evaluate the policy broker for every candidate (still records the per-decision Prometheus metric), emit `POLICY_CHECKED` **exactly once** with aggregated per-decision evidence, then commit each outcome. `EXECUTED` still follows the single policy gate.

## Verification
- New regression test drives a real 2-memory turn (`assert len(candidate_memories) >= 2`) and asserts exactly one `policy_checked` and one `executed` event.
- Full API suite green locally; `ruff` clean.
- End-to-end: the two messages that returned 500 now return **200** against a live server.
