### PR TITLE
Upgrade FastAPI 0.139.2 + Starlette 1.3.1; remove pip-audit allowlist

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -41,26 +41,15 @@ jobs:
           python-version: "3.12"
       - run: python -m pip install --upgrade pip pip-audit
       - name: Audit ${{ matrix.label }}
-        # Blocking gate: any *new* advisory fails CI. The --ignore-vuln entries below
-        # are a documented, temporary allowlist for advisories in `starlette` (pulled
-        # in transitively by fastapi==0.118.0). Their fixes live in starlette >=0.49.1
-        # / 1.x, which fastapi 0.118.0 does not allow — clearing them requires a
-        # validated FastAPI upgrade, tracked separately (see docs/limitations.md).
-        # Remove each ID here as that upgrade lands. Do NOT add ignores casually.
-        env:
-          # starlette (via fastapi 0.118.0) — remove when fastapi/starlette is bumped:
-          IGNORES: >-
-            --ignore-vuln PYSEC-2026-161
-            --ignore-vuln PYSEC-2026-248
-            --ignore-vuln PYSEC-2026-249
-            --ignore-vuln PYSEC-2026-1942
-            --ignore-vuln PYSEC-2026-2280
-            --ignore-vuln PYSEC-2026-2281
+        # Blocking gate with NO allowlist: any advisory fails CI. (The temporary
+        # --ignore-vuln entries for the fastapi==0.118.0 → starlette 0.48.0 advisories
+        # were removed once the FastAPI 0.139.2 / Starlette 1.3.1 upgrade landed.) Do
+        # NOT reintroduce ignores casually — fix or upgrade the dependency instead.
         run: |
           if [ -n "${{ matrix.req }}" ]; then
-            pip-audit --strict --progress-spinner off $IGNORES -r "${{ matrix.req }}"
+            pip-audit --strict --progress-spinner off -r "${{ matrix.req }}"
           else
-            pip-audit --strict --progress-spinner off $IGNORES ./packages/memoryops-sdk
+            pip-audit --strict --progress-spinner off ./packages/memoryops-sdk
           fi
 
   # ── Secret scanning (committed credentials) ───────────────────────────────────

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -46,12 +46,10 @@ re-deriving their own caveats.
   (JWT/JWKS via PyJWT, or a trusted upstream header) and enforce tenant/user scope.
   MemoryOps verifies identity and enforces scope; it does not *issue* identity — that
   stays with your IdP. See [auth-adapters.md](auth-adapters.md), [security.md](security.md).
-- **Known dependency debt:** `pip-audit` (in `security-scan.yml`) flags advisories in
-  `starlette` (pulled in transitively by `fastapi==0.118.0`). The fixes require
-  `starlette >=0.49.1`/1.x, which `fastapi 0.118.0` does not permit, so clearing them
-  needs a validated FastAPI upgrade. Until then the specific advisory IDs are an
-  explicit, documented `--ignore-vuln` allowlist in the workflow (the audit still
-  blocks on any *new* advisory). Tracked as a near-term follow-up.
+- **Dependency scanning is clean and unignored.** `pip-audit` (in `security-scan.yml`)
+  runs as a blocking gate with **no `--ignore-vuln` allowlist**. The earlier
+  `starlette` advisories (transitive via `fastapi==0.118.0`) were resolved by upgrading
+  to `fastapi==0.139.2` + a pinned `starlette==1.3.1`, not accepted as debt.
 
 ## Models & retrieval
 

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -14,7 +14,9 @@ license = "MIT"
 # pins mean a new version only reaches us via an intentional bump here. Smaller
 # dependency set = smaller blast radius for the next supply-chain attack.
 dependencies = [
-  "fastapi==0.118.0",
+  "fastapi==0.139.2",
+  # Explicit patched pin — <1.0.1 carries the PYSEC-2026 Starlette advisories.
+  "starlette==1.3.1",
   "uvicorn[standard]==0.37.0",
   "pydantic==2.13.4",
   "pydantic-settings==2.6.1",

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -1,6 +1,9 @@
 # Runtime deps — exact pins, mirror of pyproject [project].dependencies.
 # Postgres extras are optional; install with: pip install -r requirements.txt -r requirements-postgres.txt
-fastapi==0.118.0
+fastapi==0.139.2
+# Pinned explicitly (not just transitively via fastapi) so a patched Starlette can't
+# silently regress: <1.0.1 carries the PYSEC-2026-161/248/249/1942/2280/2281 advisories.
+starlette==1.3.1
 uvicorn[standard]==0.37.0
 pydantic==2.13.4
 pydantic-settings==2.6.1


### PR DESCRIPTION
Follow-up to #45. Turns the temporary starlette advisory allowlist into a real fix.

## Why
`fastapi==0.118.0` pinned **starlette 0.48.0**, which carries 8 advisories (PYSEC-2026-161/248/249/1942/2280/2281). #45 shipped a documented `--ignore-vuln` allowlist as accepted debt. FastAPI 0.139.2 (2026-07-16) supports `starlette>=0.46.0` and Starlette 1.3.1 is patched, so there's a current upgrade path — taken here instead of carrying the debt.

## Changes
- `requirements.txt` / `pyproject.toml`: `fastapi==0.118.0` → `**0.139.2**`, plus an **explicit `starlette==1.3.1` pin** so a future FastAPI bump can't silently regress to a vulnerable Starlette.
- `security-scan.yml`: **removed all 6 `--ignore-vuln` entries** — `pip-audit` is now a blocking gate with **no allowlist**.
- `docs/limitations.md`: updated to note scanning is clean and unignored.

## Validation (upgraded stack)
- `pip-audit -r requirements.txt` with **no ignores** → **No known vulnerabilities found**.
- Full API test suite: **pass** (0 failures, 2 skipped); `ruff check app` clean.
- SDK suite: **23 passed**. Evals: **PASS**. Benchmark: **50/50**.
- Postgres + enforced-RLS suite runs in CI (`api-postgres`).

Recommend merging before the PyPI publish + launch.