### PR TITLE
Harden for SDK launch: PyJWT CVE fix, SDK auth, docs & CI security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+# Dependabot keeps dependencies patched (supply-chain hygiene). Grouped, weekly,
+# with a bounded PR count so it stays reviewable. Security updates are raised
+# regardless of the schedule.
+version: 2
+updates:
+  # ── Python: API (runtime + dev + Postgres extras all live under services/api) ──
+  - package-ecosystem: pip
+    directory: /services/api
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      python-api:
+        patterns: ["*"]
+
+  # ── Python: SDK ──
+  - package-ecosystem: pip
+    directory: /packages/memoryops-sdk
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      python-sdk:
+        patterns: ["*"]
+
+  # ── Python: worker ──
+  - package-ecosystem: pip
+    directory: /services/worker
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  # ── Python: Streamlit demos (playground + results dashboard) ──
+  - package-ecosystem: pip
+    directory: /apps/playground
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+  - package-ecosystem: pip
+    directory: /apps/results-dashboard
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+
+  # ── Node: web frontend ──
+  - package-ecosystem: npm
+    directory: /apps/web
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      web:
+        patterns: ["*"]
+
+  # ── GitHub Actions used by the workflows ──
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,15 +111,20 @@ jobs:
   # additionally proves it passes against the real Postgres + pgvector stack.
 
   sdk:
-    name: SDK — tests
+    name: SDK — tests (py ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The SDK declares requires-python >=3.10; test every supported minor.
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: pip
 
       - name: Install deps (API for the in-process e2e fixture + SDK)
@@ -151,7 +156,9 @@ jobs:
 
       - name: Install
         working-directory: apps/web
-        run: npm ci || npm install
+        # Strict: fail if package-lock.json is out of sync rather than silently
+        # regenerating it (the old `|| npm install` fallback masked lockfile drift).
+        run: npm ci
 
       - name: Build
         working-directory: apps/web
@@ -176,9 +183,11 @@ jobs:
           python -m pip install -r requirements-dev.txt
 
       # Boots the real app (in-memory, stub providers, rate-limit off) and drives a
-      # small concurrency sweep. The strict --max-error-rate 0.02 makes this a
-      # regression gate: e.g. the multi-memory write 500 (PR #42) showed as a ~40%
-      # error rate and would fail here. Keeps benchmark/perf/run_perf.py runnable.
+      # small concurrency sweep. --max-error-rate 0 makes this a zero-tolerance
+      # regression gate: a single unexpected HTTP 500 fails it. (At 60 requests the
+      # old 0.02 threshold silently tolerated one failure — ~1.67% < 2%.) e.g. the
+      # multi-memory write 500 (PR #42) showed as a ~40% error rate and fails here.
+      # Keeps benchmark/perf/run_perf.py runnable.
       - name: Boot API + run load harness
         working-directory: services/api
         env:
@@ -195,7 +204,8 @@ jobs:
           python ../../benchmark/perf/run_perf.py \
             --base-url http://127.0.0.1:8099 \
             --requests 60 --concurrency 1,5,10 --operations write,retrieval,chat \
-            --max-error-rate 0.02 --out ../../perf-smoke.json
+            --repetitions 2 --seed-per-scenario 10 --warmup 10 \
+            --max-error-rate 0 --out ../../perf-smoke.json
           RC=$?
           kill $SRV 2>/dev/null || true
           exit $RC

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,23 +1,20 @@
 name: Publish memoryops-sdk
 
-# Publishes the Python SDK (packages/memoryops-sdk) to PyPI.
+# Publishes the Python SDK (packages/memoryops-sdk) to PyPI via Trusted Publishing.
 #
-# Setup (one time): configure PyPI Trusted Publishing for this repository,
-# workflow file, and the `pypi` GitHub environment. Then either:
-#   * push a tag like `sdk-v1.0.0`, or
-#   * run this workflow manually (Actions → Publish memoryops-sdk → Run workflow).
+# Setup (one time): configure PyPI Trusted Publishing for this repository, this
+# workflow file, and the `pypi` GitHub environment.
 #
-# A dry run (build only, no upload) happens on manual dispatch with publish=false.
+# Publishing is TAG-ONLY: push a tag like `sdk-v1.0.0`. The tag version, the SDK
+# pyproject/package version, and the API `app.__version__` must all agree (release
+# policy: the API and SDK contract versions move together — see RELEASING.md /
+# docs/api-stability.md). A manual dispatch is build-and-verify ONLY; it never
+# uploads, so it is a safe dry run.
 
 on:
   push:
     tags: ["sdk-v*"]
-  workflow_dispatch:
-    inputs:
-      publish:
-        description: "Upload to PyPI (false = build + check only)"
-        type: boolean
-        default: false
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -34,19 +31,61 @@ jobs:
         with:
           python-version: "3.12"
 
-      # The git tag (sdk-vX.Y.Z) and the SDK's pyproject version must agree, so a
-      # release can never ship a package whose version does not match its tag.
-      - name: Assert tag matches pyproject version
-        if: startsWith(github.ref, 'refs/tags/sdk-v')
-        working-directory: packages/memoryops-sdk
+      # Single source of truth: the SDK pyproject version. Every other version
+      # (git tag, SDK package, API app) must equal it, so a release can never ship
+      # a package whose version disagrees with its tag or with the API it targets.
+      - name: Assert versions agree (pyproject == tag == SDK package == API app)
+        id: version
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          tag_version="${GITHUB_REF_NAME#sdk-v}"
-          pkg_version="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")"
-          echo "tag=$tag_version pyproject=$pkg_version"
-          if [ "$tag_version" != "$pkg_version" ]; then
-            echo "::error::tag sdk-v$tag_version does not match pyproject version $pkg_version"
-            exit 1
-          fi
+          expected="$(python - <<'PY'
+          import ast, os, sys, tomllib
+
+          def module_version(path):
+              tree = ast.parse(open(path, encoding="utf-8").read())
+              for node in tree.body:
+                  if isinstance(node, ast.Assign) and any(
+                      isinstance(t, ast.Name) and t.id == "__version__" for t in node.targets
+                  ):
+                      return ast.literal_eval(node.value)
+              raise SystemExit(f"::error::no __version__ found in {path}")
+
+          # Single source of truth.
+          expected = tomllib.load(
+              open("packages/memoryops-sdk/pyproject.toml", "rb")
+          )["project"]["version"]
+
+          sources = {
+              "SDK package (memoryops.__version__)":
+                  module_version("packages/memoryops-sdk/memoryops/__init__.py"),
+              "API app (app.__version__)":
+                  module_version("services/api/app/__init__.py"),
+          }
+
+          # Git tag is only present on tag pushes.
+          if os.environ.get("REF_TYPE") == "tag":
+              sources["git tag"] = os.environ["REF_NAME"].removeprefix("sdk-v")
+
+          fail = False
+          print(f"expected (SDK pyproject): {expected}", file=sys.stderr)
+          for label, value in sources.items():
+              ok = value == expected
+              print(f"  {'ok ' if ok else 'MISMATCH'} {label}: {value}", file=sys.stderr)
+              if not ok:
+                  print(
+                      f"::error::{label} ({value}) does not match SDK pyproject "
+                      f"version {expected} (API + SDK versions must move together)",
+                      file=sys.stderr,
+                  )
+                  fail = True
+          if fail:
+              raise SystemExit(1)
+          print(expected)
+          PY
+          )"
+          echo "expected=$expected" >> "$GITHUB_OUTPUT"
 
       - name: Build sdist + wheel
         working-directory: packages/memoryops-sdk
@@ -57,17 +96,23 @@ jobs:
 
       - name: Test wheel in a clean environment
         working-directory: packages/memoryops-sdk
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.expected }}
         run: |
           python -m venv /tmp/memoryops-sdk-wheel-test
           /tmp/memoryops-sdk-wheel-test/bin/python -m pip install --upgrade pip
           /tmp/memoryops-sdk-wheel-test/bin/python -m pip install dist/*.whl
           /tmp/memoryops-sdk-wheel-test/bin/python - <<'PY'
+          import os
           import memoryops
           from memoryops import MemoryOpsClient
 
-          assert memoryops.__version__ == "1.0.0"
+          expected = os.environ["EXPECTED_VERSION"]
+          assert memoryops.__version__ == expected, (
+              f"clean wheel version {memoryops.__version__!r} != expected {expected!r}"
+          )
           assert MemoryOpsClient
-          print("memoryops-sdk clean wheel import ok")
+          print(f"memoryops-sdk clean wheel import ok (version {expected})")
           PY
 
       - name: Upload distribution artifact
@@ -79,7 +124,8 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    if: startsWith(github.ref, 'refs/tags/sdk-v') || inputs.publish
+    # TAG-ONLY. Manual dispatch runs `build` above as a dry run and stops here.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/sdk-v')
     needs: build
     runs-on: ubuntu-latest
     environment: pypi

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -29,7 +29,9 @@ jobs:
           - label: api-postgres
             req: services/api/requirements-postgres.txt
           - label: sdk
-            req: null # SDK declares deps in pyproject; audit the resolved package
+            # No `req`: the SDK declares deps in pyproject, so we audit the package
+            # directory instead of a requirements file (empty `req` selects that path).
+            req: ""
           - label: worker
             req: services/worker/requirements.txt
     steps:
@@ -55,10 +57,10 @@ jobs:
             --ignore-vuln PYSEC-2026-2280
             --ignore-vuln PYSEC-2026-2281
         run: |
-          if [ "${{ matrix.req }}" = "null" ]; then
-            pip-audit --strict --progress-spinner off $IGNORES ./packages/memoryops-sdk
-          else
+          if [ -n "${{ matrix.req }}" ]; then
             pip-audit --strict --progress-spinner off $IGNORES -r "${{ matrix.req }}"
+          else
+            pip-audit --strict --progress-spinner off $IGNORES ./packages/memoryops-sdk
           fi
 
   # ── Secret scanning (committed credentials) ───────────────────────────────────
@@ -75,20 +77,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ── Filesystem + IaC/Dockerfile misconfiguration + dependency scan (Trivy) ─────
-  # Reports vulnerabilities and Dockerfile/compose misconfigurations. Non-blocking
-  # for now (base-image CVEs are triaged, not launch-blockers); promote to blocking
-  # once the baseline is clean.
+  # Report-only for now: it surfaces vulnerabilities and Dockerfile/compose
+  # misconfigurations in the job log without blocking the PR (base-image CVEs are
+  # triaged, not launch-blockers). Promote to `--exit-code 1` once the baseline is
+  # clean. The CLI is installed directly (version-stable) rather than via a pinned
+  # marketplace action tag.
   trivy:
     name: Trivy (fs + config)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v5
-      - name: Trivy filesystem + misconfig scan
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          scan-type: fs
-          scanners: vuln,secret,misconfig
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: "1"
+      - name: Install Trivy
+        run: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+      - name: Trivy filesystem + misconfig scan (report-only)
+        run: |
+          trivy fs --scanners vuln,secret,misconfig \
+            --severity CRITICAL,HIGH --ignore-unfixed \
+            --exit-code 0 --no-progress .

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,94 @@
+name: Security scan
+
+# Supply-chain + secret + misconfiguration scanning. Complements ci.yml (tests) and
+# the PR invariant gate (governance evidence). Runs on PRs, pushes to main, and
+# weekly so newly-disclosed advisories are caught even without a code change.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "27 6 * * 1" # Mondays 06:27 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Python dependency vulnerabilities (pip-audit / OSV) ───────────────────────
+  pip-audit:
+    name: pip-audit (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: api
+            req: services/api/requirements.txt
+          - label: api-postgres
+            req: services/api/requirements-postgres.txt
+          - label: sdk
+            req: null # SDK declares deps in pyproject; audit the resolved package
+          - label: worker
+            req: services/worker/requirements.txt
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip pip-audit
+      - name: Audit ${{ matrix.label }}
+        # Blocking gate: any *new* advisory fails CI. The --ignore-vuln entries below
+        # are a documented, temporary allowlist for advisories in `starlette` (pulled
+        # in transitively by fastapi==0.118.0). Their fixes live in starlette >=0.49.1
+        # / 1.x, which fastapi 0.118.0 does not allow — clearing them requires a
+        # validated FastAPI upgrade, tracked separately (see docs/limitations.md).
+        # Remove each ID here as that upgrade lands. Do NOT add ignores casually.
+        env:
+          # starlette (via fastapi 0.118.0) — remove when fastapi/starlette is bumped:
+          IGNORES: >-
+            --ignore-vuln PYSEC-2026-161
+            --ignore-vuln PYSEC-2026-248
+            --ignore-vuln PYSEC-2026-249
+            --ignore-vuln PYSEC-2026-1942
+            --ignore-vuln PYSEC-2026-2280
+            --ignore-vuln PYSEC-2026-2281
+        run: |
+          if [ "${{ matrix.req }}" = "null" ]; then
+            pip-audit --strict --progress-spinner off $IGNORES ./packages/memoryops-sdk
+          else
+            pip-audit --strict --progress-spinner off $IGNORES -r "${{ matrix.req }}"
+          fi
+
+  # ── Secret scanning (committed credentials) ───────────────────────────────────
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history so pushes scan new commits, not just the tip
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Filesystem + IaC/Dockerfile misconfiguration + dependency scan (Trivy) ─────
+  # Reports vulnerabilities and Dockerfile/compose misconfigurations. Non-blocking
+  # for now (base-image CVEs are triaged, not launch-blockers); promote to blocking
+  # once the baseline is clean.
+  trivy:
+    name: Trivy (fs + config)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+      - name: Trivy filesystem + misconfig scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scanners: vuln,secret,misconfig
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,8 +13,11 @@ There are **two independent tracks** (see
   fixes/hardening. The tag + GitHub Release are the source of truth for "what shipped".
 - **API + SDK contract** — `app.__version__` and `packages/memoryops-sdk`
   `pyproject.toml`, released under `sdk-vX.Y.Z` tags. These two **must always move
-  together**; bump both in the same PR. CI (`publish-sdk.yml`) fails a release whose
-  `sdk-v*` tag does not match the SDK `pyproject.toml` version.
+  together**; bump both in the same PR. CI (`publish-sdk.yml`) derives the expected
+  version from the SDK `pyproject.toml` and fails the release unless the `sdk-v*` tag,
+  `memoryops.__version__`, **and** `app.__version__` all match it. Publication is
+  **tag-only** — a manual `workflow_dispatch` run builds and verifies but never
+  uploads.
 
 ## Release checklist
 
@@ -22,14 +25,14 @@ There are **two independent tracks** (see
    `npm run build`. See [docs/release-loop.md](docs/release-loop.md) for the
    `release.gate` loop contract.
 2. Decide the version and a one-line summary.
-3. Tag and push:
+3. Tag and push (use the next platform version — `v2.2` shipped most recently):
    ```bash
-   git tag -a v0.1 -m "MemoryOps AI v0.1 — <summary>"
-   git push origin v0.1
+   git tag -a v2.3 -m "MemoryOps AI v2.3 — <summary>"
+   git push origin v2.3
    ```
 4. Create the GitHub Release with the body template below:
    ```bash
-   gh release create v0.1 --title "MemoryOps AI v0.1 — <summary>" --notes-file notes.md
+   gh release create v2.3 --title "MemoryOps AI v2.3 — <summary>" --notes-file notes.md
    ```
 
 ## SDK release checklist
@@ -42,12 +45,16 @@ token. Configure PyPI once with:
 - workflow: `.github/workflows/publish-sdk.yml`
 - environment: `pypi`
 
-Then release the SDK:
+Then release the SDK (publication is **tag-only**; the manual dispatch is a
+build-and-verify dry run that never uploads):
 
 ```bash
-gh workflow run publish-sdk.yml -f publish=false
+# 1. Dry run: build + twine check + clean-wheel install + version agreement, no upload.
+gh workflow run publish-sdk.yml
+# 2. Publish by pushing the tag (must equal the SDK pyproject / app.__version__).
 git tag -a sdk-v1.0.0 -m "memoryops-sdk 1.0.0"
 git push origin sdk-v1.0.0
+# 3. Verify from a clean environment.
 python3 -m venv /tmp/memoryops-pypi-check
 source /tmp/memoryops-pypi-check/bin/activate
 pip install memoryops-sdk==1.0.0
@@ -73,10 +80,21 @@ python3 -c "import memoryops; print(memoryops.__version__)"
 * `npm run build` (apps/web)
 ```
 
-## Planned milestones
+## Remaining roadmap
 
-- **v0.1** — Phase 0 + Phase 1: design spine, write path, policy broker, audit,
-  dashboard, eval harness, invariant tests.
-- **v0.2** — Phase 2/3: retrieval wired into chat, governance UI actions complete.
-- **v0.3** — Phase 4: pgvector embeddings, enforced RLS, expanded evals.
-- **v0.4** — Phase 5: decay/reflection/conflict workers on a real scheduler.
+The v0.1–v2.2 milestones have all shipped (see `CHANGELOG.md` and the GitHub
+Releases). The remaining, forward-looking work:
+
+- **Atomic write + audit persistence** — commit the memory row and its audit event
+  in one transaction (or via a transactional outbox with durable delivery), closing
+  the crash window where a stored memory can lack its audit record.
+- **Live-provider validation** — real OpenAI/Anthropic/Gemini latency, fallback
+  frequency, and correctness in the hot path (beyond the offline stub replay).
+- **Retrieval-quality comparison** — vector-only vs BM25-only vs hybrid
+  (Recall@k / MRR / nDCG) on a labelled set.
+- **Distributed rate limiting** — a shared (Redis-backed) limiter to replace the
+  per-process counter, for a real multi-replica limit.
+- **External baseline** — benchmark against a comparable external memory system.
+- **Performance remeasurement** — re-run the corrected load harness (and the
+  Postgres/pgvector sweep) to replace the confounded first-pass numbers in
+  `docs/performance.md`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,9 +18,19 @@ A useful report includes:
 ## 2. Trust model
 
 MemoryOps AI is a memory governance layer. It assumes:
-- The gateway is the entry point; `tenant_id`/`user_id` are attached by a trusted
-  auth layer in front of it (out of scope for this repo's heuristic demo).
-- The Postgres/in-memory store is trusted infrastructure.
+- The gateway is the entry point. `tenant_id`/`user_id` identify the caller and are
+  either attached by a trusted auth layer in front of the API, or verified by the
+  built-in identity-neutral auth adapters (`MEMORYOPS_AUTH_MODE=none|trusted_header|jwt`,
+  **off by default** — `none`). The adapters verify an externally-minted identity
+  (trusted upstream header, or a bearer JWT via PyJWT — HS\* out of the box, RS\*/ES\*/JWKS
+  with the `[crypto]` extra) and enforce that every op is scoped to the authenticated
+  tenant/user (401 on missing/invalid creds, 403 on scope mismatch). MemoryOps is not
+  an auth *product* — it verifies identity and enforces scope; issuing identity stays
+  upstream (Clerk/Auth0/Supabase/BYO). See [docs/auth-adapters.md](docs/auth-adapters.md), ADR-020.
+- The Postgres/in-memory store is trusted infrastructure. On Postgres, tenant
+  isolation is additionally enforced by **forced row-level security** (`FORCE ROW LEVEL
+  SECURITY` + a tenant policy in `infra/db/migrations/004_rls_policies.sql`), verified in
+  CI against a non-superuser role (`scripts/check_rls_policies.py`). See ADR-006.
 - LLM/embedding providers are semi-trusted; their failure must never break safety.
 
 ## 3. Load-bearing security boundaries
@@ -41,9 +51,15 @@ load-bearing ones.
 
 ## 4. Non-goals (current phase)
 
-- Authentication/authorization (assumed upstream).
+- **Identity issuance** — MemoryOps verifies an externally-minted identity and
+  enforces tenant/user scope (see §2); it does not mint sessions, manage password/
+  social login, or replace an IdP. Issue identity upstream (Clerk/Auth0/Supabase/BYO).
+- Rate limiting / DoS protection (assumed at the edge — reverse proxy / API gateway).
 - Encryption at rest / KMS (roadmap — see [docs/security.md](docs/security.md)).
-- Enforced Postgres RLS (schema is RLS-ready; enforcement is Phase 4).
+
+Previously listed here and now **shipped** (no longer non-goals): built-in auth
+adapters (JWT/JWKS + trusted-header, off by default — §2, ADR-020) and enforced
+Postgres RLS (`FORCE`, CI-verified against a non-superuser — §2, ADR-006).
 
 ## 5. Defensive posture
 

--- a/benchmark/perf/run_perf.py
+++ b/benchmark/perf/run_perf.py
@@ -16,21 +16,46 @@ thread pool of `concurrency` workers and reports requests/sec, p50/p95/p99 (and
 min/mean/max) latency, and the non-2xx error rate. Optionally samples the server
 process RSS via `ps` for a coarse memory figure.
 
+What this harness controls for (so concurrency is closer to the only variable)
+-----------------------------------------------------------------------------
+* **Reused, bounded HTTP clients.** One ``httpx.Client`` is created *per scenario*
+  and shared across that scenario's worker threads (with a connection pool bounded
+  to the concurrency), then closed. Requests reuse keep-alive connections instead
+  of paying fresh client + TCP + TLS setup on every call, so latency reflects the
+  server, not client construction.
+* **Fresh scope per scenario.** Every scenario runs under a unique
+  ``tenant_id``/``user_id``, so store size, duplicate-detection state, and the
+  retrieval working set do not accumulate across the sweep.
+* **Fixed, identical seed count.** Each scenario's fresh scope is pre-seeded to the
+  same ``--seed-per-scenario`` memory count, so the retrieval workload is the same
+  in every scenario regardless of order.
+* **Repetitions + randomized order.** Each (operation × concurrency) is repeated
+  ``--repetitions`` times and the scenarios are run in a randomized order (seeded
+  via ``--rng-seed`` for reproducibility), so warm-up drift and ordering effects
+  are spread out rather than confounded with a single variable. Aggregates report
+  the median across repetitions.
+* **Actual memory counts.** Each scenario records the real memory count in its
+  scope before and after the run, so store growth is measured, not assumed.
+
 Design notes
 ------------
 * HTTP, not in-process: this is deliberately the realistic path. It exercises
-  Starlette's threadpool (the sync route handlers run there), so it can actually
-  *observe* the serialization / saturation the async-decision-rule keys on.
+  Starlette's threadpool (the sync route handlers run there).
 * Offline + reproducible: default config is in-memory store + stub providers, so
   there are no API keys, no DB, and the numbers are deterministic in shape.
 * The harness does not boot the server (server lifecycle differs a lot between a
   laptop and CI); point it at a URL you started with the env you want to measure.
+* This harness measures throughput/latency/error behavior under a load pattern.
+  It does not, on its own, isolate *why* throughput is flat (client overhead,
+  thread-pool limits, CPU/GIL work, or repository growth) — treat the numbers as
+  observations of the tested single-process configuration, not a root cause.
 
 Usage
 -----
     python benchmark/perf/run_perf.py \
         --base-url http://127.0.0.1:8099 \
         --requests 400 --concurrency 1,5,10,25,50 \
+        --repetitions 3 --seed-per-scenario 50 \
         --out results.json
 
 Exit code is 0 unless a scenario exceeds --max-error-rate (default 0.5),
@@ -41,6 +66,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import random
 import statistics
 import subprocess
 import sys
@@ -91,6 +117,7 @@ def _pct(sorted_vals: list[float], p: float) -> float:
 class ScenarioResult:
     operation: str
     concurrency: int
+    repetition: int
     n: int
     errors: int
     error_rate: float
@@ -102,23 +129,29 @@ class ScenarioResult:
     min_ms: float
     mean_ms: float
     max_ms: float
+    seed_count: int
+    memories_before: int | None
+    memories_after: int | None
     status_counts: dict = field(default_factory=dict)
 
 
 def _run_scenario(
-    client_factory,
+    client: httpx.Client,
     op: str,
     concurrency: int,
     n: int,
+    repetition: int,
     tenant: str,
     user: str,
+    seed_count: int,
+    memories_before: int | None,
 ) -> ScenarioResult:
+    """Fire `n` requests for `op` through `concurrency` workers on a shared client."""
     latencies: list[float] = []
     statuses: dict[str, int] = {}
     errors = 0
 
     def _one(i: int) -> tuple[float, int]:
-        client = client_factory()
         body = _op_body(op, tenant, user, i)
         t0 = time.perf_counter()
         try:
@@ -144,6 +177,7 @@ def _run_scenario(
     return ScenarioResult(
         operation=op,
         concurrency=concurrency,
+        repetition=repetition,
         n=n,
         errors=errors,
         error_rate=errors / n if n else 0.0,
@@ -155,23 +189,44 @@ def _run_scenario(
         min_ms=round(latencies[0], 3),
         mean_ms=round(statistics.fmean(latencies), 3),
         max_ms=round(latencies[-1], 3),
+        seed_count=seed_count,
+        memories_before=memories_before,
+        memories_after=None,  # filled in by the caller after the run
         status_counts=statuses,
     )
 
 
-# ── seeding ───────────────────────────────────────────────────────────────────
-def _seed(base_url: str, tenant: str, user: str, count: int) -> None:
-    """Populate the store with `count` memories via write-path chat messages."""
-    with httpx.Client(base_url=base_url, timeout=30.0) as c:
-        for i in range(count):
-            c.post(
-                "/api/chat",
-                json={
-                    "tenant_id": tenant,
-                    "user_id": user,
-                    "message": f"Remember fact number {i}: item_{i} has value {i * 7 % 97}.",
-                },
-            )
+# ── scope helpers ─────────────────────────────────────────────────────────────
+def _seed_scope(client: httpx.Client, tenant: str, user: str, count: int) -> None:
+    """Populate `tenant`/`user` with `count` memories via write-path chat messages."""
+    for i in range(count):
+        client.post(
+            "/api/chat",
+            json={
+                "tenant_id": tenant,
+                "user_id": user,
+                "message": f"Remember fact number {i}: item_{i} has value {i * 7 % 97}.",
+            },
+        )
+
+
+def _memory_count(client: httpx.Client, tenant: str, user: str) -> int | None:
+    """Actual active-memory count in a scope (best-effort; None on failure)."""
+    try:
+        r = client.get("/api/memories", params={"tenant_id": tenant, "user_id": user})
+        if r.status_code == 200:
+            data = r.json()
+            return len(data) if isinstance(data, list) else None
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _bounded_client(base_url: str, concurrency: int, timeout: float) -> httpx.Client:
+    """A reused client whose connection pool is bounded to the concurrency level."""
+    keep = max(concurrency, 1)
+    limits = httpx.Limits(max_connections=keep, max_keepalive_connections=keep)
+    return httpx.Client(base_url=base_url, timeout=timeout, limits=limits)
 
 
 def _server_rss_mb(pid: int | None) -> float | None:
@@ -186,6 +241,31 @@ def _server_rss_mb(pid: int | None) -> float | None:
         return None
 
 
+# ── aggregation ───────────────────────────────────────────────────────────────
+def _aggregate(results: list[ScenarioResult]) -> list[dict]:
+    """Median across repetitions for each (operation, concurrency)."""
+    groups: dict[tuple[str, int], list[ScenarioResult]] = {}
+    for r in results:
+        groups.setdefault((r.operation, r.concurrency), []).append(r)
+
+    agg: list[dict] = []
+    for (op, conc), rs in sorted(groups.items(), key=lambda kv: (kv[0][0], kv[0][1])):
+        med = lambda vals: round(statistics.median(vals), 3)  # noqa: E731
+        agg.append(
+            {
+                "operation": op,
+                "concurrency": conc,
+                "repetitions": len(rs),
+                "rps_median": med([r.rps for r in rs]),
+                "p50_ms_median": med([r.p50_ms for r in rs]),
+                "p95_ms_median": med([r.p95_ms for r in rs]),
+                "p99_ms_median": med([r.p99_ms for r in rs]),
+                "error_rate_max": round(max(r.error_rate for r in rs), 4),
+            }
+        )
+    return agg
+
+
 # ── main ──────────────────────────────────────────────────────────────────────
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
@@ -193,8 +273,22 @@ def main() -> int:
     ap.add_argument("--requests", type=int, default=400, help="requests per scenario")
     ap.add_argument("--concurrency", default="1,5,10,25,50")
     ap.add_argument("--operations", default="write,retrieval,chat")
-    ap.add_argument("--warmup", type=int, default=20)
-    ap.add_argument("--seed", type=int, default=0, help="pre-seed N memories before running")
+    ap.add_argument("--warmup", type=int, default=20, help="throwaway warmup requests")
+    ap.add_argument(
+        "--repetitions", type=int, default=3, help="times to repeat each (op × concurrency)"
+    )
+    ap.add_argument(
+        "--seed-per-scenario",
+        type=int,
+        default=50,
+        help="fixed memory count seeded into each scenario's fresh scope",
+    )
+    ap.add_argument(
+        "--no-randomize",
+        action="store_true",
+        help="run scenarios in fixed order (default: randomized)",
+    )
+    ap.add_argument("--rng-seed", type=int, default=1234, help="seed for scenario shuffling")
     ap.add_argument("--server-pid", type=int, default=None, help="sample this pid's RSS")
     ap.add_argument("--label", default="in-memory/stub", help="config label for the report")
     ap.add_argument("--max-error-rate", type=float, default=0.5)
@@ -203,12 +297,6 @@ def main() -> int:
 
     concurrencies = [int(x) for x in args.concurrency.split(",") if x]
     operations = [x.strip() for x in args.operations.split(",") if x.strip()]
-    tenant = "t_perf"
-    user = f"u_{uuid.uuid4().hex[:6]}"
-
-    def client_factory() -> httpx.Client:
-        # one client per thread-call; cheap for a localhost keep-alive pool
-        return httpx.Client(base_url=args.base_url, timeout=30.0)
 
     # health check
     with httpx.Client(base_url=args.base_url, timeout=10.0) as c:
@@ -216,37 +304,73 @@ def main() -> int:
         r.raise_for_status()
         print(f"server ok: {r.json()}")
 
-    if args.seed:
-        print(f"seeding {args.seed} memories…")
-        _seed(args.base_url, tenant, user, args.seed)
-
-    # warmup (not recorded)
+    # warmup (not recorded) against a throwaway scope, to warm the server + pool
     if args.warmup:
-        with httpx.Client(base_url=args.base_url, timeout=30.0) as c:
+        wu_tenant, wu_user = "t_warmup", f"u_{uuid.uuid4().hex[:6]}"
+        with _bounded_client(args.base_url, max(concurrencies), 30.0) as c:
             for i in range(args.warmup):
-                c.post("/api/chat", json=_op_body("chat", tenant, user, i))
+                c.post("/api/chat", json=_op_body("chat", wu_tenant, wu_user, i))
+
+    # Build the full scenario list (op × concurrency × repetition) and randomize.
+    scenarios = [
+        (op, conc, rep)
+        for op in operations
+        for conc in concurrencies
+        for rep in range(args.repetitions)
+    ]
+    if not args.no_randomize:
+        random.Random(args.rng_seed).shuffle(scenarios)
 
     rss_before = _server_rss_mb(args.server_pid)
     results: list[ScenarioResult] = []
-    for op in operations:
-        for conc in concurrencies:
-            res = _run_scenario(client_factory, op, conc, args.requests, tenant, user)
-            results.append(res)
-            print(
-                f"{op:10s} c={conc:<3d} rps={res.rps:<8.1f} "
-                f"p50={res.p50_ms:<8.3f} p95={res.p95_ms:<9.3f} p99={res.p99_ms:<9.3f} "
-                f"err={res.error_rate:.1%} {res.status_counts}"
+    for op, conc, rep in scenarios:
+        # Fresh scope per scenario so store size / dup state / retrieval set do not
+        # accumulate across the sweep.
+        tenant = f"t_perf_{uuid.uuid4().hex[:8]}"
+        user = f"u_{uuid.uuid4().hex[:8]}"
+        client = _bounded_client(args.base_url, conc, 30.0)
+        try:
+            if args.seed_per_scenario:
+                _seed_scope(client, tenant, user, args.seed_per_scenario)
+            mem_before = _memory_count(client, tenant, user)
+            res = _run_scenario(
+                client, op, conc, args.requests, rep, tenant, user,
+                args.seed_per_scenario, mem_before,
             )
+            res.memories_after = _memory_count(client, tenant, user)
+        finally:
+            client.close()
+        results.append(res)
+        print(
+            f"{op:10s} c={conc:<3d} rep={rep} rps={res.rps:<8.1f} "
+            f"p50={res.p50_ms:<8.3f} p95={res.p95_ms:<9.3f} p99={res.p99_ms:<9.3f} "
+            f"err={res.error_rate:.1%} mem={res.memories_before}->{res.memories_after} "
+            f"{res.status_counts}"
+        )
     rss_after = _server_rss_mb(args.server_pid)
+
+    aggregates = _aggregate(results)
+    print("\naggregates (median across repetitions):")
+    for a in aggregates:
+        print(
+            f"  {a['operation']:10s} c={a['concurrency']:<3d} "
+            f"rps={a['rps_median']:<8.1f} p50={a['p50_ms_median']:<8.3f} "
+            f"p95={a['p95_ms_median']:<9.3f} p99={a['p99_ms_median']:<9.3f} "
+            f"err_max={a['error_rate_max']:.1%}"
+        )
 
     report = {
         "label": args.label,
         "base_url": args.base_url,
         "requests_per_scenario": args.requests,
-        "seed": args.seed,
+        "repetitions": args.repetitions,
+        "seed_per_scenario": args.seed_per_scenario,
+        "randomized": not args.no_randomize,
+        "rng_seed": args.rng_seed,
         "server_rss_mb": {"before": rss_before, "after": rss_after},
         "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "scenarios": [asdict(r) for r in results],
+        "aggregates": aggregates,
     }
     if args.out:
         with open(args.out, "w") as fh:

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -39,9 +39,19 @@ re-deriving their own caveats.
   encryption** for high-sensitivity rows is not implemented.
 - Tenant isolation is enforced in code + tests on every scoped read; the
   in-memory backend mirrors the Postgres semantics but is for dev/demo only.
-- No built-in end-user **authentication/authorization** layer ships in v1.0 — the
-  API trusts the `tenant_id`/`user_id` scope the caller provides; deploy it behind
-  your own auth. See [security.md](security.md).
+- **Authentication/authorization adapters ship but are off by default.** With
+  `MEMORYOPS_AUTH_MODE=none` (the default) the API trusts the caller-supplied
+  `tenant_id`/`user_id` scope, so you must front it with your own auth. Set
+  `trusted_header` or `jwt` to have MemoryOps verify an externally-minted identity
+  (JWT/JWKS via PyJWT, or a trusted upstream header) and enforce tenant/user scope.
+  MemoryOps verifies identity and enforces scope; it does not *issue* identity — that
+  stays with your IdP. See [auth-adapters.md](auth-adapters.md), [security.md](security.md).
+- **Known dependency debt:** `pip-audit` (in `security-scan.yml`) flags advisories in
+  `starlette` (pulled in transitively by `fastapi==0.118.0`). The fixes require
+  `starlette >=0.49.1`/1.x, which `fastapi 0.118.0` does not permit, so clearing them
+  needs a validated FastAPI upgrade. Until then the specific advisory IDs are an
+  explicit, documented `--ignore-vuln` allowlist in the workflow (the audit still
+  blocks on any *new* advisory). Tracked as a near-term follow-up.
 
 ## Models & retrieval
 
@@ -55,9 +65,12 @@ re-deriving their own caveats.
 
 ## Observability & operations
 
-- Structured logs, audit events, worker run history, and `GET /healthz/workers`
-  ship; full **OpenTelemetry traces / Prometheus metrics / Langfuse** wiring is on
-  the production roadmap, not in the box.
+- Structured logs, audit events, worker run history, `GET /healthz/workers`,
+  **Prometheus metrics** (`GET /metrics`, content-free + low-cardinality — ADR-015),
+  and **distributed tracing** (span façade with an optional OpenTelemetry bridge,
+  spans at `GET /api/traces`; `MEMORYOPS_TRACING_ENABLED` / `MEMORYOPS_OTEL_ENABLED` —
+  ADR-022) all ship. Deeper wiring (an exporter/collector deployment, dashboards,
+  **Langfuse** LLM-trace integration) is left to the operator, not in the box.
 - Workers run on a thin lease/scheduler runtime, not Celery/Temporal; there is no
   external queue/broker.
 - **Write + audit are not yet a single transaction.** On the Postgres backend the

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,23 +1,39 @@
 # Performance (P4.3)
 
 > **Status: first pass — in-memory + stub providers, single process.**
-> This is the honest baseline the async decision (ADR / P2.1) should be made
-> *from*, not a claim that MemoryOps is tuned. Postgres, real providers, and
-> per-stage CPU/pool instrumentation are explicit follow-ups (see the end).
+> This is a starting observation, not a tuned result and not a root-cause analysis.
+> Postgres/pgvector, real providers, and per-stage CPU/pool instrumentation are the
+> follow-ups that would let us attribute *cause* (see the end).
+
+> **⚠️ Read the numbers below as observations, not proofs.** The tables in this
+> document were produced by an **earlier version of the harness** that created a
+> fresh, unclosed `httpx.Client` per request and reused a single tenant/user across
+> the whole sweep — so client/connection setup cost and a monotonically growing store
+> were confounded with concurrency. The harness has since been corrected (reused
+> bounded clients, a **fresh scope per scenario**, a **fixed identical seed count**,
+> **≥3 repetitions**, **randomized scenario order**, and **actual before/after memory
+> counts** — see [`run_perf.py`](../benchmark/perf/run_perf.py)). Re-running the sweep
+> with the corrected harness is a tracked follow-up; until then, treat the specific
+> figures here as indicative only.
 
 ## TL;DR
 
-- **The API does not scale with concurrency in a single process.** Throughput is
-  flat-to-declining from 1→50 concurrent clients while p50 latency grows roughly
-  linearly. That is the signature of **serialized request handling**.
-- Under the **stub provider + in-memory store**, that serialization is
-  **CPU/GIL-bound** (pure-Python embedding, cosine scan, ranking, policy) — work
-  that an async rewrite **would not** speed up.
-- Therefore **the current evidence does not justify the async rewrite (P2.1).**
-  The immediate scaling lever is **horizontal** (more uvicorn workers / replicas).
-  The I/O-bound case that async actually addresses (real LLM/embedding network
-  calls, Postgres round-trips) has **not been measured yet** and is the gate for
-  reopening that decision.
+- **In the tested single-process configuration, throughput is flat and latency grows
+  with concurrency** — added concurrent clients queue rather than run in parallel.
+  Error rate is 0% throughout; nothing falls over, it simply does not speed up.
+- **What this does *not* establish.** These runs do **not isolate** the cause. Flat
+  throughput here is consistent with several non-exclusive explanations —
+  per-request client/connection overhead (the old harness rebuilt a client every
+  call), Starlette thread-pool limits, CPU/GIL-bound Python work in the sync
+  handlers, and repository growth over the shared store — and this data cannot
+  separate them. Earlier drafts asserted the effect was **CPU/GIL-bound** and that
+  the fix was **horizontal scaling**; that was over-stated for what a stub +
+  in-memory + confounded-harness run can show, and has been removed.
+- **Implication for the async decision (P2.1): still undecided, not "rejected."**
+  The I/O-bound scenario that `asyncio` actually addresses (real LLM/embedding
+  network calls, Postgres round-trips) has not been measured, and the confounds
+  above have not been controlled. The decision stays open pending the corrected-
+  harness re-run and the Postgres/real-provider follow-ups.
 - The **per-process rate limiter** works exactly as specified (30/min chat →
   fail-fast 429) and is, as the review noted, **per-replica** — not a distributed
   limit.
@@ -39,10 +55,11 @@ MEMORYOPS_STORAGE=memory MEMORYOPS_EMBEDDING_PROVIDER=stub MEMORYOPS_LLM_PROVIDE
   MEMORYOPS_RATE_LIMIT_ENABLED=false \
   uvicorn app.main:app --host 127.0.0.1 --port 8099 --log-level warning
 
-# 2. drive load
+# 2. drive load (corrected harness: reused clients, fresh scope + fixed seed per
+#    scenario, repetitions, randomized order, real memory counts)
 python benchmark/perf/run_perf.py --base-url http://127.0.0.1:8099 \
   --requests 400 --concurrency 1,5,10,25,50 --operations write,retrieval,chat \
-  --out results.json
+  --repetitions 3 --seed-per-scenario 50 --out results.json
 ```
 
 Operations map to the three user-facing paths:
@@ -101,8 +118,12 @@ Raw JSON for every run below lives in
 - p50 latency rises **~linearly** with concurrency (chat 62 ms → 4175 ms ≈ 67× for
   50× the clients).
 
-That is a single serialized service: added concurrency just queues. Error rate is
-**0%** everywhere — nothing is falling over, it simply isn't parallel.
+Added concurrency queues rather than parallelizing, and error rate is **0%**
+everywhere — nothing falls over, it simply does not get faster. **Why** it queues is
+not settled by this run: the old harness rebuilt an HTTP client per request (setup
+cost charged to every latency sample) and let the store grow across the sweep, so
+client overhead, thread-pool limits, CPU work, and store growth are all still on the
+table. See the caveat at the top.
 
 ### 2. Latency vs store size — retrieval, in-memory (linear scan)
 
@@ -120,10 +141,14 @@ above already shows the shape. The in-memory repository scans **O(n)** candidate
 per query, so retrieval cost grows with the store. This is a property of the **dev/default** backend, not of
 MemoryOps as designed: on Postgres, retrieval goes through the **pgvector ANN
 index** (and the `VectorIndex` abstraction, ADR-021), which is sub-linear.
-Quantifying that is a follow-up (needs pgvector; see below). Store **memory** also
-grows with the row count — RSS rose from **37 MB → 234 MB** over the ~6 k writes in
-the concurrency sweep (~33 KB/memory incl. embedding), another reason the in-memory
-store is dev-only.
+Postgres + pgvector **is** available and is exercised locally and in CI (the
+`api-postgres` job); quantifying the ANN-vs-linear retrieval curve on it is the
+tracked follow-up below. Store **memory** also grows with row count — RSS rose from
+**37 MB → 234 MB** over the concurrency sweep — but the harness did not record the
+exact memory count for those runs, so **no reliable per-memory byte figure can be
+derived** from them. (An earlier draft's "~33 KB/memory" divided RSS by an *assumed*
+row count and has been removed.) The corrected harness now records actual before/
+after memory counts, so a defensible per-memory figure can be measured on the re-run.
 
 ### 3. Rate limiter — per-process, fail-fast
 
@@ -141,7 +166,7 @@ Each replica has its own 30/min budget, and a restart resets it. It is **local
 process protection, not distributed rate enforcement.** A Redis-backed limiter is
 the fix for a real multi-replica limit (follow-up).
 
-## The async decision (P2.1) — verdict: **not yet justified**
+## The async decision (P2.1) — verdict: **undecided (insufficient evidence)**
 
 The review's rule: proceed with the async rewrite only when measurements show
 thread-pool / connection-pool saturation, severe p95 degradation under moderate
@@ -150,34 +175,42 @@ realistic target.
 
 What the data actually shows:
 
-1. **Yes**, there is severe p95 degradation and flat throughput under concurrency.
-2. **But** the cause here is **CPU/GIL-bound** work (stub embeddings, in-memory
-   cosine scan, ranking, policy) — all synchronous Python compute. `asyncio`
-   parallelizes **I/O waits**, not CPU. Rewriting these sync routes as `async def`
-   would **not** raise throughput; it could lower it (event-loop overhead on
-   CPU-bound handlers).
-3. The place async *does* pay off — a route thread parked on a **network** LLM /
-   embedding call, or a **Postgres** round-trip, while other requests wait — is
-   **exactly what the stub + in-memory config removes from the measurement.** We
-   have not measured it.
+1. **Observed:** p95 degradation and flat throughput under concurrency, at 0% errors.
+2. **Not isolated:** this configuration cannot tell us *why*. A plausible contributor
+   is CPU/GIL-bound Python work in the sync handlers (stub embeddings, in-memory
+   cosine scan, ranking, policy) — which `asyncio` would **not** speed up — but
+   per-request client/connection overhead (old harness), the fixed Starlette
+   thread-pool, and store growth are equally unexcluded. The earlier version of this
+   doc named CPU/GIL as *the* cause; that conclusion is not supported and has been
+   withdrawn.
+3. The scenario async *does* address — a route thread parked on a **network** LLM /
+   embedding call or a **Postgres** round-trip while other requests wait — is
+   **exactly what the stub + in-memory config removes from the measurement.** It has
+   not been measured.
 
-**Conclusion.** On this evidence the correct next scaling step is **horizontal**:
-run multiple uvicorn workers / replicas (each a separate process, side-stepping the
-GIL) behind the load balancer we already deploy on Railway. The async rewrite
-should stay **deferred** until the I/O-bound numbers exist:
+**Conclusion.** The decision **stays open.** This run neither justifies the async
+rewrite nor rules it out; horizontal scaling (multiple uvicorn workers/replicas
+behind the Railway load balancer) is a reasonable operational lever regardless, but
+is **not** established here as *the* fix. Reopen P2.1 with evidence once the gating
+numbers exist:
 
+- the **corrected-harness** re-run (isolating client overhead and store growth),
 - retrieval / write / chat latency + throughput with a **real** embedding + LLM
   provider (network I/O in the hot path), and
 - the same against **Postgres** (connection-pool behaviour under concurrency).
 
-If *those* show threadpool or pool saturation, reopen P2.1 — and stage it as the
-review prescribed (async provider clients + gateway → async Postgres repo + pooling
-→ async routes/workers, each with before/after numbers).
+If *those* show threadpool or pool saturation, stage the rewrite as the review
+prescribed (async provider clients + gateway → async Postgres repo + pooling →
+async routes/workers, each with before/after numbers).
 
 ## Follow-ups (measured next, tracked separately)
 
-- [ ] **Postgres + pgvector** run of the same sweep (needs pgvector; not installable
-      in the authoring env). In-memory-vs-Postgres and ANN-vs-linear retrieval.
+- [ ] **Corrected-harness re-run** of the full sweep (reused clients, fresh scope +
+      fixed seed per scenario, repetitions, randomized order) to replace the
+      confounded tables above with numbers that isolate concurrency.
+- [ ] **Postgres + pgvector** run of the same sweep. pgvector is available and
+      CI-exercised (`api-postgres`); this run quantifies In-memory-vs-Postgres and
+      ANN-vs-linear retrieval.
 - [ ] **Real providers** (OpenAI / Anthropic) latency + fallback frequency in the
       hot path — the I/O-bound numbers that gate the async decision.
 - [ ] **Retrieval quality** comparison vector-only vs BM25-only vs hybrid

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -31,7 +31,9 @@ For the inverse (what is *not* claimed), see [limitations.md](limitations.md).
   dead-letter, persisted run history, `GET /healthz/workers`. See
   [worker-runtime.md](worker-runtime.md).
 - **Observability** — structured logs, audit events, worker run history, loop
-  timelines (`/api/loops`). Full OTel/Prometheus/Langfuse is roadmap.
+  timelines (`/api/loops`), Prometheus metrics (`GET /metrics`), and distributed
+  tracing with an optional OpenTelemetry bridge (`GET /api/traces`). Collector/
+  dashboard deployment and Langfuse LLM-trace wiring are left to the operator.
 - **Evaluation** — golden + adversarial eval suite (`evals/run_evals.py`) plus the
   invariant test suite and the deterministic PR Invariant Evidence Gate.
 
@@ -48,9 +50,13 @@ For the inverse (what is *not* claimed), see [limitations.md](limitations.md).
 ## Deploying
 
 Railway-only: one project, five core services (web/api/worker + Postgres + Redis).
-Run migrations from `infra/db/migrations`; set `MEMORYOPS_STORAGE=postgres`. Put
-the API behind your own authentication — v1.0 trusts the caller-supplied
-`tenant_id`/`user_id` scope. See [deployment/railway.md](deployment/railway.md).
+Run migrations from `infra/db/migrations`; set `MEMORYOPS_STORAGE=postgres`.
+Configure authentication: either enable a built-in auth adapter
+(`MEMORYOPS_AUTH_MODE=jwt` or `trusted_header`, which verify identity and enforce
+tenant/user scope — see [auth-adapters.md](auth-adapters.md)), or, with the default
+`MEMORYOPS_AUTH_MODE=none`, front the API with your own auth (it then trusts the
+caller-supplied `tenant_id`/`user_id` scope). Either way, identity issuance stays
+with your IdP. See [deployment/railway.md](deployment/railway.md).
 
 ## Release gate (must be green to ship)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -121,8 +121,13 @@ The most dangerous failures for an AI memory system are:
 - Detail may return a soft-deleted row for forensics, but it always carries
   `status=deleted`; it is never listed as active or rendered as active
   (`test_deletion.py`, `test_governance_api.py`).
-- Demo identity (`tenant_demo`/`user_demo`) still comes from `apps/web/lib/api.ts`;
-  real auth/session and RBAC remain on the hardening roadmap below.
+- Identity **verification** and scope enforcement ship as off-by-default auth
+  adapters (`MEMORYOPS_AUTH_MODE=none|trusted_header|jwt`): a JWT/JWKS or trusted-
+  header adapter verifies an externally-minted identity and enforces that every op is
+  scoped to the authenticated tenant/user (401/403, never 500). See
+  [auth-adapters.md](auth-adapters.md), ADR-020. The demo identity
+  (`tenant_demo`/`user_demo`) in `apps/web/lib/api.ts` is the `none`-mode default;
+  identity **issuance** (session/SSO) and **RBAC** remain on the hardening roadmap below.
 
 ### Background lifecycle workers (v0.6)
 - Workers (`services/api/app/workers/`) run **off the chat path** and are tenant +

--- a/packages/memoryops-sdk/README.md
+++ b/packages/memoryops-sdk/README.md
@@ -1,36 +1,32 @@
 # MemoryOps AI — Python SDK (1.0.0)
 
-A small, typed Python client for the [MemoryOps AI](../../README.md) API. It makes
-the governed memory lifecycle — capture, retrieve, govern, forget, audit — a few
-method calls, while the **server stays the source of truth** for tenant isolation,
-policy-before-storage, the deletion guarantee, legal hold, consent, and audit.
+A small, typed Python client for the [MemoryOps AI](https://github.com/patibandlavenkatamanideep/memoryops-ai)
+API. It makes the governed memory lifecycle — capture, retrieve, govern, forget,
+audit — a few method calls, while the **server stays the source of truth** for
+tenant isolation, policy-before-storage, the deletion guarantee, legal hold,
+consent, and audit.
 
 > The SDK is a thin, faithful client over the HTTP API. It adds no governance of
 > its own — it just makes the governed API easy to call from assistants, agents,
 > and RAG apps.
 
-## Install
+## 1. Install the SDK
 
 ```bash
 pip install memoryops-sdk
-# or, from this repo:
-pip install -e packages/memoryops-sdk
 ```
 
-Only dependency: `httpx`.
+Only dependency: `httpx`. That's all you need to *call* a MemoryOps API — you do
+not need to clone the repo.
 
-## Quickstart
+## 2. Connect to a MemoryOps API
 
-Run a MemoryOps API (no infra needed):
-
-```bash
-cd services/api && MEMORYOPS_STORAGE=memory uvicorn app.main:app --reload
-```
+Point the client at any running MemoryOps API and scope it to a tenant/user:
 
 ```python
 from memoryops import MemoryOpsClient
 
-with MemoryOpsClient("http://localhost:8000", "tenant_demo", "user_demo") as mo:
+with MemoryOpsClient("https://your-memoryops-host", "tenant_demo", "user_demo") as mo:
     # Capture (governed write)
     mo.chat("Remember I prefer metric units and dark mode.")
 
@@ -44,8 +40,32 @@ with MemoryOpsClient("http://localhost:8000", "tenant_demo", "user_demo") as mo:
         print(m.memory_type, m.content, m.status)
 ```
 
-The `tenant_id` and `user_id` you pass to the constructor are injected on **every**
-call — your code never hand-builds request bodies or leaks another user's scope.
+The `tenant_id` and `user_id` you pass to the constructor are injected on **every
+scope-bearing** call — your code never hand-builds request bodies or leaks another
+user's scope. (Global endpoints — `loops`, `loop_trace`, `health`, `workers_health`
+— carry no per-tenant scope by design.)
+
+### Authentication
+
+With the default `MEMORYOPS_AUTH_MODE=none`, the API trusts the caller-supplied
+scope and no credentials are needed. When it runs with an auth adapter
+([auth-adapters.md](https://github.com/patibandlavenkatamanideep/memoryops-ai/blob/main/docs/auth-adapters.md)),
+attach credentials on construction — they are sent on every request:
+
+```python
+# Bearer JWT (MEMORYOPS_AUTH_MODE=jwt)
+MemoryOpsClient(base_url, tenant_id, user_id, token=my_jwt)
+
+# Trusted upstream header, an API key, or any custom default headers
+MemoryOpsClient(base_url, tenant_id, user_id,
+                headers={"X-MemoryOps-User": "user_demo"})
+
+# Dynamic / refreshing credentials
+MemoryOpsClient(base_url, tenant_id, user_id, auth=my_httpx_auth)
+```
+
+The server authorizes independently: credentials must resolve to the same
+`tenant_id`/`user_id` scope, or the API returns 401/403.
 
 ## Copy-paste snippets
 
@@ -93,7 +113,8 @@ for e in mo.audit(limit=20):
 
 | Area | Methods |
 |---|---|
-| Chat | `chat(message, temporary_chat=, conversation_id=)` |
+| Construct | `MemoryOpsClient(base_url, tenant_id, user_id, *, token=, headers=, auth=, timeout=, http_client=)` |
+| Chat | `chat(message, temporary_chat=, conversation_id=, audience=)` |
 | Memories | `list_memories`, `get_memory`, `update_memory`, `delete_memory`, `memory_audit`, `memory_provenance` |
 | Retention / hold / consent | `set_legal_hold`, `pin`, `protect`, `set_consent`, `retention_policies`, `retention_decisions`, `memory_governance` |
 | Governance / ops | `audit`, `metrics`, `loops`, `loop_trace`, `health`, `workers_health` |
@@ -103,17 +124,34 @@ delete), and `APIError` (other non-2xx) — all subclasses of `MemoryOpsError`.
 
 ## Examples
 
-Runnable scripts in [`examples/`](examples):
+Runnable scripts in the repo under
+[`packages/memoryops-sdk/examples/`](https://github.com/patibandlavenkatamanideep/memoryops-ai/tree/main/packages/memoryops-sdk/examples):
 
-- [`quickstart.py`](examples/quickstart.py) — capture → retrieve → govern → forget.
-- [`fastapi_integration.py`](examples/fastapi_integration.py) — put governed memory behind your own assistant endpoint.
-- [`rag_assistant.py`](examples/rag_assistant.py) — blend governed user memory with your own RAG context.
-- [`agent_memory.py`](examples/agent_memory.py) — give a tool-using agent governed, inspectable long-term memory.
+- [`quickstart.py`](https://github.com/patibandlavenkatamanideep/memoryops-ai/blob/main/packages/memoryops-sdk/examples/quickstart.py) — capture → retrieve → govern → forget.
+- [`fastapi_integration.py`](https://github.com/patibandlavenkatamanideep/memoryops-ai/blob/main/packages/memoryops-sdk/examples/fastapi_integration.py) — put governed memory behind your own assistant endpoint.
+- [`rag_assistant.py`](https://github.com/patibandlavenkatamanideep/memoryops-ai/blob/main/packages/memoryops-sdk/examples/rag_assistant.py) — blend governed user memory with your own RAG context.
+- [`agent_memory.py`](https://github.com/patibandlavenkatamanideep/memoryops-ai/blob/main/packages/memoryops-sdk/examples/agent_memory.py) — give a tool-using agent governed, inspectable long-term memory.
+
+## 3. Run the server locally (optional)
+
+You only need this to run your *own* MemoryOps API — SDK users pointing at a hosted
+API can skip it. Clone the repo, then start the API with the in-memory backend (no
+infrastructure required):
+
+```bash
+git clone https://github.com/patibandlavenkatamanideep/memoryops-ai
+cd memoryops-ai/services/api
+pip install -r requirements.txt
+MEMORYOPS_STORAGE=memory uvicorn app.main:app --reload   # serves http://localhost:8000
+```
+
+Then point the client at `http://localhost:8000` as in step 2.
 
 ## Testing / in-process use
 
 Pass any `httpx.Client` (including FastAPI's `TestClient`) via `http_client=` to
-drive the SDK in-process without a network:
+drive the SDK in-process without a network. This requires a repo checkout so the
+`app` package is importable (see step 3):
 
 ```python
 from fastapi.testclient import TestClient
@@ -123,11 +161,11 @@ from memoryops import MemoryOpsClient
 mo = MemoryOpsClient("http://testserver", "t", "u", http_client=TestClient(app))
 ```
 
-Run the SDK test suite:
+Run the SDK test suite (from a repo checkout):
 
 ```bash
-cd packages/memoryops-sdk && pytest -q
+cd memoryops-ai/packages/memoryops-sdk && pytest -q
 ```
 
-See [docs/assistant-sdk.md](../../docs/assistant-sdk.md) for the project-level
-overview.
+See [docs/assistant-sdk.md](https://github.com/patibandlavenkatamanideep/memoryops-ai/blob/main/docs/assistant-sdk.md)
+for the project-level overview.

--- a/packages/memoryops-sdk/memoryops/client.py
+++ b/packages/memoryops-sdk/memoryops/client.py
@@ -2,9 +2,11 @@
 
 It wraps the HTTP surface (chat, memories, retention/legal-hold/consent, audit,
 metrics, loops, health) and injects the ``tenant_id`` / ``user_id`` scope on every
-call so application code never hand-builds request bodies. Tenant isolation,
-the deletion guarantee, policy-before-storage, and auditability are enforced by
-the server — the SDK is a thin, faithful client over that governed API.
+**scope-bearing** call so application code never hand-builds request bodies. (Global
+endpoints — :meth:`loops`, :meth:`loop_trace`, :meth:`health`, :meth:`workers_health`
+— carry no per-tenant scope by design.) Tenant isolation, the deletion guarantee,
+policy-before-storage, and auditability are enforced by the server — the SDK is a
+thin, faithful client over that governed API.
 
 Example::
 
@@ -16,9 +18,26 @@ Example::
         for m in mo.list_memories():
             print(m.memory_type, m.content)
 
+When the API runs with an auth adapter (``MEMORYOPS_AUTH_MODE=jwt`` or
+``trusted_header``), attach credentials on construction — they are sent on every
+request::
+
+    # Bearer JWT (MEMORYOPS_AUTH_MODE=jwt):
+    MemoryOpsClient(base_url, tenant_id, user_id, token=my_jwt)
+
+    # Trusted upstream header, an API key, or any custom default headers:
+    MemoryOpsClient(base_url, tenant_id, user_id,
+                    headers={"X-MemoryOps-User": "user_demo"})
+
+    # Anything more dynamic (refreshing tokens, signing): pass an httpx.Auth:
+    MemoryOpsClient(base_url, tenant_id, user_id, auth=my_httpx_auth)
+
+The server still authorizes independently: credentials must resolve to the same
+``tenant_id``/``user_id`` scope, or the API returns 401/403.
+
 The client is synchronous and built on ``httpx``. For tests or in-process use you
 can pass a pre-built ``httpx.Client`` (e.g. one bound to an ASGI app) via
-``http_client``.
+``http_client``; ``token``/``headers``/``auth`` are still applied to it.
 """
 
 from __future__ import annotations
@@ -40,13 +59,50 @@ class MemoryOpsClient:
         tenant_id: str,
         user_id: str,
         *,
+        token: str | None = None,
+        headers: dict[str, str] | None = None,
+        auth: httpx.Auth | None = None,
         timeout: float = 30.0,
         http_client: httpx.Client | None = None,
     ) -> None:
+        """Construct a client scoped to ``tenant_id`` / ``user_id``.
+
+        Auth (all optional; needed only when the API enforces an auth adapter):
+
+        * ``token`` — convenience for a bearer JWT; sends ``Authorization: Bearer <token>``.
+        * ``headers`` — default headers applied to every request (trusted-header auth,
+          an API key, etc.). Passing both ``token`` and an ``Authorization`` header is
+          an error.
+        * ``auth`` — an :class:`httpx.Auth` for dynamic/refreshing credentials.
+
+        These are applied whether the client is created here or supplied via
+        ``http_client``.
+        """
         self.tenant_id = tenant_id
         self.user_id = user_id
+
+        default_headers = {str(k): str(v) for k, v in (headers or {}).items()}
+        if token is not None:
+            if any(k.lower() == "authorization" for k in default_headers):
+                raise ValueError(
+                    "pass either token= or an Authorization header, not both"
+                )
+            default_headers["Authorization"] = f"Bearer {token}"
+
         self._owns_client = http_client is None
-        self._http = http_client or httpx.Client(base_url=base_url.rstrip("/"), timeout=timeout)
+        if http_client is None:
+            self._http = httpx.Client(
+                base_url=base_url.rstrip("/"),
+                timeout=timeout,
+                headers=default_headers or None,
+                auth=auth,
+            )
+        else:
+            self._http = http_client
+            if default_headers:
+                self._http.headers.update(default_headers)
+            if auth is not None:
+                self._http.auth = auth
 
     # ── lifecycle ──────────────────────────────────────────────────────────────
     def close(self) -> None:

--- a/packages/memoryops-sdk/pyproject.toml
+++ b/packages/memoryops-sdk/pyproject.toml
@@ -12,7 +12,14 @@ license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "MemoryOps AI" }]
 keywords = ["memoryops", "ai", "memory", "governance", "llm", "agents", "rag"]
-classifiers = ["Development Status :: 5 - Production/Stable"]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Typing :: Typed",
+]
 dependencies = ["httpx>=0.24,<1"]
 
 [project.urls]
@@ -24,6 +31,10 @@ dev = ["pytest>=7", "ruff>=0.4"]
 
 [tool.setuptools]
 packages = ["memoryops"]
+
+# Ship the PEP 561 marker so downstream type checkers trust the package's annotations.
+[tool.setuptools.package-data]
+memoryops = ["py.typed"]
 
 [tool.ruff]
 line-length = 100

--- a/packages/memoryops-sdk/tests/test_client_unit.py
+++ b/packages/memoryops-sdk/tests/test_client_unit.py
@@ -128,3 +128,71 @@ def test_generic_api_error_surfaces_status() -> None:
         with pytest.raises(APIError) as exc:
             mo.metrics()
     assert exc.value.status_code == 500
+
+
+# ── authentication ─────────────────────────────────────────────────────────────
+def _auth_client(handler, **auth_kwargs) -> MemoryOpsClient:
+    transport = httpx.MockTransport(handler)
+    http = httpx.Client(transport=transport, base_url="http://test")
+    return MemoryOpsClient("http://test", "t1", "u1", http_client=http, **auth_kwargs)
+
+
+def test_token_sets_bearer_authorization_on_every_request() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json=[])
+
+    with _auth_client(handler, token="jwt-abc") as mo:
+        mo.list_memories()
+    assert seen["auth"] == "Bearer jwt-abc"
+
+
+def test_custom_headers_are_sent() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["hdr"] = request.headers.get("x-memoryops-user")
+        return httpx.Response(200, json=[])
+
+    with _auth_client(handler, headers={"X-MemoryOps-User": "user_demo"}) as mo:
+        mo.list_memories()
+    assert seen["hdr"] == "user_demo"
+
+
+def test_token_and_authorization_header_conflict_raises() -> None:
+    with pytest.raises(ValueError):
+        MemoryOpsClient(
+            "http://test", "t1", "u1",
+            token="x", headers={"Authorization": "Bearer y"},
+        )
+
+
+def test_httpx_auth_is_applied() -> None:
+    seen = {}
+
+    class _StaticAuth(httpx.Auth):
+        def auth_flow(self, request):
+            request.headers["Authorization"] = "Custom sig"
+            yield request
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json=[])
+
+    with _auth_client(handler, auth=_StaticAuth()) as mo:
+        mo.list_memories()
+    assert seen["auth"] == "Custom sig"
+
+
+def test_no_auth_sends_no_authorization_header() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json=[])
+
+    with _client(handler) as mo:
+        mo.list_memories()
+    assert seen["auth"] is None

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "pydantic-settings==2.6.1",
   "tenacity==9.1.4",
   "python-dotenv==1.2.2",
-  "PyJWT==2.10.1",
+  "PyJWT[crypto]==2.13.0",
 ]
 
 [project.optional-dependencies]

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -6,6 +6,8 @@ pydantic==2.13.4
 pydantic-settings==2.6.1
 tenacity==9.1.4
 python-dotenv==1.2.2
-# JWT verification (auth adapters, off by default). HS* works with this alone;
-# RS*/ES*/JWKS additionally need the 'cryptography' extra: pip install "PyJWT[crypto]".
-PyJWT==2.10.1
+# JWT verification (auth adapters, off by default). The [crypto] extra ships the
+# 'cryptography' backend so RS*/ES*/JWKS (advertised in docs/auth-adapters.md) work
+# out of the box, not just HS*. Pinned >=2.13.0: releases before 2.12.0 are affected
+# by a high-severity JWT critical-header validation vulnerability.
+PyJWT[crypto]==2.13.0


### PR DESCRIPTION
Pre-launch remediation addressing the P0/P1/P2 review items. **No `services/api` app-code changes** beyond dependency pins; all changes are dependency/SDK/CI/docs.

## P0 — pre-publish blockers
- **PyJWT** `2.10.1` → `PyJWT[crypto]==2.13.0` (fixes the pre-2.12 critical-header advisory; `[crypto]` extra ships the RS*/ES*/JWKS support the docs advertise). Both `requirements.txt` and `pyproject.toml`. Verified: PyJWT 2.13.0 + cryptography 49.0.0, **all 16 auth tests pass**.
- **`publish-sdk.yml`**: expected version derived from the SDK `pyproject.toml` and checked against the tag, `memoryops.__version__`, **and** `app.__version__`; clean-install test no longer hardcodes `1.0.0`; **publication is tag-only** (`workflow_dispatch` builds+verifies, never uploads).
- **Docs corrected** to reflect shipped reality: `SECURITY.md`, `docs/limitations.md`, `docs/production-readiness.md`, `docs/security.md` — auth adapters (JWT/JWKS + trusted-header), forced Postgres RLS, Prometheus metrics + distributed tracing.

## P1
- **`MemoryOpsClient`** gains first-class auth: `token=` (bearer), `headers=`, and `httpx.Auth` — applied even to a caller-supplied client. Scope-injection docs clarified ("every scope-bearing call"). +5 auth unit tests; **all 23 SDK tests pass**.
- **SDK README**: absolute GitHub links (was `../../…`); separate *Install SDK* / *Connect to an API* / *Run the server locally* sections; auth section.
- **Python matrix 3.10–3.13** for the SDK CI job; `py.typed` marker (confirmed shipped in the built wheel) + typing classifiers.
- **`run_perf.py`** reworked: reused bounded clients, fresh scope + fixed seed per scenario, ≥3 repetitions, randomized order, real before/after memory counts. Smoke-tested against a live server.
- **`performance.md`**: withdrew the unproven "CPU/GIL-bound → scale horizontally" conclusion, removed the unsupported ~33 KB/memory figure, corrected the stale "pgvector unavailable" claim.
- **CI perf-smoke gate** → `--max-error-rate 0`.

## P2
- **`RELEASING.md`**: obsolete v0.1–v0.4 milestones replaced with the real remaining roadmap; fixed the now-removed `publish` input and `v0.1` examples.
- **CI security**: new `.github/dependabot.yml` (pip/npm/actions) and `security-scan.yml` (pip-audit + gitleaks + trivy); `npm ci || npm install` → `npm ci` (lockfile verified in sync).

## ⚠️ New finding surfaced by pip-audit
`fastapi==0.118.0` pulls in **starlette 0.48.0 with 8 advisories** (PYSEC-2026-161/248/249/1942/2280/2281). Fixes require starlette ≥0.49.1/1.x → a validated **FastAPI upgrade** (its own task). The gate is **blocking with a documented `--ignore-vuln` allowlist** for exactly those IDs (any *new* advisory still fails CI); debt recorded in `docs/limitations.md`.

## Not in this PR (need credentials/decisions)
PyPI Trusted Publisher config + `sdk-v1.0.0` tag push + `pip install` verification; the launch thread; and the post-launch write/audit atomicity fix.