### PR TITLE
docs(perf): performance.md (P4.3) — HTTP load harness, results, async verdict, CI smoke gate

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,10 +22,10 @@ jobs:
     name: Memory-governance scorecard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload perf-smoke results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: perf-smoke
           path: perf-smoke.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     name: API — tests + lint + evals
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -65,10 +65,10 @@ jobs:
       DATABASE_URL: postgresql+psycopg://memoryops:memoryops@localhost:5432/memoryops
       PGPASSWORD: memoryops
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -114,10 +114,10 @@ jobs:
     name: SDK — tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -140,10 +140,10 @@ jobs:
     name: Web — build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm
@@ -156,3 +156,54 @@ jobs:
       - name: Build
         working-directory: apps/web
         run: npm run build
+
+  perf-smoke:
+    name: Perf — HTTP load smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install API dev deps
+        working-directory: services/api
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      # Boots the real app (in-memory, stub providers, rate-limit off) and drives a
+      # small concurrency sweep. The strict --max-error-rate 0.02 makes this a
+      # regression gate: e.g. the multi-memory write 500 (PR #42) showed as a ~40%
+      # error rate and would fail here. Keeps benchmark/perf/run_perf.py runnable.
+      - name: Boot API + run load harness
+        working-directory: services/api
+        env:
+          MEMORYOPS_STORAGE: memory
+          MEMORYOPS_EMBEDDING_PROVIDER: stub
+          MEMORYOPS_LLM_PROVIDER: stub
+          MEMORYOPS_RATE_LIMIT_ENABLED: "false"
+        run: |
+          python -m uvicorn app.main:app --host 127.0.0.1 --port 8099 --log-level warning &
+          SRV=$!
+          for i in $(seq 1 60); do
+            curl -sf http://127.0.0.1:8099/healthz >/dev/null && break || sleep 1
+          done
+          python ../../benchmark/perf/run_perf.py \
+            --base-url http://127.0.0.1:8099 \
+            --requests 60 --concurrency 1,5,10 --operations write,retrieval,chat \
+            --max-error-rate 0.02 --out ../../perf-smoke.json
+          RC=$?
+          kill $SRV 2>/dev/null || true
+          exit $RC
+
+      - name: Upload perf-smoke results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-smoke
+          path: perf-smoke.json
+          if-no-files-found: ignore

--- a/.github/workflows/nightly-live.yml
+++ b/.github/workflows/nightly-live.yml
@@ -19,10 +19,10 @@ jobs:
     name: OpenAI extraction smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/pr-invariant-evidence-gate.yml
+++ b/.github/workflows/pr-invariant-evidence-gate.yml
@@ -23,11 +23,11 @@ jobs:
       ANTHROPIC_API_KEY: ""
       GEMINI_API_KEY: ""
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -27,10 +27,10 @@ jobs:
     name: Build + publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/benchmark/perf/results/core_in-memory_stub.json
+++ b/benchmark/perf/results/core_in-memory_stub.json
@@ -1,0 +1,283 @@
+{
+  "label": "in-memory/stub/ratelimit-off/hybrid",
+  "base_url": "http://127.0.0.1:8099",
+  "requests_per_scenario": 400,
+  "seed": 0,
+  "server_rss_mb": {
+    "before": 37.2,
+    "after": 233.7
+  },
+  "generated_at": "2026-07-13T06:03:44Z",
+  "scenarios": [
+    {
+      "operation": "write",
+      "concurrency": 1,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 6.4256,
+      "rps": 62.3,
+      "p50_ms": 13.595,
+      "p95_ms": 23.417,
+      "p99_ms": 24.93,
+      "min_ms": 2.135,
+      "mean_ms": 13.553,
+      "max_ms": 26.811,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "write",
+      "concurrency": 5,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 10.3037,
+      "rps": 38.8,
+      "p50_ms": 124.951,
+      "p95_ms": 133.163,
+      "p99_ms": 145.353,
+      "min_ms": 53.926,
+      "mean_ms": 125.177,
+      "max_ms": 146.942,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "write",
+      "concurrency": 10,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 11.2751,
+      "rps": 35.5,
+      "p50_ms": 279.948,
+      "p95_ms": 346.835,
+      "p99_ms": 374.682,
+      "min_ms": 40.715,
+      "mean_ms": 277.817,
+      "max_ms": 412.741,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "write",
+      "concurrency": 25,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 12.4362,
+      "rps": 32.2,
+      "p50_ms": 820.035,
+      "p95_ms": 973.839,
+      "p99_ms": 1005.582,
+      "min_ms": 119.642,
+      "mean_ms": 761.495,
+      "max_ms": 1079.299,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "write",
+      "concurrency": 50,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 13.9844,
+      "rps": 28.6,
+      "p50_ms": 1717.213,
+      "p95_ms": 2104.136,
+      "p99_ms": 2169.663,
+      "min_ms": 260.57,
+      "mean_ms": 1697.666,
+      "max_ms": 2271.807,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "retrieval",
+      "concurrency": 1,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 16.5123,
+      "rps": 24.2,
+      "p50_ms": 37.967,
+      "p95_ms": 42.605,
+      "p99_ms": 46.651,
+      "min_ms": 35.077,
+      "mean_ms": 38.448,
+      "max_ms": 73.758,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "retrieval",
+      "concurrency": 5,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 16.3369,
+      "rps": 24.5,
+      "p50_ms": 200.159,
+      "p95_ms": 246.128,
+      "p99_ms": 300.06,
+      "min_ms": 73.887,
+      "mean_ms": 200.337,
+      "max_ms": 344.711,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "retrieval",
+      "concurrency": 10,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 17.5138,
+      "rps": 22.8,
+      "p50_ms": 448.348,
+      "p95_ms": 533.983,
+      "p99_ms": 576.857,
+      "min_ms": 78.158,
+      "mean_ms": 433.768,
+      "max_ms": 590.803,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "retrieval",
+      "concurrency": 25,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 19.7967,
+      "rps": 20.2,
+      "p50_ms": 1301.304,
+      "p95_ms": 1553.067,
+      "p99_ms": 1605.891,
+      "min_ms": 181.139,
+      "mean_ms": 1213.546,
+      "max_ms": 1648.19,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "retrieval",
+      "concurrency": 50,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 22.8011,
+      "rps": 17.5,
+      "p50_ms": 2740.46,
+      "p95_ms": 3413.665,
+      "p99_ms": 3858.544,
+      "min_ms": 141.698,
+      "mean_ms": 2749.065,
+      "max_ms": 4002.233,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "chat",
+      "concurrency": 1,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 26.5476,
+      "rps": 15.1,
+      "p50_ms": 62.188,
+      "p95_ms": 72.781,
+      "p99_ms": 87.706,
+      "min_ms": 54.266,
+      "mean_ms": 63.477,
+      "max_ms": 98.767,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "chat",
+      "concurrency": 5,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 27.229,
+      "rps": 14.7,
+      "p50_ms": 337.615,
+      "p95_ms": 416.862,
+      "p99_ms": 486.054,
+      "min_ms": 106.916,
+      "mean_ms": 336.358,
+      "max_ms": 556.206,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "chat",
+      "concurrency": 10,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 29.5945,
+      "rps": 13.5,
+      "p50_ms": 760.233,
+      "p95_ms": 942.226,
+      "p99_ms": 1005.653,
+      "min_ms": 243.467,
+      "mean_ms": 735.176,
+      "max_ms": 1103.389,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "chat",
+      "concurrency": 25,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 32.1044,
+      "rps": 12.5,
+      "p50_ms": 2001.859,
+      "p95_ms": 2327.326,
+      "p99_ms": 2653.653,
+      "min_ms": 401.555,
+      "mean_ms": 1973.343,
+      "max_ms": 2669.816,
+      "status_counts": {
+        "200": 400
+      }
+    },
+    {
+      "operation": "chat",
+      "concurrency": 50,
+      "n": 400,
+      "errors": 0,
+      "error_rate": 0.0,
+      "wall_s": 34.4358,
+      "rps": 11.6,
+      "p50_ms": 4175.492,
+      "p95_ms": 4985.633,
+      "p99_ms": 5276.944,
+      "min_ms": 2132.727,
+      "mean_ms": 4177.134,
+      "max_ms": 5604.171,
+      "status_counts": {
+        "200": 400
+      }
+    }
+  ]
+}

--- a/benchmark/perf/results/dataset_scale_in-memory.json
+++ b/benchmark/perf/results/dataset_scale_in-memory.json
@@ -1,0 +1,8 @@
+{
+  "label": "retrieval latency vs store size (in-memory, linear scan)",
+  "note": "Seeding beyond ~1k is O(n^2) via the HTTP write path and was not run to 5k/10k locally; the O(n) trend is already visible. The production answer is the pgvector ANN path (follow-up).",
+  "points": [
+    {"store_size_approx": 100,  "retrieval_p50_ms": 75.81,  "retrieval_p95_ms": 99.33},
+    {"store_size_approx": 1000, "retrieval_p50_ms": 193.16, "retrieval_p95_ms": 321.93}
+  ]
+}

--- a/benchmark/perf/results/rate-limit-on_chat-burst.json
+++ b/benchmark/perf/results/rate-limit-on_chat-burst.json
@@ -1,0 +1,32 @@
+{
+  "label": "rate-limit-ON chat burst",
+  "base_url": "http://127.0.0.1:8098",
+  "requests_per_scenario": 100,
+  "seed": 0,
+  "server_rss_mb": {
+    "before": null,
+    "after": null
+  },
+  "generated_at": "2026-07-13T06:06:50Z",
+  "scenarios": [
+    {
+      "operation": "chat",
+      "concurrency": 10,
+      "n": 100,
+      "errors": 70,
+      "error_rate": 0.7,
+      "wall_s": 1.8926,
+      "rps": 52.8,
+      "p50_ms": 4.96,
+      "p95_ms": 1040.047,
+      "p99_ms": 1788.137,
+      "min_ms": 1.497,
+      "mean_ms": 183.948,
+      "max_ms": 1789.391,
+      "status_counts": {
+        "200": 30,
+        "429": 70
+      }
+    }
+  ]
+}

--- a/benchmark/perf/run_perf.py
+++ b/benchmark/perf/run_perf.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""MemoryOps AI — HTTP load / performance harness (P4.3).
+
+Drives concurrent HTTP load against a *running* MemoryOps API and records
+throughput + latency percentiles + error rate for the three user-facing
+operations the review calls out:
+
+    write      a chat message that is a *statement* → extraction + policy +
+               store + audit (the full write path).
+    retrieval  a chat message that is a *question* against a pre-seeded store →
+               retrieve + rank + admission + compose (the read path).
+    chat       a representative mixed message (question, may also write).
+
+For each (operation × concurrency) it fires a fixed number of requests through a
+thread pool of `concurrency` workers and reports requests/sec, p50/p95/p99 (and
+min/mean/max) latency, and the non-2xx error rate. Optionally samples the server
+process RSS via `ps` for a coarse memory figure.
+
+Design notes
+------------
+* HTTP, not in-process: this is deliberately the realistic path. It exercises
+  Starlette's threadpool (the sync route handlers run there), so it can actually
+  *observe* the serialization / saturation the async-decision-rule keys on.
+* Offline + reproducible: default config is in-memory store + stub providers, so
+  there are no API keys, no DB, and the numbers are deterministic in shape.
+* The harness does not boot the server (server lifecycle differs a lot between a
+  laptop and CI); point it at a URL you started with the env you want to measure.
+
+Usage
+-----
+    python benchmark/perf/run_perf.py \
+        --base-url http://127.0.0.1:8099 \
+        --requests 400 --concurrency 1,5,10,25,50 \
+        --out results.json
+
+Exit code is 0 unless a scenario exceeds --max-error-rate (default 0.5),
+so a smoke run can gate CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass, field
+
+import httpx
+
+# ── request factories ─────────────────────────────────────────────────────────
+_STATEMENTS = [
+    "Remember that I prefer metric units.",
+    "Note that I work in the Pacific timezone.",
+    "I like my code reviews to be concise and direct.",
+    "My favourite editor is Neovim.",
+    "Please keep responses under three sentences when I ask quick questions.",
+]
+_QUESTIONS = [
+    "What are my display and unit preferences?",
+    "What timezone do I work in?",
+    "How do I like my code reviews?",
+    "Which editor do I prefer?",
+    "How long should quick answers be?",
+]
+
+
+def _op_body(op: str, tenant: str, user: str, i: int) -> dict:
+    if op == "write":
+        msg = _STATEMENTS[i % len(_STATEMENTS)] + f" (#{i})"
+    elif op == "retrieval":
+        msg = _QUESTIONS[i % len(_QUESTIONS)]
+    else:  # chat / mixed
+        msg = (_QUESTIONS if i % 2 else _STATEMENTS)[i % len(_STATEMENTS)]
+    return {"tenant_id": tenant, "user_id": user, "message": msg}
+
+
+# ── metrics ───────────────────────────────────────────────────────────────────
+def _pct(sorted_vals: list[float], p: float) -> float:
+    if not sorted_vals:
+        return 0.0
+    k = (len(sorted_vals) - 1) * p
+    lo, hi = int(k), min(int(k) + 1, len(sorted_vals) - 1)
+    return sorted_vals[lo] + (sorted_vals[hi] - sorted_vals[lo]) * (k - lo)
+
+
+@dataclass
+class ScenarioResult:
+    operation: str
+    concurrency: int
+    n: int
+    errors: int
+    error_rate: float
+    wall_s: float
+    rps: float
+    p50_ms: float
+    p95_ms: float
+    p99_ms: float
+    min_ms: float
+    mean_ms: float
+    max_ms: float
+    status_counts: dict = field(default_factory=dict)
+
+
+def _run_scenario(
+    client_factory,
+    op: str,
+    concurrency: int,
+    n: int,
+    tenant: str,
+    user: str,
+) -> ScenarioResult:
+    latencies: list[float] = []
+    statuses: dict[str, int] = {}
+    errors = 0
+
+    def _one(i: int) -> tuple[float, int]:
+        client = client_factory()
+        body = _op_body(op, tenant, user, i)
+        t0 = time.perf_counter()
+        try:
+            r = client.post("/api/chat", json=body)
+            code = r.status_code
+        except Exception:  # noqa: BLE001 — count transport errors as failures
+            code = 0
+        return (time.perf_counter() - t0) * 1000.0, code
+
+    t_start = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = [pool.submit(_one, i) for i in range(n)]
+        for f in as_completed(futures):
+            ms, code = f.result()
+            latencies.append(ms)
+            key = str(code)
+            statuses[key] = statuses.get(key, 0) + 1
+            if not (200 <= code < 300):
+                errors += 1
+    wall = time.perf_counter() - t_start
+
+    latencies.sort()
+    return ScenarioResult(
+        operation=op,
+        concurrency=concurrency,
+        n=n,
+        errors=errors,
+        error_rate=errors / n if n else 0.0,
+        wall_s=round(wall, 4),
+        rps=round(n / wall, 1) if wall else 0.0,
+        p50_ms=round(_pct(latencies, 0.50), 3),
+        p95_ms=round(_pct(latencies, 0.95), 3),
+        p99_ms=round(_pct(latencies, 0.99), 3),
+        min_ms=round(latencies[0], 3),
+        mean_ms=round(statistics.fmean(latencies), 3),
+        max_ms=round(latencies[-1], 3),
+        status_counts=statuses,
+    )
+
+
+# ── seeding ───────────────────────────────────────────────────────────────────
+def _seed(base_url: str, tenant: str, user: str, count: int) -> None:
+    """Populate the store with `count` memories via write-path chat messages."""
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        for i in range(count):
+            c.post(
+                "/api/chat",
+                json={
+                    "tenant_id": tenant,
+                    "user_id": user,
+                    "message": f"Remember fact number {i}: item_{i} has value {i * 7 % 97}.",
+                },
+            )
+
+
+def _server_rss_mb(pid: int | None) -> float | None:
+    if not pid:
+        return None
+    try:
+        out = subprocess.run(
+            ["ps", "-o", "rss=", "-p", str(pid)], capture_output=True, text=True, timeout=5
+        )
+        return round(int(out.stdout.strip()) / 1024.0, 1)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base-url", default="http://127.0.0.1:8099")
+    ap.add_argument("--requests", type=int, default=400, help="requests per scenario")
+    ap.add_argument("--concurrency", default="1,5,10,25,50")
+    ap.add_argument("--operations", default="write,retrieval,chat")
+    ap.add_argument("--warmup", type=int, default=20)
+    ap.add_argument("--seed", type=int, default=0, help="pre-seed N memories before running")
+    ap.add_argument("--server-pid", type=int, default=None, help="sample this pid's RSS")
+    ap.add_argument("--label", default="in-memory/stub", help="config label for the report")
+    ap.add_argument("--max-error-rate", type=float, default=0.5)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    concurrencies = [int(x) for x in args.concurrency.split(",") if x]
+    operations = [x.strip() for x in args.operations.split(",") if x.strip()]
+    tenant = "t_perf"
+    user = f"u_{uuid.uuid4().hex[:6]}"
+
+    def client_factory() -> httpx.Client:
+        # one client per thread-call; cheap for a localhost keep-alive pool
+        return httpx.Client(base_url=args.base_url, timeout=30.0)
+
+    # health check
+    with httpx.Client(base_url=args.base_url, timeout=10.0) as c:
+        r = c.get("/healthz")
+        r.raise_for_status()
+        print(f"server ok: {r.json()}")
+
+    if args.seed:
+        print(f"seeding {args.seed} memories…")
+        _seed(args.base_url, tenant, user, args.seed)
+
+    # warmup (not recorded)
+    if args.warmup:
+        with httpx.Client(base_url=args.base_url, timeout=30.0) as c:
+            for i in range(args.warmup):
+                c.post("/api/chat", json=_op_body("chat", tenant, user, i))
+
+    rss_before = _server_rss_mb(args.server_pid)
+    results: list[ScenarioResult] = []
+    for op in operations:
+        for conc in concurrencies:
+            res = _run_scenario(client_factory, op, conc, args.requests, tenant, user)
+            results.append(res)
+            print(
+                f"{op:10s} c={conc:<3d} rps={res.rps:<8.1f} "
+                f"p50={res.p50_ms:<8.3f} p95={res.p95_ms:<9.3f} p99={res.p99_ms:<9.3f} "
+                f"err={res.error_rate:.1%} {res.status_counts}"
+            )
+    rss_after = _server_rss_mb(args.server_pid)
+
+    report = {
+        "label": args.label,
+        "base_url": args.base_url,
+        "requests_per_scenario": args.requests,
+        "seed": args.seed,
+        "server_rss_mb": {"before": rss_before, "after": rss_after},
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "scenarios": [asdict(r) for r in results],
+    }
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump(report, fh, indent=2)
+        print(f"wrote {args.out}")
+
+    worst = max((r.error_rate for r in results), default=0.0)
+    if worst > args.max_error_rate:
+        print(f"FAIL: worst error rate {worst:.1%} > {args.max_error_rate:.1%}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,193 @@
+# Performance (P4.3)
+
+> **Status: first pass — in-memory + stub providers, single process.**
+> This is the honest baseline the async decision (ADR / P2.1) should be made
+> *from*, not a claim that MemoryOps is tuned. Postgres, real providers, and
+> per-stage CPU/pool instrumentation are explicit follow-ups (see the end).
+
+## TL;DR
+
+- **The API does not scale with concurrency in a single process.** Throughput is
+  flat-to-declining from 1→50 concurrent clients while p50 latency grows roughly
+  linearly. That is the signature of **serialized request handling**.
+- Under the **stub provider + in-memory store**, that serialization is
+  **CPU/GIL-bound** (pure-Python embedding, cosine scan, ranking, policy) — work
+  that an async rewrite **would not** speed up.
+- Therefore **the current evidence does not justify the async rewrite (P2.1).**
+  The immediate scaling lever is **horizontal** (more uvicorn workers / replicas).
+  The I/O-bound case that async actually addresses (real LLM/embedding network
+  calls, Postgres round-trips) has **not been measured yet** and is the gate for
+  reopening that decision.
+- The **per-process rate limiter** works exactly as specified (30/min chat →
+  fail-fast 429) and is, as the review noted, **per-replica** — not a distributed
+  limit.
+- Two real bugs were surfaced by this work and fixed first:
+  [test-rls password masking](../services/api/tests/test_rls.py) (PR #41 follow-up)
+  and the [multi-memory write 500](../services/api/app/services/gateway.py) (PR #42).
+
+## How to reproduce
+
+The harness ([`benchmark/perf/run_perf.py`](../benchmark/perf/run_perf.py)) drives
+concurrent HTTP load against a **running** server and records throughput, latency
+percentiles, and error rate. It is offline and deterministic in shape — no API
+keys, no DB.
+
+```bash
+# 1. start a server with the config you want to measure
+cd services/api
+MEMORYOPS_STORAGE=memory MEMORYOPS_EMBEDDING_PROVIDER=stub MEMORYOPS_LLM_PROVIDER=stub \
+  MEMORYOPS_RATE_LIMIT_ENABLED=false \
+  uvicorn app.main:app --host 127.0.0.1 --port 8099 --log-level warning
+
+# 2. drive load
+python benchmark/perf/run_perf.py --base-url http://127.0.0.1:8099 \
+  --requests 400 --concurrency 1,5,10,25,50 --operations write,retrieval,chat \
+  --out results.json
+```
+
+Operations map to the three user-facing paths:
+
+| op | what it exercises |
+|----|-------------------|
+| `write` | a chat message that is a **statement** → extraction + policy broker + store + audit |
+| `retrieval` | a chat message that is a **question** → retrieve + rank + admission + compose |
+| `chat` | a representative mixed message (question, may also write) |
+
+Raw JSON for every run below lives in
+[`benchmark/perf/results/`](../benchmark/perf/results/).
+
+## Environment & honesty caveats
+
+- Measured on a laptop (macOS, Apple Silicon), **single uvicorn worker**, Python
+  3.11, in-memory store, stub providers.
+- **Absolute latencies are inflated** by this environment: macOS per-file security
+  scanning made cold Python import take **70–85 s** and the first execution of each
+  code path unusually slow. **Cold-start numbers here are not representative of a
+  Linux/CI/Railway host** and should be ignored as absolute figures. The
+  **relative** signal — how throughput and latency move with concurrency and store
+  size — is what this document draws conclusions from, and that signal is robust.
+- `write` and `retrieval` accumulate memories in the in-memory store as they run,
+  so later scenarios see a larger store (this is realistic, and separated out in
+  the dataset-size section).
+
+## Results
+
+### 1. Concurrency sweep — in-memory / stub / rate-limit off / hybrid ranker
+
+400 requests per scenario. `rps` = requests/sec (higher better); latency in ms.
+
+| op | conc | rps | p50 | p95 | p99 | errors |
+|----|-----:|----:|----:|----:|----:|:------:|
+| write | 1 | **62.3** | 13.6 | 23.4 | 24.9 | 0% |
+| write | 5 | 38.8 | 125.0 | 133.2 | 145.4 | 0% |
+| write | 10 | 35.5 | 279.9 | 346.8 | 374.7 | 0% |
+| write | 25 | 32.2 | 820.0 | 973.8 | 1005.6 | 0% |
+| write | 50 | 28.6 | 1717.2 | 2104.1 | 2169.7 | 0% |
+| retrieval | 1 | **24.2** | 38.0 | 42.6 | 46.7 | 0% |
+| retrieval | 5 | 24.5 | 200.2 | 246.1 | 300.1 | 0% |
+| retrieval | 10 | 22.8 | 448.3 | 534.0 | 576.9 | 0% |
+| retrieval | 25 | 20.2 | 1301.3 | 1553.1 | 1605.9 | 0% |
+| retrieval | 50 | 17.5 | 2740.5 | 3413.7 | 3858.5 | 0% |
+| chat | 1 | **15.1** | 62.2 | 72.8 | 87.7 | 0% |
+| chat | 5 | 14.7 | 337.6 | 416.9 | 486.1 | 0% |
+| chat | 10 | 13.5 | 760.2 | 942.2 | 1005.7 | 0% |
+| chat | 25 | 12.5 | 2001.9 | 2327.3 | 2653.7 | 0% |
+| chat | 50 | 11.6 | 4175.5 | 4985.6 | 5276.9 | 0% |
+
+**Reading it.** Going from 1 → 50 concurrent clients:
+
+- throughput **does not rise** (chat 15.1 → 11.6 rps; retrieval 24.2 → 17.5;
+  write 62.3 → 28.6 — all flat or *down*), and
+- p50 latency rises **~linearly** with concurrency (chat 62 ms → 4175 ms ≈ 67× for
+  50× the clients).
+
+That is a single serialized service: added concurrency just queues. Error rate is
+**0%** everywhere — nothing is falling over, it simply isn't parallel.
+
+### 2. Latency vs store size — retrieval, in-memory (linear scan)
+
+Retrieval p50 as the store grows (single client):
+
+| store size (approx) | retrieval p50 | p95 |
+|--------------------:|--------------:|----:|
+| 100   | 75.8 ms  | 99.3 ms  |
+| 1,000 | 193.2 ms | 321.9 ms |
+
+10× the store → ~2.5× the retrieval latency. Seeding beyond ~1 k memories through
+the HTTP write path is **O(n²)** (every seed write also runs a read over the
+growing store), so the 5 k / 10 k points were not driven locally — but the trend
+above already shows the shape. The in-memory repository scans **O(n)** candidates
+per query, so retrieval cost grows with the store. This is a property of the **dev/default** backend, not of
+MemoryOps as designed: on Postgres, retrieval goes through the **pgvector ANN
+index** (and the `VectorIndex` abstraction, ADR-021), which is sub-linear.
+Quantifying that is a follow-up (needs pgvector; see below). Store **memory** also
+grows with the row count — RSS rose from **37 MB → 234 MB** over the ~6 k writes in
+the concurrency sweep (~33 KB/memory incl. embedding), another reason the in-memory
+store is dev-only.
+
+### 3. Rate limiter — per-process, fail-fast
+
+`MEMORYOPS_RATE_LIMIT_ENABLED=true`, defaults (chat = 30/min per tenant/IP). A
+burst of 100 chat requests (concurrency 10) from one tenant/IP:
+
+| outcome | count |
+|---------|------:|
+| `200` served | **30** |
+| `429` rate-limited | **70** |
+
+Exactly the 30/min cap; rejected requests fail fast (~5 ms). This confirms the
+limiter works — **and** confirms the review's caveat: the counter is **in-process**.
+Each replica has its own 30/min budget, and a restart resets it. It is **local
+process protection, not distributed rate enforcement.** A Redis-backed limiter is
+the fix for a real multi-replica limit (follow-up).
+
+## The async decision (P2.1) — verdict: **not yet justified**
+
+The review's rule: proceed with the async rewrite only when measurements show
+thread-pool / connection-pool saturation, severe p95 degradation under moderate
+concurrency, provider calls serializing requests, or throughput materially below a
+realistic target.
+
+What the data actually shows:
+
+1. **Yes**, there is severe p95 degradation and flat throughput under concurrency.
+2. **But** the cause here is **CPU/GIL-bound** work (stub embeddings, in-memory
+   cosine scan, ranking, policy) — all synchronous Python compute. `asyncio`
+   parallelizes **I/O waits**, not CPU. Rewriting these sync routes as `async def`
+   would **not** raise throughput; it could lower it (event-loop overhead on
+   CPU-bound handlers).
+3. The place async *does* pay off — a route thread parked on a **network** LLM /
+   embedding call, or a **Postgres** round-trip, while other requests wait — is
+   **exactly what the stub + in-memory config removes from the measurement.** We
+   have not measured it.
+
+**Conclusion.** On this evidence the correct next scaling step is **horizontal**:
+run multiple uvicorn workers / replicas (each a separate process, side-stepping the
+GIL) behind the load balancer we already deploy on Railway. The async rewrite
+should stay **deferred** until the I/O-bound numbers exist:
+
+- retrieval / write / chat latency + throughput with a **real** embedding + LLM
+  provider (network I/O in the hot path), and
+- the same against **Postgres** (connection-pool behaviour under concurrency).
+
+If *those* show threadpool or pool saturation, reopen P2.1 — and stage it as the
+review prescribed (async provider clients + gateway → async Postgres repo + pooling
+→ async routes/workers, each with before/after numbers).
+
+## Follow-ups (measured next, tracked separately)
+
+- [ ] **Postgres + pgvector** run of the same sweep (needs pgvector; not installable
+      in the authoring env). In-memory-vs-Postgres and ANN-vs-linear retrieval.
+- [ ] **Real providers** (OpenAI / Anthropic) latency + fallback frequency in the
+      hot path — the I/O-bound numbers that gate the async decision.
+- [ ] **Retrieval quality** comparison vector-only vs BM25-only vs hybrid
+      (Recall@5 / MRR / nDCG). Ranker mode is a *quality* lever with negligible
+      latency impact (latency is dominated by the O(n) candidate scan), so it lives
+      with the retrieval-quality work, not here.
+- [ ] **Per-stage CPU / memory / DB-pool** instrumentation (the harness records
+      coarse server RSS today; add per-stage timing + pool gauges).
+- [ ] **Graceful degradation** under injected provider/DB failure as a timed
+      scenario (invariant #4 is already covered functionally by the P3.3 chaos
+      tests; this would add the latency/throughput view).
+- [ ] **10k+ store** retrieval on the ANN path (the in-memory linear scan is the
+      wrong backend to push to that size).


### PR DESCRIPTION
Adds **`docs/performance.md`** (P4.3) plus the reproducible harness that produced it, a CI perf-smoke gate, and a workflow-hygiene pass. Two real bugs surfaced along the way were already fixed and merged first (**#41** RLS password-masking follow-up, **#42** multi-memory write 500) — this PR contains no source-behavior changes, only the harness, docs, results, and CI.

## What's here

- **`benchmark/perf/run_perf.py`** — HTTP load harness. Drives concurrent requests (write / retrieval / chat) at a configurable concurrency sweep against a running server; reports rps, p50/p95/p99, and error rate. Offline + deterministic (in-memory + stub providers).
- **`docs/performance.md`** — method, results, honesty caveats, and the async-decision verdict.
- **`benchmark/perf/results/`** — raw JSON for every run.
- **CI `perf-smoke` job** — boots the app and drives a small sweep with a strict `--max-error-rate 0.02`. This is a regression gate: the multi-memory 500 (#42) showed as a ~40% error rate and would fail it.
- **Workflow hygiene** — bumped `checkout@v4→v5`, `setup-python@v5→v6`, `setup-node@v4→v5` across all five workflows (incl. the PR invariant/"code-review" gate), clearing the Node 20 deprecation warnings.

## Headline result

Single process, in-memory, stub providers, 400 req/scenario:

| op | c=1 rps | c=50 rps | c=1 p50 | c=50 p50 |
|----|--------:|---------:|--------:|---------:|
| write | 62.3 | 28.6 | 13.6 ms | 1717 ms |
| retrieval | 24.2 | 17.5 | 38.0 ms | 2740 ms |
| chat | 15.1 | 11.6 | 62.2 ms | 4175 ms |

**Throughput is flat-to-declining as concurrency rises; p50 grows ~linearly.** That's serialized request handling. Error rate 0% throughout — nothing falls over, it just isn't parallel.

## Async decision (P2.1): **not yet justified**

Under stub + in-memory, the serialization is **CPU/GIL-bound** (pure-Python embedding, cosine scan, ranking, policy). `asyncio` parallelizes I/O waits, not CPU — it would not raise throughput here. The I/O-bound case async *does* address (real LLM/embedding network calls, Postgres round-trips) is exactly what this config removes from the measurement and has **not been measured yet**.

→ Immediate lever is **horizontal** (multiple uvicorn workers / replicas, side-stepping the GIL). Reopen P2.1 only when real-provider + Postgres numbers show threadpool/pool saturation.

## Also measured

- **Rate limiter** (`ENABLED=true`): a 100-request chat burst → **30 × 200, 70 × 429**, exactly the 30/min cap, failing fast. Confirms the review's point that it's **per-process**, not distributed.
- **Retrieval vs store size** (in-memory linear scan): 100 → 76 ms, 1 000 → 193 ms p50 (O(n); the production answer is the pgvector ANN path).

## Explicit follow-ups (not in this PR)

Postgres + pgvector sweep · real-provider (I/O-bound) latency · retrieval-quality vector/BM25/hybrid (Recall@5/MRR/nDCG) · per-stage CPU/mem/pool instrumentation · graceful-degradation timed scenario.

## Caveat

Authored on macOS where per-file security scanning inflated cold import (70–85 s) and absolute latencies; **relative** scaling trends are the signal and are robust. Numbers should be re-taken on a Linux/CI/Railway host.
