### PR TITLE
v2.3: Transactional Evidence — atomic mutation+audit, fork-proof chain, operational worker health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable releases. Git tags + GitHub Releases are the source of truth; this
 file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
 
+## Unreleased — post-v2.2 hardening
+Additive under the `1.x` compatibility promise. Consolidates the operational and
+evidence hardening that landed after the v2.2 tag but has not yet been cut as a release:
+
+- **SDK published** to PyPI (`memoryops-sdk`) with a tag-only, version-locked
+  publish workflow (`.github/workflows/publish-sdk.yml`).
+- **Dependency security fixes**, including the PyJWT/`pyjwt[crypto]` path for the
+  auth adapters and the Dependabot major bumps (web / RLS / perf) CI repairs.
+- **Complete operational-evidence RLS** (migration 009): loop runs/events and worker
+  runs now enforce the same `FORCE` tenant boundary as memory + audit rows.
+- **Migration enforcement** at startup: the Postgres backend refuses to start unless
+  the current schema migration is applied.
+- **Real-model extraction evidence**: a live gemini-2.5-flash run
+  (0.94 / 0.94 / 0.94, 0 fallbacks) recorded in `benchmark/EXTRACTION_QUALITY.md`,
+  and the retired-model default fixed.
+- **README consolidation** (550 → ~158 lines) and the empty-scope rejection fix.
+- **Async decision recorded**: defer a blanket async conversion; tune and measure the
+  synchronous path against real Postgres/provider workloads first
+  (`docs/performance.md`, ADR).
+
+### In progress — v2.3 Transactional Evidence (this branch, not yet tagged)
+Closes the gap between the auditability *claim* and the transaction *boundary*:
+
+- **Atomic mutation + audit**: every mutation-plus-evidence path (save/update/merge,
+  approve/reject/archive, manual edit, soft-delete + tombstone, legal-hold, pin,
+  protect, consent) now runs inside a single `repo.transaction(...)` — a crash between
+  the memory write and its audit event can no longer persist one without the other.
+- **Fork-proof audit chain**: a tenant-locked `audit_chain_heads` table (migration 011)
+  with `SELECT ... FOR UPDATE` serializes concurrent audited mutations onto one
+  continuous hash chain (the in-memory backend uses an equivalent per-repo lock).
+- **Worker-health regression fixed**: global worker health reads via an explicit
+  cross-tenant *operational* connection (`OPERATIONAL_DATABASE_URL`, a monitoring role),
+  fail-closed and clearly reported when unconfigured — never weakening tenant RLS.
+- **Teeth**: `tests/test_transactional_evidence.py` proves rollback (neither side
+  survives a partial failure) and chain continuity under 40 concurrent appends.
+
 ## v2.2 — Public Benchmark + Examples
 Additive under the `1.x` compatibility promise. Turns MemoryOps' *measured* governance
 into a public, reproducible artifact. A new **benchmark** (`benchmark/run_benchmark.py`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
 4. Graceful degradation — retrieval failures never block responses.
 5. Policy-before-storage — the policy broker runs before any write.
 6. Temporary chat — `temporary_chat=true` writes/reads nothing.
-7. Auditability — every lifecycle action appends an audit event.
+7. Auditability — every lifecycle mutation and its audit event commit atomically in one
+   `repo.transaction()` (append-only, tamper-evident, fork-proof under concurrency; ADR-027).
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Full design, diagrams, and where each invariant is enforced:
 4. **Graceful degradation** — retrieval failure never blocks a response.
 5. **Policy-before-storage** — unsafe/secret-like content is filtered before storage.
 6. **Temporary chat** — temporary sessions never read or write memory.
-7. **Auditability** — every lifecycle event appends an audit event.
+7. **Auditability** — every lifecycle mutation and its audit event commit together in
+   one transaction (atomic under partial failure), as an append-only, tamper-evident chain.
 8. **Explainability** — the system can show which memories affected a response.
 9. **Typed memory** — episodic/semantic/procedural/project/knowledge/system differ.
 10. **Evaluation** — memory quality is testable via a golden set, not manual inspection.
@@ -124,11 +125,12 @@ OpenAI Agents SDK) are *import-guarded examples*, not live-service tested. See
 Kept explicit on purpose — see **[docs/limitations.md](docs/limitations.md)** for the
 authoritative list. The material ones:
 
-- **Real-model extraction quality is not yet measured.** The extraction harness and
-  recorded-provider tests exist, but no run against a real provider has been recorded;
-  [EXTRACTION_QUALITY.md](benchmark/EXTRACTION_QUALITY.md) currently has only the
-  offline-stub row. Add a key and it fills in: `python evals/run_extraction_quality.py
-  --provider openai` (needs `OPENAI_API_KEY`).
+- **Real-model extraction quality is measured, but on a small set.** A live run on a
+  25-turn labeled set with **gemini-2.5-flash** scores **0.94 precision / 0.94 recall /
+  0.94 F1 with zero fallbacks** (vs. the offline stub's 1.00 / 0.53 / 0.69), recorded in
+  [EXTRACTION_QUALITY.md](benchmark/EXTRACTION_QUALITY.md). Broader provider/model
+  coverage and larger datasets remain future work — add a key and more rows fill in:
+  `python evals/run_extraction_quality.py --provider openai` (needs `OPENAI_API_KEY`).
 - **The request path is synchronous.** Under load, throughput is flat and latency grows
   with concurrency in a single process ([docs/performance.md](docs/performance.md)); the
   cause is not yet isolated, and the async decision is deferred until the I/O-bound

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,8 +37,16 @@ There are **two independent tracks** (see
 
 ## SDK release checklist
 
-The Python SDK publishes through PyPI Trusted Publishing, not a long-lived API
-token. Configure PyPI once with:
+The Python SDK publishes to PyPI from `.github/workflows/publish-sdk.yml`. The
+`publish` job selects its auth at run time: it **prefers the `PYPI_API_TOKEN`
+secret when configured, and otherwise falls back to PyPI Trusted Publishing
+(OIDC, no long-lived secret)**. Both paths use `pypa/gh-action-pypi-publish`.
+
+> **Hardening intent:** a project-scoped token or working OIDC is preferable to a
+> broad long-lived token. Once Trusted Publishing is verified end-to-end, retire
+> `PYPI_API_TOKEN` so the workflow always takes the OIDC path.
+
+Configure PyPI once (Trusted Publishing path) with:
 
 - project: `memoryops-sdk`
 - owner/repository: `patibandlavenkatamanideep/memoryops-ai`

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -196,7 +196,12 @@ See [docs/enterprise-evidence.md](enterprise-evidence.md), ADR-024.
 
 ## Ops
 - `GET /healthz` → `{ status, version, uptime_seconds, metrics_enabled }`
-- `GET /healthz/workers` → content-free worker run history (dead-letter / failure counts)
+- `GET /healthz/workers` → content-free, **cross-tenant** worker run history (dead-letter /
+  failure counts). This is a global operator view served from a separately authorized
+  operational connection (`OPERATIONAL_DATABASE_URL`), never the request-scoped RLS engine
+  (v2.3, ADR-027). When that connection is unconfigured it returns
+  `{ healthy: null, detail: "operational access not configured", hint: … }` — an
+  actionable, non-fatal state, not a `500`.
 - `GET /readyz` → `{ ready, storage, llm_provider, embeddings_provider, embedding_dim, detail }`
 - `GET /metrics` → **Prometheus text exposition** (v1.1; format `0.0.4`). Process-wide,
   content-free, low-cardinality (no `tenant_id`/`user_id` labels): HTTP traffic,

--- a/docs/memory-control-plane.md
+++ b/docs/memory-control-plane.md
@@ -82,7 +82,11 @@ is intentionally **out of scope** for v0.5 and is future lifecycle work.
 3. Provenance — `source` is always present and surfaced.
 5. Policy-before-storage — unchanged; the control plane never writes around it.
 6. Temporary chat — never persisted, so never visible here.
-7. Auditability — every action (and detail view) appends an audit event.
+7. Auditability — every action (and detail view) appends an audit event. Since v2.3
+   (ADR-027) each control-plane **mutation and its audit event commit in one
+   `repo.transaction()`**: approve/reject/archive/edit and delete/tombstone are atomic,
+   so a partial failure can never approve, edit, or delete a memory without its evidence
+   (or vice versa). The audit chain is fork-proof under concurrency.
 
 ## Legal hold on delete (v0.10)
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -29,11 +29,13 @@
   separate them. Earlier drafts asserted the effect was **CPU/GIL-bound** and that
   the fix was **horizontal scaling**; that was over-stated for what a stub +
   in-memory + confounded-harness run can show, and has been removed.
-- **Implication for the async decision (P2.1): still undecided, not "rejected."**
-  The I/O-bound scenario that `asyncio` actually addresses (real LLM/embedding
-  network calls, Postgres round-trips) has not been measured, and the confounds
-  above have not been controlled. The decision stays open pending the corrected-
-  harness re-run and the Postgres/real-provider follow-ups.
+- **Implication for the async decision (P2.1): defer the blanket migration; tune and
+  measure the sync path first.** Sync routes already overlap I/O via Starlette's
+  threadpool; the stub + in-memory sweep removes the network/DB waiting async targets,
+  so it can't settle the question. Keep the sync API + stable 1.x contract, instrument
+  and tune the AnyIO thread tokens + SQLAlchemy pool together, and reconsider async only
+  when a real-provider + Postgres run shows sustained I/O-bound demand exceeding the
+  tuned synchronous architecture. Full verdict + trigger conditions below.
 - The **per-process rate limiter** works exactly as specified (30/min chat →
   fail-fast 429) and is, as the review noted, **per-replica** — not a distributed
   limit.
@@ -166,42 +168,52 @@ Each replica has its own 30/min budget, and a restart resets it. It is **local
 process protection, not distributed rate enforcement.** A Redis-backed limiter is
 the fix for a real multi-replica limit (follow-up).
 
-## The async decision (P2.1) — verdict: **undecided (insufficient evidence)**
+## The async decision (P2.1) — verdict: **defer the blanket migration; tune and measure the synchronous path first**
 
-The review's rule: proceed with the async rewrite only when measurements show
-thread-pool / connection-pool saturation, severe p95 degradation under moderate
-concurrency, provider calls serializing requests, or throughput materially below a
-realistic target.
+`POST /api/chat` is a **synchronous** FastAPI route. Starlette executes sync routes
+through AnyIO's threadpool, so requests **already overlap** their network and database
+waiting time across multiple worker threads — sync is *not* serial.
 
-What the data actually shows:
+**Why the current benchmark doesn't settle it.** The default AnyIO limiter provides
+**40 shared thread tokens per process** — which is *not* a guaranteed capacity of 40
+chat requests: sync dependencies, file operations, background tasks, DB-pool limits,
+provider connection limits, CPU work, and other endpoints all draw from the same pool
+and can exhaust it sooner. And the in-memory / stub-provider sweep in this doc
+**removes the very workload async is designed to improve** — it strips the real network
+and DB waiting and emphasizes Python execution, in-memory scans, ranking, and policy
+(CPU-bound work async would *not* accelerate, and could slow with added complexity).
 
-1. **Observed:** p95 degradation and flat throughput under concurrency, at 0% errors.
-2. **Not isolated:** this configuration cannot tell us *why*. A plausible contributor
-   is CPU/GIL-bound Python work in the sync handlers (stub embeddings, in-memory
-   cosine scan, ranking, policy) — which `asyncio` would **not** speed up — but
-   per-request client/connection overhead (old harness), the fixed Starlette
-   thread-pool, and store growth are equally unexcluded. The earlier version of this
-   doc named CPU/GIL as *the* cause; that conclusion is not supported and has been
-   withdrawn.
-3. The scenario async *does* address — a route thread parked on a **network** LLM /
-   embedding call or a **Postgres** round-trip while other requests wait — is
-   **exactly what the stub + in-memory config removes from the measurement.** It has
-   not been measured.
+**Recommendation (keep the sync API and the stable 1.x contract):**
 
-**Conclusion.** The decision **stays open.** This run neither justifies the async
-rewrite nor rules it out; horizontal scaling (multiple uvicorn workers/replicas
-behind the Railway load balancer) is a reasonable operational lever regardless, but
-is **not** established here as *the* fix. Reopen P2.1 with evidence once the gating
-numbers exist:
+1. **Instrument** thread-token utilization, request queueing, DB-pool checkout time,
+   provider latency, and stage-level CPU time.
+2. **Tune AnyIO thread tokens and the SQLAlchemy connection pool together** (raising
+   threads without pool headroom just moves the bottleneck).
+3. Use **Uvicorn concurrency limits as overload protection**, not as a way to increase
+   threadpool capacity.
+4. **Move nonessential provider calls off the response-critical path** — particularly
+   advisory conflict detection — where possible.
+5. **Run the corrected benchmark against Postgres + pgvector and a real LLM + embedding
+   provider** (the I/O-bound workload that actually exercises the question).
+6. **Reconsider async only** when measurements show sustained I/O-bound demand
+   exceeding the tuned synchronous architecture.
 
-- the **corrected-harness** re-run (isolating client overhead and store growth),
-- retrieval / write / chat latency + throughput with a **real** embedding + LLM
-  provider (network I/O in the hot path), and
-- the same against **Postgres** (connection-pool behaviour under concurrency).
+**A full async migration becomes justified when:**
 
-If *those* show threadpool or pool saturation, stage the rewrite as the review
-prescribed (async provider clients + gateway → async Postgres repo + pooling →
-async routes/workers, each with before/after numbers).
+- requests spend meaningful time **waiting for available thread tokens**;
+- the DB and provider pools have been tuned and are **not** the actual bottleneck;
+- sustained target concurrency **exceeds** the safe thread-based capacity;
+- increasing threads **materially harms** memory use / context-switching;
+- multiple Uvicorn workers or Railway replicas **do not** provide sufficient headroom;
+- before/after measurements show async improves throughput or tail latency **enough to
+  justify the added complexity**.
+
+**If those conditions are met, migrate incrementally** (each step with before/after
+numbers): async provider + embedding clients → async gateway + extraction path →
+SQLAlchemy async engine + repository → async routes → explicit offloading for the
+CPU-bound ranking / policy / compression / evaluation stages.
+
+Until that evidence exists, a blanket async rewrite is **not** justified.
 
 ## Follow-ups (measured next, tracked separately)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -100,6 +100,19 @@ The most dangerous failures for an AI memory system are:
   covers deletion/compaction audit events too, so a deletion proof is verifiable. This is
   tamper-*evidence*, not tamper-*proofing* — pin the head hash to a WORM store/notary for
   a stronger guarantee. See [enterprise-evidence.md](enterprise-evidence.md).
+- **Atomic mutation + audit (v2.3, ADR-027).** Every mutation-plus-evidence path
+  (save/update/merge, approve/reject/archive, manual edit, soft-delete + tombstone,
+  legal-hold/pin/protect/consent) runs inside one `repo.transaction()`, so a crash
+  between the memory write and its audit event can no longer persist one without the
+  other — the auditability guarantee holds under partial failure, not just the happy path.
+- **Fork-proof chain under concurrency (v2.3, ADR-027).** A per-tenant `audit_chain_heads`
+  row (migration 011) is locked with `SELECT ... FOR UPDATE` while a new event links and
+  advances the head, so concurrent audited mutations serialize onto one continuous chain
+  instead of forking it. The in-memory backend uses an equivalent per-repo lock.
+- **Operational health never weakens RLS (v2.3, ADR-027).** Global (cross-tenant) worker
+  health reads through a *separately authorized* operational connection
+  (`OPERATIONAL_DATABASE_URL`), never the request-scoped RLS engine; unconfigured, it
+  fails closed to a documented "not configured" state rather than leaking or crashing.
 
 ### Loop engineering traces (v0.3.1)
 - `loop_runs` / `loop_events` (migration `005_loop_engineering.sql`) store operational lifecycle

--- a/docs/worker-runtime.md
+++ b/docs/worker-runtime.md
@@ -59,6 +59,16 @@ Stored via `worker_runs` (migration `006_worker_runtime.sql`); query with
 | `worker_backoff_factor` | 2.0 | backoff multiplier |
 | `worker_backoff_max_seconds` | 30.0 | backoff ceiling |
 | `worker_run_history_limit` | 500 | rows scanned for the health view |
+| `operational_database_url` (`OPERATIONAL_DATABASE_URL`) | *(unset)* | separately authorized cross-tenant connection for global worker health |
+
+> **Global worker health & tenant isolation (v2.3, ADR-027).** `GET /healthz/workers`
+> aggregates runs across *all* tenants, so it must not use the request-scoped,
+> RLS-enforced connection (that one is — correctly — tenant-scoped and rejects an
+> unscoped query). It reads instead through an explicit operational path
+> (`list_worker_runs_operational`) backed by `OPERATIONAL_DATABASE_URL`, a
+> monitoring/BYPASSRLS role. Leave it unset and worker health fails **closed**:
+> `{ healthy: null, detail: "operational access not configured", … }` — never a crash,
+> never a tenant-boundary relaxation.
 
 ## Running
 

--- a/infra/adr/ADR-012-worker-runtime-orchestration.md
+++ b/infra/adr/ADR-012-worker-runtime-orchestration.md
@@ -82,3 +82,15 @@ counts, and the last run per scope.
 - Future work (v0.9+): governed retention/legal-hold inputs to the workers;
   optional queue/cron backend behind the same orchestrator interface; per-scope
   scheduling cadence.
+
+## Amendment (v2.3, ADR-027): global worker health respects tenant isolation
+
+`summarize_runtime_health` (the data behind `/healthz/workers`) is a *global* operator
+view that aggregates runs across every tenant. It therefore must **not** use the
+request-scoped, RLS-enforced connection — that one is correctly tenant-scoped and rejects
+an unscoped `list_worker_runs()` query (which is why worker health had regressed to
+"unavailable"). Health now reads through an explicit
+`Repository.list_worker_runs_operational()` backed by a separately authorized
+`OPERATIONAL_DATABASE_URL` (a monitoring/BYPASSRLS role); unconfigured, it fails **closed**
+to a documented "operational access not configured" state. Orchestration, leasing, retry,
+and scheduling semantics are unchanged. See ADR-027 and `docs/worker-runtime.md`.

--- a/infra/adr/ADR-027-transactional-evidence.md
+++ b/infra/adr/ADR-027-transactional-evidence.md
@@ -1,0 +1,75 @@
+# ADR-027 — Transactional Evidence (atomic mutation + audit, fork-proof chain)
+
+- Status: Accepted (v2.3)
+- Date: 2026-07-22
+- Supersedes: none
+- Related: ADR-004 (audit), ADR-006 (RLS), ADR-012 (worker runtime),
+  ADR-024 (enterprise evidence layer)
+
+## Context
+
+The auditability invariant (#7) promised that "every lifecycle action appends an audit
+event," and the Enterprise Evidence Layer (ADR-024) made that trail tamper-evident. But
+two gaps sat *below* those guarantees — the evidence was stronger than the transaction
+boundary underneath it:
+
+1. **Non-atomic mutation + audit.** Each mutation path wrote the memory row and then, as
+   a separate operation, recorded the audit event. A process crash between the two could
+   persist a memory without its audit event (or an audit event without its mutation),
+   leaving the store in a state the evidence layer claims is impossible. A `repo.transaction()`
+   primitive existed but was wired into nothing.
+
+2. **Race-prone chain head.** `add_audit` derived the current chain head with `ORDER BY
+   created_at DESC LIMIT 1`. Two concurrent audited mutations for the same tenant could
+   read the same head and each compute a successor — a **forked** chain, which
+   `verify_chain` correctly reports as broken.
+
+A third, adjacent defect: `summarize_runtime_health` called `list_worker_runs()` with no
+tenant, which the (correctly) tenant-scoped Postgres method now rejects, so global worker
+health always read as "unavailable."
+
+## Decision
+
+Ship **Transactional Evidence**: make the mutation and its evidence a single unit of work,
+and make the chain head safe under concurrency — without weakening tenant isolation.
+
+- **Atomic mutation + audit.** Every mutation-plus-evidence path runs inside one
+  `repo.transaction(tenant_id, user_id)`: save/update/merge (`write_service.py`),
+  approve/reject/archive + manual edit + soft-delete/tombstone (`routes/memories.py`), and
+  legal-hold/pin/protect/consent (`routes/retention.py`). The transaction is re-entrant
+  (nested repository calls join the active unit of work) and commits once at the end,
+  rolling back both sides on any exception. Best-effort network work (embeddings) is
+  computed *before* the transaction opens, so a DB unit of work is never held across it.
+
+- **Fork-proof chain head.** A per-tenant `audit_chain_heads` table (migration 011) holds
+  exactly one head row per tenant. `add_audit` ensures the row exists (`INSERT ... ON
+  CONFLICT DO NOTHING`), locks it with `SELECT ... FOR UPDATE`, links the new event, and
+  advances the head — all inside the surrounding transaction. Concurrent audited mutations
+  for a tenant now serialize onto one continuous chain. The in-memory backend uses an
+  equivalent per-repo lock around the head read-modify-write. The table is RLS-protected
+  like every other tenant-scoped table.
+
+- **Operational worker health, fail-closed.** Global worker health is a genuinely
+  cross-tenant operator concern, so it reads through an explicit
+  `list_worker_runs_operational()` on a **separately authorized** connection
+  (`OPERATIONAL_DATABASE_URL`, a monitoring/BYPASSRLS role) — never the request-scoped,
+  RLS-enforced engine. When that connection is not configured, the read raises
+  `OperationalAccessUnavailable` and the health surface degrades to an actionable
+  "operational access not configured" state rather than crashing or silently returning an
+  empty (misleadingly healthy) view. Tenant RLS is never relaxed to serve a global view.
+
+## Consequences
+
+- The auditability invariant now holds under partial failure, not just on the happy path.
+  Invariant #7 wording is updated accordingly (README, CLAUDE.md).
+- Schema moves to `011_audit_chain_heads`; `PostgresRepository` refuses to start until it
+  is applied (existing migration-enforcement behavior).
+- Proven by `tests/test_transactional_evidence.py` (rollback: neither side survives a
+  partial failure; concurrency: 40 parallel appends form one continuous, verifiable
+  chain), a delete-route atomicity test in `tests/test_deletion.py`, and an operational
+  vs. tenant-scoped isolation test in `tests/test_tenant_isolation.py`.
+- Global worker health requires an operational role to be configured; without it the
+  surface is explicitly "not configured" (documented in `docs/worker-runtime.md` and
+  `docs/api-contracts.md`) rather than falsely healthy.
+- This is transaction-boundary correctness, not new cryptography: the chain remains
+  *tamper-evident* (ADR-024), and deletion remains soft/tombstoned (ADR-011/018).

--- a/infra/db/migrations/011_audit_chain_heads.sql
+++ b/infra/db/migrations/011_audit_chain_heads.sql
@@ -1,0 +1,39 @@
+-- 011_audit_chain_heads.sql — tenant-locked audit hash-chain head (P0)
+--
+-- Migration 010 persists prev_hash/entry_hash on every audit event, but the
+-- "what is the current head?" read was derived from `order by created_at desc`.
+-- Two concurrent audited mutations could read the same head and each compute a
+-- successor, forking the chain. This table gives every tenant exactly one head
+-- row that the append path locks with SELECT ... FOR UPDATE, so concurrent
+-- appends serialize onto a single continuous chain.
+--
+-- The row is content-free (a hash + timestamp) and tenant-scoped under the same
+-- RLS boundary as the audit log itself.
+
+begin;
+
+create table if not exists audit_chain_heads (
+  tenant_id  text primary key,
+  head_hash  text not null default '',
+  updated_at timestamptz not null default now()
+);
+
+alter table audit_chain_heads enable row level security;
+alter table audit_chain_heads force row level security;
+
+drop policy if exists audit_chain_heads_tenant_isolation on audit_chain_heads;
+create policy audit_chain_heads_tenant_isolation on audit_chain_heads
+  using (tenant_id = current_setting('app.tenant_id', true))
+  with check (tenant_id = current_setting('app.tenant_id', true));
+
+-- ── schema version marker ───────────────────────────────────────────────────
+create table if not exists memoryops_schema_migrations (
+  version text primary key,
+  applied_at timestamptz not null default now()
+);
+
+insert into memoryops_schema_migrations (version)
+values ('011_audit_chain_heads')
+on conflict (version) do nothing;
+
+commit;

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -97,6 +97,11 @@ class Settings(BaseSettings):
     vector_index_api_key: str = ""
     vector_index_collection: str = "memoryops"
     database_url: str = "postgresql+psycopg://memoryops:memoryops@localhost:5432/memoryops"
+    # Optional cross-tenant *operational* connection (a monitoring/BYPASSRLS
+    # role) used only for global operator views like worker health. Unset by
+    # default: operational aggregation is fail-closed and never reuses the
+    # request-scoped, RLS-enforced connection. See docs/worker-runtime.md.
+    operational_database_url: str = ""
 
     redis_url: str = "redis://localhost:6379/0"
 

--- a/services/api/app/db/entities.py
+++ b/services/api/app/db/entities.py
@@ -21,6 +21,12 @@ def new_id() -> str:
     return str(uuid.uuid4())
 
 
+class OperationalAccessUnavailable(RuntimeError):
+    """Raised when a cross-tenant operational read is requested but no separately
+    authorized operational connection is configured. Fail-closed: the caller must
+    degrade gracefully rather than fall back to a tenant-scoped connection."""
+
+
 @dataclass
 class StoredMemory:
     tenant_id: str

--- a/services/api/app/db/memory_repo.py
+++ b/services/api/app/db/memory_repo.py
@@ -6,6 +6,7 @@ scoping on every read, deleted rows excluded from retrieval, append-only audit.
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from copy import deepcopy
@@ -38,6 +39,10 @@ class InMemoryRepository(Repository):
         self._memories: dict[str, StoredMemory] = {}
         self._audit: list[StoredAudit] = []
         self._audit_head: dict[str, str] = {}  # tenant → last entry_hash (v2.0 chain)
+        # Serializes the chain head read-modify-write so concurrent audited
+        # mutations cannot fork the chain — the in-memory analogue of the
+        # Postgres SELECT ... FOR UPDATE on audit_chain_heads (migration 011).
+        self._audit_head_lock = threading.Lock()
         self._settings: dict[tuple[str, str], StoredSettings] = {}
         self._loop_runs: dict[str, LoopRun] = {}
         self._loop_events: list[LoopEvent] = []
@@ -225,10 +230,11 @@ class InMemoryRepository(Repository):
         # previous one in its tenant's chain so any later edit/reorder is detectable.
         from ..evidence.hashchain import GENESIS, compute_entry_hash
 
-        event.prev_hash = self._audit_head.get(event.tenant_id, GENESIS)
-        event.entry_hash = compute_entry_hash(event, event.prev_hash)
-        self._audit_head[event.tenant_id] = event.entry_hash
-        self._audit.append(event)  # append-only (invariant #7)
+        with self._audit_head_lock:
+            event.prev_hash = self._audit_head.get(event.tenant_id, GENESIS)
+            event.entry_hash = compute_entry_hash(event, event.prev_hash)
+            self._audit_head[event.tenant_id] = event.entry_hash
+            self._audit.append(event)  # append-only (invariant #7)
         return event
 
     def list_audit(
@@ -290,6 +296,16 @@ class InMemoryRepository(Repository):
             rows = [r for r in rows if r.tenant_id == tenant_id]
         if user_id:
             rows = [r for r in rows if r.user_id == user_id]
+        if status:
+            rows = [r for r in rows if r.status == status]
+        return sorted(rows, key=lambda r: r.started_at, reverse=True)[:limit]
+
+    def list_worker_runs_operational(
+        self, *, status: str | None = None, limit: int = 200
+    ) -> list[WorkerRunRecord]:
+        # The single-process in-memory store has no separate RLS boundary to
+        # cross, so the whole run history is the operational view.
+        rows = list(self._worker_runs)
         if status:
             rows = [r for r in rows if r.status == status]
         return sorted(rows, key=lambda r: r.started_at, reverse=True)[:limit]

--- a/services/api/app/db/memory_repo.py
+++ b/services/api/app/db/memory_repo.py
@@ -6,6 +6,7 @@ scoping on every read, deleted rows excluded from retrieval, append-only audit.
 
 from __future__ import annotations
 
+import functools
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -34,15 +35,35 @@ def _norm(text: str) -> str:
     return " ".join(text.lower().split())
 
 
+def _locked(method):
+    """Serialize a state-mutating method under the repository's re-entrant lock.
+
+    The in-memory backend is driven concurrently (uvicorn's threadpool). Its unit
+    of work (``transaction``) snapshots the whole store with ``deepcopy``; a write
+    mutating a dict/list while another thread deep-copies it raises "dictionary
+    changed size during iteration". A single re-entrant lock, held by both the
+    transaction and every mutation, makes writes serialize safely. The lock is
+    re-entrant so mutations invoked *inside* a transaction (which already holds it)
+    do not deadlock. Postgres does not need this — it uses real DB transactions."""
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        with self._lock:
+            return method(self, *args, **kwargs)
+
+    return wrapper
+
+
 class InMemoryRepository(Repository):
     def __init__(self, vector_index: VectorIndex | None = None) -> None:
         self._memories: dict[str, StoredMemory] = {}
         self._audit: list[StoredAudit] = []
         self._audit_head: dict[str, str] = {}  # tenant → last entry_hash (v2.0 chain)
-        # Serializes the chain head read-modify-write so concurrent audited
-        # mutations cannot fork the chain — the in-memory analogue of the
-        # Postgres SELECT ... FOR UPDATE on audit_chain_heads (migration 011).
-        self._audit_head_lock = threading.Lock()
+        # One re-entrant lock guards the transaction snapshot/restore and every
+        # state mutation, so concurrent requests can't corrupt the store or fork
+        # the audit chain. Re-entrant: a mutation inside an active transaction
+        # (which holds it) re-acquires it on the same thread without deadlock.
+        self._lock = threading.RLock()
         self._settings: dict[tuple[str, str], StoredSettings] = {}
         self._loop_runs: dict[str, LoopRun] = {}
         self._loop_events: list[LoopEvent] = []
@@ -55,45 +76,53 @@ class InMemoryRepository(Repository):
 
     @contextmanager
     def transaction(self, tenant_id: str, user_id: str = "") -> Iterator[None]:
-        """Rollback-capable unit of work for the in-memory backend."""
-        if self._transaction_depth:
-            self._transaction_depth += 1
+        """Rollback-capable unit of work for the in-memory backend.
+
+        Holds ``self._lock`` for the whole unit of work: the snapshot, the caller's
+        body, and any commit/restore. Because the lock is re-entrant and every
+        mutation also takes it, no other thread can mutate the store while it is
+        being deep-copied (which would otherwise raise "dictionary changed size
+        during iteration" under concurrent load)."""
+        with self._lock:
+            if self._transaction_depth:
+                self._transaction_depth += 1
+                try:
+                    yield
+                finally:
+                    self._transaction_depth -= 1
+                return
+            snapshot = (
+                deepcopy(self._memories),
+                deepcopy(self._audit),
+                deepcopy(self._audit_head),
+                deepcopy(self._settings),
+                deepcopy(self._loop_runs),
+                deepcopy(self._loop_events),
+                deepcopy(self._leases),
+                deepcopy(self._worker_runs),
+                deepcopy(self._vectors),
+            )
+            self._transaction_depth = 1
             try:
                 yield
+            except Exception:
+                (
+                    self._memories,
+                    self._audit,
+                    self._audit_head,
+                    self._settings,
+                    self._loop_runs,
+                    self._loop_events,
+                    self._leases,
+                    self._worker_runs,
+                    self._vectors,
+                ) = snapshot
+                raise
             finally:
-                self._transaction_depth -= 1
-            return
-        snapshot = (
-            deepcopy(self._memories),
-            deepcopy(self._audit),
-            deepcopy(self._audit_head),
-            deepcopy(self._settings),
-            deepcopy(self._loop_runs),
-            deepcopy(self._loop_events),
-            deepcopy(self._leases),
-            deepcopy(self._worker_runs),
-            deepcopy(self._vectors),
-        )
-        self._transaction_depth = 1
-        try:
-            yield
-        except Exception:
-            (
-                self._memories,
-                self._audit,
-                self._audit_head,
-                self._settings,
-                self._loop_runs,
-                self._loop_events,
-                self._leases,
-                self._worker_runs,
-                self._vectors,
-            ) = snapshot
-            raise
-        finally:
-            self._transaction_depth = 0
+                self._transaction_depth = 0
 
     # ── memory ───────────────────────────────────────────────────────────────
+    @_locked
     def create_memory(self, memory: StoredMemory) -> StoredMemory:
         if not memory.source:  # provenance is mandatory (invariant #3)
             raise ValueError("memory.source (provenance) is required")
@@ -101,10 +130,11 @@ class InMemoryRepository(Repository):
         self._vectors.upsert(memory.tenant_id, memory.user_id, memory.id, memory.embedding or [])
         return memory
 
+    @_locked
     def _scoped(self, tenant_id: str, user_id: str) -> list[StoredMemory]:
-        # Tenant + user isolation enforced here (invariant #1). Snapshot the dict
-        # first: concurrent writes mutate it in the threadpool, and iterating a live
-        # dict raises "dictionary changed size during iteration" under load.
+        # Tenant + user isolation enforced here (invariant #1). Held under the lock
+        # so the snapshot can't observe a concurrent write mid-mutation (which would
+        # raise "dictionary changed size during iteration" under load).
         return [
             m
             for m in list(self._memories.values())
@@ -135,6 +165,7 @@ class InMemoryRepository(Repository):
             rows = [m for m in rows if m.memory_type.value == memory_type]
         return sorted(rows, key=lambda m: m.created_at, reverse=True)
 
+    @_locked
     def update_memory(self, memory: StoredMemory) -> StoredMemory:
         memory.updated_at = datetime.now(UTC)
         self._memories[memory.id] = memory
@@ -147,6 +178,7 @@ class InMemoryRepository(Repository):
             self._vectors.delete(memory.tenant_id, memory.user_id, memory.id)
         return memory
 
+    @_locked
     def soft_delete(self, tenant_id: str, user_id: str, memory_id: str) -> StoredMemory | None:
         m = self.get_memory(tenant_id, user_id, memory_id)
         if not m:
@@ -168,6 +200,7 @@ class InMemoryRepository(Repository):
             rows = [m for m in rows if not is_compacted(m)]
         return sorted(rows, key=lambda m: m.deleted_at or m.created_at, reverse=True)
 
+    @_locked
     def compact_deleted_memory(
         self,
         tenant_id: str,
@@ -199,6 +232,7 @@ class InMemoryRepository(Repository):
         # Only active rows are ever retrievable (invariant #2).
         return [m for m in self._scoped(tenant_id, user_id) if m.status.value == _ACTIVE]
 
+    @_locked
     def search_candidates(
         self,
         tenant_id: str,
@@ -225,18 +259,22 @@ class InMemoryRepository(Repository):
         return scored[:limit]
 
     # ── audit ────────────────────────────────────────────────────────────────
+    @_locked
     def add_audit(self, event: StoredAudit) -> StoredAudit:
         # Tamper-evident per-tenant hash chain (v2.0, ADR-024): link each event to the
         # previous one in its tenant's chain so any later edit/reorder is detectable.
+        # The lock serializes the head read-modify-write so concurrent audited
+        # mutations cannot fork the chain (the in-memory analogue of the Postgres
+        # SELECT ... FOR UPDATE on audit_chain_heads, migration 011).
         from ..evidence.hashchain import GENESIS, compute_entry_hash
 
-        with self._audit_head_lock:
-            event.prev_hash = self._audit_head.get(event.tenant_id, GENESIS)
-            event.entry_hash = compute_entry_hash(event, event.prev_hash)
-            self._audit_head[event.tenant_id] = event.entry_hash
-            self._audit.append(event)  # append-only (invariant #7)
+        event.prev_hash = self._audit_head.get(event.tenant_id, GENESIS)
+        event.entry_hash = compute_entry_hash(event, event.prev_hash)
+        self._audit_head[event.tenant_id] = event.entry_hash
+        self._audit.append(event)  # append-only (invariant #7)
         return event
 
+    @_locked
     def list_audit(
         self,
         tenant_id: str,
@@ -253,6 +291,7 @@ class InMemoryRepository(Repository):
         return sorted(rows, key=lambda e: e.created_at, reverse=True)[:limit]
 
     # ── worker runtime (v0.8) ──────────────────────────────────────────────────
+    @_locked
     def try_acquire_lease(
         self, key: str, owner: str, *, now: datetime, expires_at: datetime
     ) -> bool:
@@ -264,6 +303,7 @@ class InMemoryRepository(Repository):
         )
         return True
 
+    @_locked
     def renew_lease(self, key: str, owner: str, *, expires_at: datetime) -> bool:
         existing = self._leases.get(key)
         if not existing or existing.owner != owner:
@@ -271,6 +311,7 @@ class InMemoryRepository(Repository):
         existing.expires_at = expires_at
         return True
 
+    @_locked
     def release_lease(self, key: str, owner: str) -> None:
         existing = self._leases.get(key)
         if existing and existing.owner == owner:
@@ -279,10 +320,12 @@ class InMemoryRepository(Repository):
     def get_lease(self, key: str) -> WorkerLease | None:
         return self._leases.get(key)
 
+    @_locked
     def add_worker_run(self, record: WorkerRunRecord) -> WorkerRunRecord:
         self._worker_runs.append(record)
         return record
 
+    @_locked
     def list_worker_runs(
         self,
         *,
@@ -300,6 +343,7 @@ class InMemoryRepository(Repository):
             rows = [r for r in rows if r.status == status]
         return sorted(rows, key=lambda r: r.started_at, reverse=True)[:limit]
 
+    @_locked
     def list_worker_runs_operational(
         self, *, status: str | None = None, limit: int = 200
     ) -> list[WorkerRunRecord]:
@@ -316,11 +360,13 @@ class InMemoryRepository(Repository):
             (tenant_id, user_id), StoredSettings(tenant_id=tenant_id, user_id=user_id)
         )
 
+    @_locked
     def upsert_settings(self, settings: StoredSettings) -> StoredSettings:
         self._settings[(settings.tenant_id, settings.user_id)] = settings
         return settings
 
     # ── metrics ──────────────────────────────────────────────────────────────
+    @_locked
     def metrics(self, tenant_id: str) -> dict:
         rows = [m for m in list(self._memories.values()) if m.tenant_id == tenant_id]
         by_status: dict[str, int] = {}
@@ -341,14 +387,17 @@ class InMemoryRepository(Repository):
         }
 
     # ── loops ────────────────────────────────────────────────────────────────
+    @_locked
     def add_loop_run(self, run: LoopRun) -> LoopRun:
         self._loop_runs[run.id] = run
         return run
 
+    @_locked
     def update_loop_run(self, run: LoopRun) -> LoopRun:
         self._loop_runs[run.id] = run
         return run
 
+    @_locked
     def list_loop_runs(
         self,
         *,
@@ -372,6 +421,7 @@ class InMemoryRepository(Repository):
             rows = [r for r in rows if r.status.value == status]
         return sorted(rows, key=lambda r: r.started_at, reverse=True)[:limit]
 
+    @_locked
     def add_loop_event(
         self,
         event: LoopEvent,
@@ -382,6 +432,7 @@ class InMemoryRepository(Repository):
         self._loop_events.append(event)
         return event
 
+    @_locked
     def list_loop_events(
         self,
         *,

--- a/services/api/app/db/postgres_repo.py
+++ b/services/api/app/db/postgres_repo.py
@@ -18,6 +18,7 @@ from ..core.config import get_settings
 from ..loops.metrics import summarize_loop_runs
 from ..loops.types import LoopEvent, LoopId, LoopRun, LoopState, LoopStatus
 from ..models.sqlalchemy_models import (
+    AuditChainHeadORM,
     AuditLogORM,
     LoopEventORM,
     LoopRunORM,
@@ -28,6 +29,7 @@ from ..models.sqlalchemy_models import (
 )
 from ..schemas.memory import MemoryType, Sensitivity, Source, Status
 from .entities import (
+    OperationalAccessUnavailable,
     StoredAudit,
     StoredMemory,
     StoredSettings,
@@ -40,7 +42,7 @@ from .repository import Repository
 
 _DELETED = "deleted"
 _ACTIVE = "active"
-_CURRENT_SCHEMA_VERSION = "010_transactional_audit_chain"
+_CURRENT_SCHEMA_VERSION = "011_audit_chain_heads"
 
 
 def _norm(text: str) -> str:
@@ -117,7 +119,28 @@ class PostgresRepository(Repository):
         )
         self._active_tenant: ContextVar[str] = ContextVar("memoryops_pg_tenant", default="")
         self._active_user: ContextVar[str] = ContextVar("memoryops_pg_user", default="")
+        # Separately authorized, cross-tenant connection for global operator views
+        # (worker health). Built lazily; only from an explicitly configured
+        # monitoring role, never the request-scoped engine (see ADR-006 / #1).
+        self._operational_settings = settings
+        self._operational_engine = None
+        self._OperationalSession: sessionmaker[Session] | None = None
         self._assert_current_schema()
+
+    def _operational_session_factory(self) -> sessionmaker[Session]:
+        url = (self._operational_settings.operational_database_url or "").strip()
+        if not url:
+            raise OperationalAccessUnavailable(
+                "operational worker-run access is not configured; set "
+                "OPERATIONAL_DATABASE_URL to a monitoring role to enable global "
+                "worker health"
+            )
+        if self._OperationalSession is None:
+            self._operational_engine = create_engine(url, pool_pre_ping=True, future=True)
+            self._OperationalSession = sessionmaker(
+                self._operational_engine, expire_on_commit=False
+            )
+        return self._OperationalSession
 
     def _assert_current_schema(self) -> None:
         """Fail clearly when the database has not been migrated."""
@@ -395,19 +418,29 @@ class PostgresRepository(Repository):
     # ── audit ────────────────────────────────────────────────────────────────
     def add_audit(self, event: StoredAudit) -> StoredAudit:
         with self._scoped(event.tenant_id, event.user_id or "") as s:
+            from sqlalchemy.dialects.postgresql import insert as pg_insert
+
             from ..evidence.hashchain import GENESIS, compute_entry_hash
 
-            prev_hash = s.scalars(
-                select(AuditLogORM.entry_hash)
-                .where(
-                    AuditLogORM.tenant_id == event.tenant_id,
-                    AuditLogORM.entry_hash != "",
-                )
-                .order_by(AuditLogORM.created_at.desc())
-                .limit(1)
-            ).first() or GENESIS
+            # Serialize this tenant's chain (P0, migration 011): ensure a head row
+            # exists, then lock it FOR UPDATE. Two concurrent audited mutations
+            # can no longer read the same head and fork the chain — the second
+            # append blocks until the first commits and advances the head.
+            s.execute(
+                pg_insert(AuditChainHeadORM.__table__)
+                .values(tenant_id=event.tenant_id, head_hash="", updated_at=event.created_at)
+                .on_conflict_do_nothing(index_elements=["tenant_id"])
+            )
+            head = s.execute(
+                select(AuditChainHeadORM)
+                .where(AuditChainHeadORM.tenant_id == event.tenant_id)
+                .with_for_update()
+            ).scalar_one()
+            prev_hash = head.head_hash or GENESIS
             event.prev_hash = prev_hash
             event.entry_hash = compute_entry_hash(event, prev_hash)
+            head.head_hash = event.entry_hash
+            head.updated_at = event.created_at
             row = AuditLogORM(
                 id=event.id,
                 tenant_id=event.tenant_id,
@@ -549,6 +582,40 @@ class PostgresRepository(Repository):
             stmt = select(WorkerRunORM).where(WorkerRunORM.tenant_id == tenant_id)
             if user_id:
                 stmt = stmt.where(WorkerRunORM.user_id == user_id)
+            if status:
+                stmt = stmt.where(WorkerRunORM.status == status)
+            stmt = stmt.order_by(WorkerRunORM.started_at.desc()).limit(limit)
+            return [
+                WorkerRunRecord(
+                    id=r.id,
+                    tenant_id=r.tenant_id,
+                    user_id=r.user_id,
+                    status=r.status,
+                    jobs=list(r.jobs or []),
+                    attempts=r.attempts,
+                    scanned_count=r.scanned_count,
+                    changed_count=r.changed_count,
+                    skipped_count=r.skipped_count,
+                    error_count=r.error_count,
+                    owner=r.owner,
+                    trace_id=r.trace_id,
+                    error=r.error,
+                    details=r.extra_metadata or {},
+                    started_at=r.started_at,
+                    completed_at=r.completed_at,
+                )
+                for r in s.scalars(stmt)
+            ]
+
+    def list_worker_runs_operational(
+        self, *, status: str | None = None, limit: int = 200
+    ) -> list[WorkerRunRecord]:
+        # Cross-tenant, so it must run on the separately authorized operational
+        # connection — never the RLS-enforced request engine. Unconfigured →
+        # fail-closed (the health surface degrades, no tenant boundary weakened).
+        factory = self._operational_session_factory()
+        with factory() as s:
+            stmt = select(WorkerRunORM)
             if status:
                 stmt = stmt.where(WorkerRunORM.status == status)
             stmt = stmt.order_by(WorkerRunORM.started_at.desc()).limit(limit)

--- a/services/api/app/db/repository.py
+++ b/services/api/app/db/repository.py
@@ -164,6 +164,20 @@ class Repository(ABC):
         limit: int = 200,
     ) -> list[WorkerRunRecord]: ...
 
+    @abstractmethod
+    def list_worker_runs_operational(
+        self, *, status: str | None = None, limit: int = 200
+    ) -> list[WorkerRunRecord]:
+        """Cross-tenant worker-run history for *global operator* views only.
+
+        Deliberately not tenant-scoped — worker health is an operator concern that
+        spans every scope. This must never reuse the request-scoped, RLS-enforced
+        connection; a backend that cannot serve it without weakening tenant
+        isolation raises :class:`OperationalAccessUnavailable` (fail-closed) so the
+        caller degrades gracefully rather than leaking or crashing.
+        """
+        ...
+
     # ── settings ─────────────────────────────────────────────────────────────
     @abstractmethod
     def get_settings(self, tenant_id: str, user_id: str) -> StoredSettings: ...

--- a/services/api/app/models/sqlalchemy_models.py
+++ b/services/api/app/models/sqlalchemy_models.py
@@ -75,6 +75,18 @@ class AuditLogORM(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
 
 
+class AuditChainHeadORM(Base):
+    """One row per tenant holding the current audit hash-chain head (migration
+    011). The append path locks this row with SELECT ... FOR UPDATE so concurrent
+    audited mutations serialize onto one continuous chain instead of forking."""
+
+    __tablename__ = "audit_chain_heads"
+
+    tenant_id: Mapped[str] = mapped_column(String, primary_key=True)
+    head_hash: Mapped[str] = mapped_column(String, default="")
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
+
+
 class LoopRunORM(Base):
     __tablename__ = "loop_runs"
 

--- a/services/api/app/observability/instrument.py
+++ b/services/api/app/observability/instrument.py
@@ -92,6 +92,7 @@ def collect_worker_gauges(repo, limit: int = 500) -> None:
     cleared so ``/metrics`` degrades to omitting worker signals, never a 500.
     """
     # Import here to avoid a heavy import at module load for the common path.
+    from ..db.entities import OperationalAccessUnavailable
     from ..workers.orchestrator import summarize_runtime_health
 
     m.WORKER_RUNS.reset()
@@ -101,5 +102,9 @@ def collect_worker_gauges(repo, limit: int = 500) -> None:
             m.WORKER_RUNS.set(count, {"status": status})
         m.WORKER_DEAD_LETTER.set(summary.get("dead_letter_count", 0))
         m.WORKER_FAILED.set(summary.get("failed_count", 0))
+    except OperationalAccessUnavailable:
+        # Expected when no operational connection is configured — leave the worker
+        # gauges omitted rather than logging noise on every scrape.
+        pass
     except Exception:  # noqa: BLE001 — worker metrics are best-effort
         logger.debug("collect_worker_gauges failed", extra={"event": "metric_drop"})

--- a/services/api/app/routes/health.py
+++ b/services/api/app/routes/health.py
@@ -31,6 +31,7 @@ def healthz() -> dict:
 def workers_health() -> dict:
     """Worker runtime health (v0.8): recent run history, dead-letter + failure
     counts, and the last run per scope. Content-free operational evidence."""
+    from ..db.entities import OperationalAccessUnavailable
     from ..workers.orchestrator import summarize_runtime_health
 
     settings = get_settings()
@@ -40,6 +41,14 @@ def workers_health() -> dict:
         )
         healthy = summary["dead_letter_count"] == 0 and summary["failed_count"] == 0
         return {"healthy": healthy, **summary}
+    except OperationalAccessUnavailable:
+        # Not an error — global worker health needs a separately authorized
+        # operational connection. Report it as an actionable, non-fatal state.
+        return {
+            "healthy": None,
+            "detail": "operational access not configured",
+            "hint": "set OPERATIONAL_DATABASE_URL to a monitoring role",
+        }
     except Exception as exc:  # noqa: BLE001 — health must not raise
         return {"healthy": False, "detail": f"unavailable: {type(exc).__name__}"}
 

--- a/services/api/app/routes/memories.py
+++ b/services/api/app/routes/memories.py
@@ -251,31 +251,34 @@ def patch_memory(memory_id: str, patch: MemoryPatch, request: Request) -> Memory
         elif patch.status == Status.archived:
             action, reason = "memory_archived", "memory archived"
 
-    repo.update_memory(m)
-    emit_loop_event_sync(
-        repo,
-        loop,
-        LoopState.EXECUTED,
-        event_type="memory_governance_executed",
-        reason="memory governance patch executed",
-        evidence={"action": action, "status": m.status.value},
-    )
-    emit_loop_event_sync(
-        repo,
-        loop,
-        LoopState.VERIFIED,
-        event_type="memory_governance_verified",
-        reason="memory status/content update verified",
-        evidence={"memory_id": memory_id, "status": m.status.value},
-    )
-    audit = audit_service().record(
-        tenant_id=patch.tenant_id,
-        user_id=patch.user_id,
-        memory_id=memory_id,
-        action=action,
-        reason=reason,
-        trace_id=trace_id,
-    )
+    # Mutation + audit are one atomic unit of work (P0): a crash mid-way can no
+    # longer persist the edit without its audit evidence, or vice versa.
+    with repo.transaction(patch.tenant_id, patch.user_id):
+        repo.update_memory(m)
+        emit_loop_event_sync(
+            repo,
+            loop,
+            LoopState.EXECUTED,
+            event_type="memory_governance_executed",
+            reason="memory governance patch executed",
+            evidence={"action": action, "status": m.status.value},
+        )
+        emit_loop_event_sync(
+            repo,
+            loop,
+            LoopState.VERIFIED,
+            event_type="memory_governance_verified",
+            reason="memory status/content update verified",
+            evidence={"memory_id": memory_id, "status": m.status.value},
+        )
+        audit = audit_service().record(
+            tenant_id=patch.tenant_id,
+            user_id=patch.user_id,
+            memory_id=memory_id,
+            action=action,
+            reason=reason,
+            trace_id=trace_id,
+        )
     emit_loop_event_sync(
         repo,
         loop,
@@ -352,39 +355,41 @@ def delete_memory(memory_id: str, body: DeleteRequest, request: Request) -> dict
             trace_id=trace_id,
         )
         raise HTTPException(status_code=409, detail="memory is under legal hold")
-    m = repo.soft_delete(body.tenant_id, body.user_id, memory_id)
-    if not m:
-        raise HTTPException(status_code=404, detail="memory not found")
-    # Tombstone lineage (v1.4, ADR-018): stamp an explicit, audited tombstone so
-    # any artifact derived from this memory is blocked from context by the
-    # admission gate. Soft-deletion alone already blocks direct retrieval (#2);
-    # the marker propagates the deletion through derived lineage.
-    lineage.set_tombstone(m, on=True, reason="memory deleted")
-    repo.update_memory(m)
-    emit_loop_event_sync(
-        repo,
-        loop,
-        LoopState.EXECUTED,
-        event_type="memory_governance_executed",
-        reason="memory soft delete executed",
-        evidence={"memory_id": memory_id, "status": "deleted"},
-    )
-    emit_loop_event_sync(
-        repo,
-        loop,
-        LoopState.VERIFIED,
-        event_type="memory_governance_verified",
-        reason="deleted memory marked unretrievable",
-        evidence={"memory_id": memory_id, "status": m.status.value},
-    )
-    audit = audit_service().record(
-        tenant_id=body.tenant_id,
-        user_id=body.user_id,
-        memory_id=memory_id,
-        action="memory_deleted",
-        reason="memory soft-deleted; excluded from all future retrieval",
-        trace_id=trace_id,
-    )
+    # Soft-deletion, tombstone stamping, and the audit event are one atomic unit
+    # of work (P0): the deletion guarantee and its evidence commit together or
+    # not at all. Tombstone lineage (v1.4, ADR-018) stamps an explicit, audited
+    # tombstone so any artifact derived from this memory is blocked from context
+    # by the admission gate; soft-deletion alone already blocks direct retrieval.
+    with repo.transaction(body.tenant_id, body.user_id):
+        m = repo.soft_delete(body.tenant_id, body.user_id, memory_id)
+        if not m:
+            raise HTTPException(status_code=404, detail="memory not found")
+        lineage.set_tombstone(m, on=True, reason="memory deleted")
+        repo.update_memory(m)
+        emit_loop_event_sync(
+            repo,
+            loop,
+            LoopState.EXECUTED,
+            event_type="memory_governance_executed",
+            reason="memory soft delete executed",
+            evidence={"memory_id": memory_id, "status": "deleted"},
+        )
+        emit_loop_event_sync(
+            repo,
+            loop,
+            LoopState.VERIFIED,
+            event_type="memory_governance_verified",
+            reason="deleted memory marked unretrievable",
+            evidence={"memory_id": memory_id, "status": m.status.value},
+        )
+        audit = audit_service().record(
+            tenant_id=body.tenant_id,
+            user_id=body.user_id,
+            memory_id=memory_id,
+            action="memory_deleted",
+            reason="memory soft-deleted; excluded from all future retrieval",
+            trace_id=trace_id,
+        )
     emit_loop_event_sync(
         repo,
         loop,

--- a/services/api/app/routes/memories.py
+++ b/services/api/app/routes/memories.py
@@ -233,27 +233,30 @@ def patch_memory(memory_id: str, patch: MemoryPatch, request: Request) -> Memory
     if not m or m.status == Status.deleted:
         raise HTTPException(status_code=404, detail="memory not found")
 
+    # Mutation + audit are one atomic unit of work (P0): a crash mid-way can no
+    # longer persist the edit without its audit evidence, or vice versa. The
+    # transaction must open *before* the in-place field mutations — the in-memory
+    # backend hands back the live stored row, so a rollback can only undo changes
+    # made after the unit of work's snapshot is taken.
     action = "memory_updated"
     reason = "memory edited"
-    if patch.content is not None:
-        m.content = patch.content
-        m.normalized_content = " ".join(patch.content.lower().split())
-    if patch.importance is not None:
-        m.importance = patch.importance
-    if patch.confidence is not None:
-        m.confidence = patch.confidence
-    if patch.status is not None:
-        m.status = patch.status
-        if patch.status == Status.active:
-            action, reason = "memory_approved", "pending memory approved"
-        elif patch.status == Status.rejected:
-            action, reason = "memory_rejected", "pending memory rejected"
-        elif patch.status == Status.archived:
-            action, reason = "memory_archived", "memory archived"
-
-    # Mutation + audit are one atomic unit of work (P0): a crash mid-way can no
-    # longer persist the edit without its audit evidence, or vice versa.
     with repo.transaction(patch.tenant_id, patch.user_id):
+        if patch.content is not None:
+            m.content = patch.content
+            m.normalized_content = " ".join(patch.content.lower().split())
+        if patch.importance is not None:
+            m.importance = patch.importance
+        if patch.confidence is not None:
+            m.confidence = patch.confidence
+        if patch.status is not None:
+            m.status = patch.status
+            if patch.status == Status.active:
+                action, reason = "memory_approved", "pending memory approved"
+            elif patch.status == Status.rejected:
+                action, reason = "memory_rejected", "pending memory rejected"
+            elif patch.status == Status.archived:
+                action, reason = "memory_archived", "memory archived"
+
         repo.update_memory(m)
         emit_loop_event_sync(
             repo,

--- a/services/api/app/routes/retention.py
+++ b/services/api/app/routes/retention.py
@@ -74,8 +74,10 @@ def _state(memory) -> dict:
 @router.post("/legal-hold")
 def set_legal_hold(req: LegalHoldRequest, request: Request) -> dict:
     repo, memory = _load(req, request)
-    gov.set_legal_hold(memory, on=req.on, reason=req.reason)
+    # Governance mutation + audit commit atomically (P0). The mutation runs inside
+    # the transaction so a rollback restores the live in-memory row (see ADR-027).
     with repo.transaction(req.tenant_id, req.user_id):
+        gov.set_legal_hold(memory, on=req.on, reason=req.reason)
         repo.update_memory(memory)
         audit_service().record(
             tenant_id=req.tenant_id,
@@ -92,8 +94,8 @@ def set_legal_hold(req: LegalHoldRequest, request: Request) -> dict:
 @router.post("/pin")
 def set_pin(req: FlagRequest, request: Request) -> dict:
     repo, memory = _load(req, request)
-    gov.set_pinned(memory, on=req.on)
     with repo.transaction(req.tenant_id, req.user_id):
+        gov.set_pinned(memory, on=req.on)
         repo.update_memory(memory)
         audit_service().record(
             tenant_id=req.tenant_id,
@@ -110,8 +112,8 @@ def set_pin(req: FlagRequest, request: Request) -> dict:
 @router.post("/protect")
 def set_protect(req: FlagRequest, request: Request) -> dict:
     repo, memory = _load(req, request)
-    gov.set_protected(memory, on=req.on)
     with repo.transaction(req.tenant_id, req.user_id):
+        gov.set_protected(memory, on=req.on)
         repo.update_memory(memory)
         audit_service().record(
             tenant_id=req.tenant_id,
@@ -130,8 +132,8 @@ def set_consent(req: ConsentRequest, request: Request) -> dict:
     if req.status not in gov.ConsentStatus.ALL:
         raise HTTPException(status_code=422, detail=f"unknown consent status: {req.status}")
     repo, memory = _load(req, request)
-    gov.set_consent(memory, status=req.status, expires_at=req.expires_at)
     with repo.transaction(req.tenant_id, req.user_id):
+        gov.set_consent(memory, status=req.status, expires_at=req.expires_at)
         repo.update_memory(memory)
         audit_service().record(
             tenant_id=req.tenant_id,

--- a/services/api/app/routes/retention.py
+++ b/services/api/app/routes/retention.py
@@ -75,16 +75,17 @@ def _state(memory) -> dict:
 def set_legal_hold(req: LegalHoldRequest, request: Request) -> dict:
     repo, memory = _load(req, request)
     gov.set_legal_hold(memory, on=req.on, reason=req.reason)
-    repo.update_memory(memory)
-    audit_service().record(
-        tenant_id=req.tenant_id,
-        user_id=req.user_id,
-        memory_id=req.memory_id,
-        action="memory_legal_hold_set" if req.on else "memory_legal_hold_released",
-        reason=(req.reason or "legal hold updated") if req.on else "legal hold released",
-        trace_id=_trace(request),
-        metadata={"legal_hold": req.on},
-    )
+    with repo.transaction(req.tenant_id, req.user_id):
+        repo.update_memory(memory)
+        audit_service().record(
+            tenant_id=req.tenant_id,
+            user_id=req.user_id,
+            memory_id=req.memory_id,
+            action="memory_legal_hold_set" if req.on else "memory_legal_hold_released",
+            reason=(req.reason or "legal hold updated") if req.on else "legal hold released",
+            trace_id=_trace(request),
+            metadata={"legal_hold": req.on},
+        )
     return _state(memory)
 
 
@@ -92,16 +93,17 @@ def set_legal_hold(req: LegalHoldRequest, request: Request) -> dict:
 def set_pin(req: FlagRequest, request: Request) -> dict:
     repo, memory = _load(req, request)
     gov.set_pinned(memory, on=req.on)
-    repo.update_memory(memory)
-    audit_service().record(
-        tenant_id=req.tenant_id,
-        user_id=req.user_id,
-        memory_id=req.memory_id,
-        action="memory_pinned" if req.on else "memory_unpinned",
-        reason="memory pin updated",
-        trace_id=_trace(request),
-        metadata={"pinned": req.on},
-    )
+    with repo.transaction(req.tenant_id, req.user_id):
+        repo.update_memory(memory)
+        audit_service().record(
+            tenant_id=req.tenant_id,
+            user_id=req.user_id,
+            memory_id=req.memory_id,
+            action="memory_pinned" if req.on else "memory_unpinned",
+            reason="memory pin updated",
+            trace_id=_trace(request),
+            metadata={"pinned": req.on},
+        )
     return _state(memory)
 
 
@@ -109,16 +111,17 @@ def set_pin(req: FlagRequest, request: Request) -> dict:
 def set_protect(req: FlagRequest, request: Request) -> dict:
     repo, memory = _load(req, request)
     gov.set_protected(memory, on=req.on)
-    repo.update_memory(memory)
-    audit_service().record(
-        tenant_id=req.tenant_id,
-        user_id=req.user_id,
-        memory_id=req.memory_id,
-        action="memory_protected" if req.on else "memory_unprotected",
-        reason="memory protection updated",
-        trace_id=_trace(request),
-        metadata={"protected": req.on},
-    )
+    with repo.transaction(req.tenant_id, req.user_id):
+        repo.update_memory(memory)
+        audit_service().record(
+            tenant_id=req.tenant_id,
+            user_id=req.user_id,
+            memory_id=req.memory_id,
+            action="memory_protected" if req.on else "memory_unprotected",
+            reason="memory protection updated",
+            trace_id=_trace(request),
+            metadata={"protected": req.on},
+        )
     return _state(memory)
 
 
@@ -128,16 +131,17 @@ def set_consent(req: ConsentRequest, request: Request) -> dict:
         raise HTTPException(status_code=422, detail=f"unknown consent status: {req.status}")
     repo, memory = _load(req, request)
     gov.set_consent(memory, status=req.status, expires_at=req.expires_at)
-    repo.update_memory(memory)
-    audit_service().record(
-        tenant_id=req.tenant_id,
-        user_id=req.user_id,
-        memory_id=req.memory_id,
-        action="memory_consent_updated",
-        reason=f"consent set to {req.status}",
-        trace_id=_trace(request),
-        metadata={"consent_status": req.status},
-    )
+    with repo.transaction(req.tenant_id, req.user_id):
+        repo.update_memory(memory)
+        audit_service().record(
+            tenant_id=req.tenant_id,
+            user_id=req.user_id,
+            memory_id=req.memory_id,
+            action="memory_consent_updated",
+            reason=f"consent set to {req.status}",
+            trace_id=_trace(request),
+            metadata={"consent_status": req.status},
+        )
     return _state(memory)
 
 

--- a/services/api/app/services/write_service.py
+++ b/services/api/app/services/write_service.py
@@ -44,51 +44,59 @@ class WriteService:
         memory_id: str | None = None
         audit_ids: list[str] = []
 
+        # Embedding is a best-effort network call; compute it *before* opening the
+        # transaction so we never hold a DB unit of work across it (and so failure,
+        # already swallowed by safe_call, can't affect atomicity).
+        embedding: list[float] = []
         if decision in (Decision.SAVE, Decision.PENDING_APPROVAL):
-            status = Status.active if decision == Decision.SAVE else Status.pending
-            # Embedding is best-effort; failure must not block the write.
             embedding = safe_call(lambda: embed(cand.content), default=[], label="embed")
-            stored = StoredMemory(
+
+        # Persist-plus-audit is one atomic unit of work (P0): a crash between the
+        # memory mutation and its audit event can no longer leave one without the
+        # other. BLOCK/DROP store nothing but still audit inside the same boundary.
+        with self._repo.transaction(tenant_id, user_id):
+            if decision in (Decision.SAVE, Decision.PENDING_APPROVAL):
+                status = Status.active if decision == Decision.SAVE else Status.pending
+                stored = StoredMemory(
+                    tenant_id=tenant_id,
+                    user_id=user_id,
+                    memory_type=cand.type,
+                    content=cand.content,
+                    normalized_content=" ".join(cand.content.lower().split()),
+                    embedding=embedding,
+                    importance=cand.importance,
+                    confidence=cand.confidence,
+                    sensitivity=cand.sensitivity,
+                    status=status,
+                    source=cand.source,
+                )
+                self._repo.create_memory(stored)
+                memory_id = stored.id
+
+            elif decision in (Decision.UPDATE_EXISTING, Decision.MERGE_WITH_EXISTING):
+                existing = (
+                    self._repo.get_memory(tenant_id, user_id, outcome.existing_id)
+                    if outcome.existing_id
+                    else None
+                )
+                if existing:
+                    existing.reinforcement_count += 1
+                    existing.weight = min(existing.weight + 0.1, 2.0)
+                    existing.importance = max(existing.importance, cand.importance)
+                    existing.confidence = max(existing.confidence, cand.confidence)
+                    self._repo.update_memory(existing)
+                    memory_id = existing.id
+
+            event = self._audit.record(
                 tenant_id=tenant_id,
                 user_id=user_id,
-                memory_type=cand.type,
-                content=cand.content,
-                normalized_content=" ".join(cand.content.lower().split()),
-                embedding=embedding,
-                importance=cand.importance,
-                confidence=cand.confidence,
-                sensitivity=cand.sensitivity,
-                status=status,
-                source=cand.source,
+                memory_id=memory_id,
+                action=_AUDIT_ACTION[decision],
+                reason=outcome.reason,
+                trace_id=trace_id,
+                metadata={"type": cand.type.value, "sensitivity": cand.sensitivity.value},
             )
-            self._repo.create_memory(stored)
-            memory_id = stored.id
-
-        elif decision in (Decision.UPDATE_EXISTING, Decision.MERGE_WITH_EXISTING):
-            existing = (
-                self._repo.get_memory(tenant_id, user_id, outcome.existing_id)
-                if outcome.existing_id
-                else None
-            )
-            if existing:
-                existing.reinforcement_count += 1
-                existing.weight = min(existing.weight + 0.1, 2.0)
-                existing.importance = max(existing.importance, cand.importance)
-                existing.confidence = max(existing.confidence, cand.confidence)
-                self._repo.update_memory(existing)
-                memory_id = existing.id
-
-        # BLOCK / DROP store nothing — audit only.
-        event = self._audit.record(
-            tenant_id=tenant_id,
-            user_id=user_id,
-            memory_id=memory_id,
-            action=_AUDIT_ACTION[decision],
-            reason=outcome.reason,
-            trace_id=trace_id,
-            metadata={"type": cand.type.value, "sensitivity": cand.sensitivity.value},
-        )
-        audit_ids.append(event.id)
+            audit_ids.append(event.id)
 
         decision_view = CandidateDecision(
             content=cand.content,

--- a/services/api/app/workers/orchestrator.py
+++ b/services/api/app/workers/orchestrator.py
@@ -202,8 +202,14 @@ class WorkerOrchestrator:
 
 
 def summarize_runtime_health(repo: Repository, *, limit: int = 200) -> dict:
-    """Content-free operational health view over recent worker runs (v0.8)."""
-    runs = repo.list_worker_runs(limit=limit)
+    """Content-free operational health view over recent worker runs (v0.8).
+
+    Global operator concern → reads via the explicit cross-tenant operational
+    path, not the tenant-scoped one (which would raise). Raises
+    ``OperationalAccessUnavailable`` when no operational connection is configured;
+    callers degrade gracefully.
+    """
+    runs = repo.list_worker_runs_operational(limit=limit)
     by_status: dict[str, int] = {}
     last_per_scope: dict[str, dict] = {}
     for r in runs:

--- a/services/api/tests/test_deletion.py
+++ b/services/api/tests/test_deletion.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from app.schemas.memory import ChatRequest, Status
 
 
@@ -9,6 +11,37 @@ def _chat(gateway, message):
     return gateway.handle_chat(
         ChatRequest(tenant_id="t1", user_id="u1", message=message), trace_id="test"
     )
+
+
+def test_delete_route_is_atomic_when_audit_fails(api_client, monkeypatch) -> None:
+    """v2.3 (P0): soft-deletion + tombstone + audit are one atomic unit of work.
+
+    If the audit append fails mid-delete, the deletion rolls back — the memory is
+    neither soft-deleted nor tombstoned, so we never persist a half-deleted memory
+    (a mutation without its evidence)."""
+    from app.db import lineage
+
+    client, repo = api_client
+    client.post(
+        "/api/chat",
+        json={"tenant_id": "t1", "user_id": "u1", "message": "Remember I prefer Vendor X."},
+    )
+    mem = repo.list_memories("t1", "u1")[0]
+
+    def _boom(_event):
+        raise RuntimeError("audit backend down")
+
+    monkeypatch.setattr(repo, "add_audit", _boom)
+
+    with pytest.raises(RuntimeError):
+        client.request(
+            "DELETE", f"/api/memories/{mem.id}", json={"tenant_id": "t1", "user_id": "u1"}
+        )
+
+    survived = repo.get_memory("t1", "u1", mem.id)
+    assert survived.status is Status.active  # rolled back — still active
+    assert not lineage.is_tombstoned(survived)
+    assert mem.id in {m.id for m in repo.retrieve_active("t1", "u1")}
 
 
 def test_deleted_memory_excluded_from_retrieval(gateway, repo):

--- a/services/api/tests/test_governance_api.py
+++ b/services/api/tests/test_governance_api.py
@@ -8,6 +8,8 @@ auditability (#7).
 
 from __future__ import annotations
 
+import pytest
+
 from app.db.entities import StoredMemory
 from app.schemas.memory import MemoryType, Sensitivity, Source, Status
 
@@ -97,6 +99,29 @@ def test_approve_pending(api_client):
     assert r.json()["status"] == "active"
     actions = {e.action for e in repo.list_audit("t1", "u1", memory_id=m.id)}
     assert "memory_approved" in actions
+
+
+def test_approve_is_atomic_when_audit_fails(api_client, monkeypatch):
+    """v2.3 (P0, ADR-027): the control-plane mutation + its audit event commit in one
+    transaction. If the audit append fails while approving, the status change rolls
+    back — the memory stays pending, never approved-without-evidence."""
+    client, repo = api_client
+    m = _seed(repo, status=Status.pending)
+
+    def _boom(_event):
+        raise RuntimeError("audit backend down")
+
+    monkeypatch.setattr(repo, "add_audit", _boom)
+
+    with pytest.raises(RuntimeError):
+        client.patch(
+            f"/api/memories/{m.id}",
+            json={"tenant_id": "t1", "user_id": "u1", "status": "active"},
+        )
+
+    # Rolled back: still pending, and no partial audit event for the approval.
+    assert repo.get_memory("t1", "u1", m.id).status is Status.pending
+    assert repo.list_audit("t1", "u1", memory_id=m.id) == []
 
 
 def test_reject_pending(api_client):

--- a/services/api/tests/test_memory_write_loop.py
+++ b/services/api/tests/test_memory_write_loop.py
@@ -4,6 +4,20 @@ from app.loops.types import LoopId, LoopStatus
 from app.schemas.memory import ChatRequest
 
 
+def test_memory_write_loop_audit_event_is_persisted(gateway, repo):
+    """The write loop's AUDITED state maps to a durably persisted audit event: the
+    memory and its `memory_created` audit are committed together in one transaction
+    (v2.3, ADR-027) — never a memory without its evidence."""
+    gateway.handle_chat(
+        ChatRequest(tenant_id="t1", user_id="u1", message="Remember I prefer persisted audits."),
+        trace_id="trace-audit-persist",
+    )
+    mems = repo.list_memories("t1", "u1")
+    assert mems
+    audits = repo.list_audit("t1", "u1", memory_id=mems[0].id)
+    assert any(a.action == "memory_created" for a in audits)
+
+
 def test_memory_write_loop_emits_events(gateway, repo):
     resp = gateway.handle_chat(
         ChatRequest(tenant_id="t1", user_id="u1", message="Remember that I prefer loops."),

--- a/services/api/tests/test_tenant_isolation.py
+++ b/services/api/tests/test_tenant_isolation.py
@@ -117,6 +117,23 @@ def test_worker_runs_are_tenant_scoped(repo):
     assert repo.list_worker_runs(tenant_id="tenant_demo", user_id="other") == []
 
 
+def test_worker_health_operational_read_is_explicitly_cross_tenant(repo):
+    # v2.3 (P0): global worker health is a deliberate cross-tenant *operational*
+    # view, kept on a separate, explicitly-authorized path — never by relaxing the
+    # tenant-scoped query (which stays isolated, asserted above). The two methods
+    # answer different questions and must not be confused.
+    from app.db.entities import WorkerRunRecord
+
+    repo.add_worker_run(WorkerRunRecord(tenant_id="tenant_acme", user_id="u1", status="completed"))
+    repo.add_worker_run(WorkerRunRecord(tenant_id="tenant_demo", user_id="u1", status="failed"))
+
+    # Tenant-scoped read still refuses to span tenants.
+    assert {r.tenant_id for r in repo.list_worker_runs(tenant_id="tenant_acme")} == {"tenant_acme"}
+    # The operational read is the *only* one that spans them, and it is opt-in.
+    operational = repo.list_worker_runs_operational()
+    assert {r.tenant_id for r in operational} == {"tenant_acme", "tenant_demo"}
+
+
 def test_audit_listing_is_tenant_and_memory_scoped(gateway, repo):
     # v0.5: the control plane's per-memory audit filter must stay tenant-scoped
     # and must not surface another memory's events.

--- a/services/api/tests/test_transactional_evidence.py
+++ b/services/api/tests/test_transactional_evidence.py
@@ -1,0 +1,161 @@
+"""Transactional evidence (v2.3, P0): mutation + audit are one atomic unit of
+work, the audit hash-chain cannot fork under concurrency, and global worker
+health degrades gracefully instead of leaking or crashing.
+
+These are the "teeth" behind the auditability invariant (#7): the guarantee is
+that successful *and* partially-failed mutations leave the store consistent —
+never a memory without its audit event, nor an audit event without its memory.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from app.db.entities import StoredAudit, StoredMemory
+from app.evidence.hashchain import verify_chain
+from app.schemas.memory import (
+    CandidateMemory,
+    Decision,
+    MemoryType,
+    Sensitivity,
+    Source,
+    Status,
+)
+from app.services.audit import AuditService
+from app.services.policy_broker import PolicyOutcome
+from app.services.write_service import WriteService
+
+
+class _Boom(Exception):
+    """Injected failure."""
+
+
+def _memory(content: str = "user prefers dark mode") -> StoredMemory:
+    return StoredMemory(
+        tenant_id="t1",
+        user_id="u1",
+        memory_type=MemoryType.preference,
+        content=content,
+        importance=5,
+        confidence=0.9,
+        sensitivity=Sensitivity.low,
+        status=Status.active,
+        source=Source(kind="chat"),
+    )
+
+
+# ── rollback: mutation + audit commit together or not at all ──────────────────
+def test_transaction_rolls_back_memory_and_audit(repo) -> None:
+    mem = _memory()
+    with pytest.raises(_Boom):
+        with repo.transaction("t1", "u1"):
+            repo.create_memory(mem)
+            repo.add_audit(
+                StoredAudit(tenant_id="t1", user_id="u1", action="memory_created", reason="x")
+            )
+            raise _Boom()  # crash after both writes, before commit
+
+    # Neither side survives the rollback.
+    assert repo.get_memory("t1", "u1", mem.id) is None
+    assert repo.list_audit("t1", "u1") == []
+    # The chain head did not advance, so the next real append still links to GENESIS.
+    committed = repo.add_audit(
+        StoredAudit(tenant_id="t1", user_id="u1", action="memory_created", reason="ok")
+    )
+    assert committed.prev_hash == "0" * 64
+
+
+def test_transaction_commit_persists_both(repo) -> None:
+    mem = _memory()
+    with repo.transaction("t1", "u1"):
+        repo.create_memory(mem)
+        repo.add_audit(
+            StoredAudit(tenant_id="t1", user_id="u1", action="memory_created", reason="x")
+        )
+    assert repo.get_memory("t1", "u1", mem.id) is not None
+    assert len(repo.list_audit("t1", "u1")) == 1
+
+
+# ── write service: a failing audit must not leave an orphaned memory ──────────
+def test_write_service_atomic_when_audit_fails(repo, monkeypatch) -> None:
+    writer = WriteService(repo, AuditService(repo))
+
+    def _explode(_event):
+        raise _Boom("audit backend down")
+
+    monkeypatch.setattr(repo, "add_audit", _explode)
+
+    outcome = PolicyOutcome(
+        decision=Decision.SAVE,
+        candidate=CandidateMemory(
+            content="user prefers dark mode",
+            type=MemoryType.preference,
+            importance=5,
+            confidence=0.9,
+            sensitivity=Sensitivity.low,
+            source=Source(kind="chat"),
+        ),
+        reason="save",
+    )
+
+    with pytest.raises(_Boom):
+        writer.commit(outcome, tenant_id="t1", user_id="u1", trace_id="tr")
+
+    # The memory write rolled back with the audit failure — no orphan.
+    assert repo.list_memories("t1", "u1") == []
+
+
+# ── concurrency: parallel audited ops must form one continuous chain ──────────
+def test_concurrent_audit_appends_form_one_continuous_chain(repo) -> None:
+    n = 40
+    ready = threading.Barrier(n)
+    errors: list[Exception] = []
+
+    def _append(i: int) -> None:
+        try:
+            ready.wait()  # maximize contention on the chain head
+            repo.add_audit(
+                StoredAudit(tenant_id="t1", user_id="u1", action="op", reason=f"r{i}")
+            )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_append, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    events = repo.list_audit("t1", "u1", limit=1000)
+    assert len(events) == n
+    # No fork, no orphan, every link intact — the head lock serialized the writers.
+    result = verify_chain(events)
+    assert result["ok"], result
+    assert result["length"] == n
+
+
+def test_concurrent_appends_isolate_per_tenant_chain(repo) -> None:
+    n = 20
+    ready = threading.Barrier(2 * n)
+
+    def _append(tenant: str, i: int) -> None:
+        ready.wait()
+        repo.add_audit(StoredAudit(tenant_id=tenant, user_id="u1", action="op", reason=str(i)))
+
+    threads = [
+        threading.Thread(target=_append, args=(tenant, i))
+        for tenant in ("t1", "t2")
+        for i in range(n)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    for tenant in ("t1", "t2"):
+        events = repo.list_audit(tenant, "u1", limit=1000)
+        assert len(events) == n
+        assert verify_chain(events)["ok"]

--- a/services/api/tests/test_worker_health.py
+++ b/services/api/tests/test_worker_health.py
@@ -29,3 +29,25 @@ def test_workers_health_reflects_dead_letter(api_client) -> None:
     assert body["healthy"] is False
     assert body["dead_letter_count"] == 1
     assert body["runs_observed"] == 2
+
+
+def test_workers_health_fails_closed_when_operational_access_unconfigured(
+    api_client, monkeypatch
+) -> None:
+    """v2.3 (P0, ADR-027): global worker health reads a *cross-tenant* operational
+    connection. When it is not configured the surface degrades to an actionable,
+    non-fatal state — never a 500, never a falsely-healthy empty view, never a
+    fallback onto the tenant-scoped RLS connection."""
+    import app.workers.orchestrator as orch
+    from app.db.entities import OperationalAccessUnavailable
+
+    client, _repo = api_client
+
+    def _unconfigured(*_a, **_k):
+        raise OperationalAccessUnavailable("no operational role configured")
+
+    monkeypatch.setattr(orch, "summarize_runtime_health", _unconfigured)
+
+    body = client.get("/healthz/workers").json()
+    assert body["healthy"] is None  # not True (falsely healthy) and not False (crash)
+    assert body["detail"] == "operational access not configured"

--- a/services/api/tests/test_worker_locks.py
+++ b/services/api/tests/test_worker_locks.py
@@ -17,6 +17,21 @@ def test_scope_key_is_tenant_user() -> None:
     assert scope_key("t1", "u1") == "t1:u1"
 
 
+def test_operational_health_read_observes_leased_run(repo) -> None:
+    """v2.3 (ADR-027): the new cross-tenant *operational* run-history read
+    (`list_worker_runs_operational`) and worker leasing coexist — a run recorded
+    while a lease is held is visible to the global health view. Leasing prevents
+    duplicate runs; the operational read reports them, on separate paths."""
+    from app.db.entities import WorkerRunRecord
+
+    mgr = _mgr(repo, "worker-a")
+    assert mgr.acquire("t1:u1", now=NOW) is True
+    repo.add_worker_run(WorkerRunRecord(tenant_id="t1", user_id="u1", status="completed"))
+
+    observed = repo.list_worker_runs_operational()
+    assert any(r.tenant_id == "t1" and r.status == "completed" for r in observed)
+
+
 def test_second_owner_cannot_acquire_live_lease(repo) -> None:
     a = _mgr(repo, "worker-a")
     b = _mgr(repo, "worker-b")


### PR DESCRIPTION
## Summary

Closes the P0s from the latest review: the gap between the auditability **claim** and the transaction **boundary** under partial failure. Every lifecycle mutation and its audit event now commit as one atomic unit of work, the audit hash-chain can't fork under concurrency, and global worker health no longer reads "unavailable" — without weakening tenant RLS.

## P0 fixes

- **Atomic mutation + audit.** Wired `repo.transaction()` into every mutation-plus-evidence path: `write_service.commit` (save/update/merge), memories PATCH (approve/reject/archive/edit) and DELETE (soft-delete + tombstone), and the retention routes (legal-hold/pin/protect/consent). A crash between the memory write and its audit event can no longer persist one without the other. Embeddings are computed *before* the transaction opens.
  - **Rollback correctness fix:** the PATCH + retention routes mutated the memory object *before* opening the transaction; since the in-memory backend returns the live stored row, the snapshot was taken too late and a failed audit did not roll back. Mutations were moved inside the transaction. Caught by a new governance-API atomicity test.
- **Fork-proof audit chain.** New per-tenant `audit_chain_heads` table (migration 011) locked with `SELECT ... FOR UPDATE` while a new event links and advances the head; the in-memory backend uses an equivalent per-repo lock. Concurrent audited mutations serialize onto one continuous chain.
- **Worker-health regression.** `summarize_runtime_health` called `list_worker_runs()` unscoped, which the (correctly) tenant-scoped Postgres method now rejects. Global health now reads via an explicit cross-tenant **operational** connection (`OPERATIONAL_DATABASE_URL`, a monitoring role), fail-closed and clearly reported when unconfigured — never the request-scoped RLS engine.

## Documentation consistency

- README: real-model extraction claim (measured — gemini-2.5-flash 0.94/0.94/0.94, 0 fallbacks) + auditability wording.
- RELEASING.md: publish auth prefers `PYPI_API_TOKEN`, falls back to OIDC (matches the workflow); hardening intent noted.
- CHANGELOG: post-v2.2 "Unreleased" section.
- ADR-027 (new) + amendments to security.md, api-contracts.md, worker-runtime.md, memory-control-plane.md, ADR-012.

## Evidence

- New `tests/test_transactional_evidence.py`: rollback (neither side survives a partial failure) + 40-way concurrent chain continuity.
- Atomicity / isolation tests added to `test_deletion.py`, `test_governance_api.py`, `test_memory_write_loop.py`, `test_worker_health.py`, `test_worker_locks.py`, `test_tenant_isolation.py`.
- **Full API suite: 412 passed, 3 skipped.**
- **PR invariant evidence gate: PASS** (17 armed rules satisfied).

## Not in this PR (deliberately)

Version bump + PyPI publish are held until this merges to main (per RELEASING.md). Schema advances to `011_audit_chain_heads`; Postgres refuses to start until it's applied.