### PR TITLE
fix: reject empty tenant_id/user_id at schema boundary (fixes iso-probe-tenant-empty)

### DIFF
--- a/services/api/app/schemas/memory.py
+++ b/services/api/app/schemas/memory.py
@@ -141,10 +141,16 @@ class MemoryUsageTrace(BaseModel):
 
 # ── API contracts ────────────────────────────────────────────────────────────
 class ChatRequest(BaseModel):
-    # max_length caps bound abuse / oversized payloads (P2.4). No min_length so odd
-    # ids (empty, wildcard) are handled by scoping, not rejected with 422.
-    tenant_id: str = Field(max_length=200)
-    user_id: str = Field(max_length=200)
+    # max_length caps bound abuse / oversized payloads (P2.4). tenant_id/user_id
+    # require min_length=1: an empty scope is invalid input, so it is rejected at the
+    # boundary (422) instead of flowing through the pipeline with no owner. Odd-but-
+    # non-empty ids (wildcards, injection-looking strings, whitespace) are still
+    # allowed and defused by parameterized scoping — that is what the isolation evals
+    # probe. (Empty scope was previously allowed on purpose; that let an empty-tenant
+    # probe crash the Postgres loop-evidence path — invariant #4 — so it is now
+    # rejected up front, which is also stronger isolation.)
+    tenant_id: str = Field(min_length=1, max_length=200)
+    user_id: str = Field(min_length=1, max_length=200)
     message: str = Field(max_length=8000)
     temporary_chat: bool = False
     conversation_id: str | None = None

--- a/services/api/app/services/eval_harness.py
+++ b/services/api/app/services/eval_harness.py
@@ -34,6 +34,8 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pydantic import ValidationError
+
 from ..db.memory_repo import InMemoryRepository
 from ..loops.types import LoopId
 from ..schemas.memory import ChatRequest, Decision, Status
@@ -339,11 +341,17 @@ def _run_case(gw: Gateway, repo: InMemoryRepository, case: dict) -> CaseResult:
         repo_leak = [m for m in repo.retrieve_active(probe_tenant, probe_user)
                      if m.id in foreign_ids]
         # 2. Full gateway read path (if a probe query is given) must not surface
-        #    any foreign memory into the composed context.
+        #    any foreign memory into the composed context. A probe whose scope is
+        #    *rejected at the boundary* (e.g. an empty tenant/user, now a 422 via the
+        #    ChatRequest schema) leaks nothing — that is the strongest isolation, so
+        #    it counts as no-leak rather than an error.
         gw_leak = []
         if case.get("probe_query"):
-            resp = _decisions_for(gw, probe_tenant, probe_user, case["probe_query"])
-            gw_leak = [u for u in resp.used_memories if u.memory_id in foreign_ids]
+            try:
+                resp = _decisions_for(gw, probe_tenant, probe_user, case["probe_query"])
+                gw_leak = [u for u in resp.used_memories if u.memory_id in foreign_ids]
+            except ValidationError:
+                gw_leak = []
 
         ok = not repo_leak and not gw_leak
         return CaseResult(

--- a/services/api/tests/test_chat_request_scope.py
+++ b/services/api/tests/test_chat_request_scope.py
@@ -1,0 +1,47 @@
+"""ChatRequest scope validation (schema boundary).
+
+An empty tenant_id / user_id is invalid input and must be rejected at the schema
+boundary (422) rather than flowed through the pipeline with no owner — otherwise an
+empty-scope request reaches backend-specific paths (e.g. Postgres loop-evidence
+recording, which requires a tenant) and can crash instead of degrading (invariant #4).
+Odd-but-*non-empty* ids (wildcards, injection-looking strings, whitespace) are still
+accepted and defused by parameterized scoping — that is what the isolation evals probe.
+
+These are pure schema tests: no app, no DB.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.memory import ChatRequest
+
+
+@pytest.mark.parametrize("tenant_id,user_id", [("", "u"), ("t", ""), ("", "")])
+def test_empty_scope_is_rejected(tenant_id: str, user_id: str) -> None:
+    with pytest.raises(ValidationError):
+        ChatRequest(tenant_id=tenant_id, user_id=user_id, message="hi")
+
+
+@pytest.mark.parametrize(
+    "tenant_id,user_id",
+    [
+        ("acme", "alice"),          # ordinary
+        ("%", "%"),                 # wildcard-looking
+        ("   ", "user_eval"),       # whitespace (non-empty)
+        ("' OR '1'='1", "user"),    # injection-looking
+        ("victim_tenant\n", "u"),   # trailing newline
+    ],
+)
+def test_odd_but_nonempty_scope_is_accepted(tenant_id: str, user_id: str) -> None:
+    # Non-empty but adversarial ids are allowed through — scoping (not the schema)
+    # is what prevents cross-tenant leakage, and the isolation evals prove it.
+    req = ChatRequest(tenant_id=tenant_id, user_id=user_id, message="hi")
+    assert req.tenant_id == tenant_id
+    assert req.user_id == user_id
+
+
+def test_max_length_still_bounds_scope() -> None:
+    with pytest.raises(ValidationError):
+        ChatRequest(tenant_id="t" * 201, user_id="u", message="hi")


### PR DESCRIPTION
The last CI-red item. The isolation eval `iso-probe-tenant-empty` probes with an empty tenant/user; the schema deliberately allowed empty scope, so it flowed into the pipeline — harmless in-memory but crashing the Postgres loop-evidence guard (which is why it passed in-memory, failed on Postgres).

Per your guidance (reject invalid scope at the boundary; question the eval's implicit 200-empty expectation rather than special-casing deeper):
- `ChatRequest.tenant_id/user_id` → `min_length=1` (empty scope = 422 before any pipeline work). Odd-but-non-empty ids (wildcards, whitespace, injection strings) still accepted and defused by scoping.
- isolation harness: a probe **rejected at the boundary** leaks nothing → counts as no-leak (strongest isolation), not an error.
- + schema-only unit tests (no DB).

**Verified in-memory: full eval 50/50, `iso-probe-tenant-empty` PASS.** Backend-agnostic, so it fixes the Postgres eval step that was the one remaining red after #69.

Note: I intentionally overrode the schema's old `# No min_length ...` comment — the old design let an empty probe crash Postgres (invariant #4). Query-param GET routes (enforce_scope) still accept empty scope; tightening those is a small follow-up.