### PR TITLE
feat: real-model extraction-quality evidence (gemini-2.5-flash) + fix retired model default

### DIFF
--- a/benchmark/EXTRACTION_QUALITY.md
+++ b/benchmark/EXTRACTION_QUALITY.md
@@ -3,9 +3,24 @@
 | Provider | Precision | Recall | F1 | No-op handled | Multi-memory turns |
 | --- | --- | --- | --- | --- | --- |
 | stub | 1.00 | 0.53 | 0.69 | 3/3 | 4/9 |
+| gemini-2.5-flash | 0.94 | 0.94 | 0.94 | 3/3 | 7/9 |
 
-> Regenerate: `python evals/run_extraction_quality.py --md benchmark/EXTRACTION_QUALITY.md`.
-> The stub is the offline heuristic fixture; run `--provider openai anthropic`
-> with keys to fill in real-model rows (the stub is expected to trail on recall
-> and multi-memory turns — that gap is the honest signal).
-
+> **The gap is the point.** The offline **stub** is high-precision (1.00) but
+> low-recall (0.53) and can only split **4 of 9** compound "multi-memory" turns — it
+> misses roughly half the facts a real model captures. A real model (**gemini-2.5-flash**)
+> nearly doubles recall to **0.94** and handles **7 of 9** multi-memory turns, at a
+> small, honest precision cost (0.94 — it occasionally over-extracts). This is why the
+> stub is a *reproducible test fixture, not the product*: it keeps CI offline and
+> deterministic, but the flagship capability (governed extraction quality) requires a
+> real model, and now that is measured rather than asserted.
+>
+> **Reproduce** (the gemini row was produced from a live run, 0 fallbacks):
+> ```bash
+> set -a; source .env; set +a           # GEMINI_API_KEY=...
+> MEMORYOPS_LLM_PROVIDER=gemini GEMINI_MODEL=gemini-2.5-flash \
+>   PYTHONPATH=services/api python evals/run_extraction_quality.py \
+>   --provider stub gemini --md benchmark/EXTRACTION_QUALITY.md
+> ```
+> Runs offline for `stub`; `--provider openai anthropic gemini` fills in more rows
+> when their keys are set. Note `gemini-1.5-flash` has been retired — use a current
+> model (`gemini-2.5-flash`, `gemini-2.0-flash`, or `gemini-flash-latest`).

--- a/docs/provider-llm-adapters.md
+++ b/docs/provider-llm-adapters.md
@@ -45,7 +45,7 @@ MEMORYOPS_LLM_TIMEOUT_SECONDS=20
 
 OPENAI_API_KEY=        OPENAI_MODEL=gpt-4o-mini
 ANTHROPIC_API_KEY=     ANTHROPIC_MODEL=claude-haiku-4-5-20251001
-GEMINI_API_KEY=        GEMINI_MODEL=gemini-1.5-flash
+GEMINI_API_KEY=        GEMINI_MODEL=gemini-2.5-flash   # 1.5-flash retired
 ```
 
 ## Reliability & safety contract

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -107,7 +107,7 @@ class Settings(BaseSettings):
     llm_provider: Literal["stub", "heuristic", "openai", "anthropic", "gemini"] = "stub"
     openai_model: str = "gpt-4o-mini"
     anthropic_model: str = "claude-haiku-4-5-20251001"
-    gemini_model: str = "gemini-1.5-flash"
+    gemini_model: str = "gemini-2.5-flash"  # 1.5-flash was retired; flash-latest also valid
 
     # Structured memory intelligence knobs (v0.4). Defaults keep LLM output
     # advisory and always recoverable: validate structured output, and fall back


### PR DESCRIPTION
Turns the flagship "governed extraction quality" claim from scaffolding into a **measured result** — and fixes the bug that hid it.

## The bug that faked the evidence
`benchmark/EXTRACTION_QUALITY.md` only ever had the offline stub row because the default Gemini model, **`gemini-1.5-flash`, has been retired**. Every real call errored and *silently fell back to the heuristic*, producing a "gemini" row identical to the stub. (The live model list now offers only `gemini-2.5-flash` / `gemini-2.0-flash` / `gemini-flash-latest`.)

- `config.py`: `gemini_model` default `gemini-1.5-flash` → **`gemini-2.5-flash`**; `docs/provider-llm-adapters.md` updated so users don't copy a dead model.

## The real evidence (live run, 25 labeled turns, 0 fallbacks)
| Provider | Precision | Recall | F1 | No-op | Multi-memory |
|---|---|---|---|---|---|
| stub | 1.00 | 0.53 | 0.69 | 3/3 | 4/9 |
| **gemini-2.5-flash** | 0.94 | **0.94** | **0.94** | 3/3 | **7/9** |

The offline stub is high-precision but **misses ~half the facts** and splits only 4/9 compound turns; a real model nearly doubles recall and handles 7/9 multi-memory, at a small honest precision cost (0.94 — it occasionally over-extracts). The gap between "reproducible test fixture" and "the product" is now **measured, not asserted**.

Reproduce: `MEMORYOPS_LLM_PROVIDER=gemini GEMINI_MODEL=gemini-2.5-flash PYTHONPATH=services/api python evals/run_extraction_quality.py --provider stub gemini --md benchmark/EXTRACTION_QUALITY.md` (with `GEMINI_API_KEY` set).