### PR TITLE
feat(v2.3): production guardrails — fail-closed profile + dependency-aware readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,23 @@
 # ── MemoryOps AI environment ─────────────────────────────────────────────────
 
+# Deployment profile. "dev" (default) keeps demo-friendly defaults so the app
+# runs with no infra. "production" is FAIL-CLOSED: the API refuses to start while
+# storage is in-memory, auth is off, CORS is "*", the DSN uses demo/localhost
+# credentials, or public evals are enabled. Only set this once every value below
+# is production-safe. See docs/production-readiness.md.
+MEMORYOPS_PROFILE=dev
+
+# Auth adapter: none | trusted_header | jwt. "none" trusts caller-supplied scope
+# (fine behind your own gateway); production rejects "none".
+MEMORYOPS_AUTH_MODE=none
+
+# CORS allow-list. "*" is fine for the demo but is rejected under the production
+# profile. Comma-separated origins, e.g. https://app.example.com,https://admin.example.com
+MEMORYOPS_CORS_ALLOW_ORIGINS=*
+
+# Public eval trigger (denial-of-wallet risk if exposed). Keep false in production.
+MEMORYOPS_PUBLIC_EVALS=false
+
 # Storage backend for the API: "memory" (no infra) or "postgres"
 MEMORYOPS_STORAGE=postgres
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ Closes the gap between the auditability *claim* and the transaction *boundary*:
   fail-closed and clearly reported when unconfigured — never weakening tenant RLS.
 - **Teeth**: `tests/test_transactional_evidence.py` proves rollback (neither side
   survives a partial failure) and chain continuity under 40 concurrent appends.
+- **Production profile (fail-closed startup)**: `MEMORYOPS_PROFILE=production` makes
+  the demo-friendly defaults hard startup errors — the API refuses to boot while the
+  store is in-memory, auth is off, CORS is open (`*`), the DSN uses the bundled demo
+  credentials, or the public-eval trigger is enabled. `MEMORYOPS_CORS_ALLOW_ORIGINS`
+  now drives the real CORS allow-list. `dev` is unchanged. See
+  `Settings.production_readiness_errors()` + `tests/test_production_profile.py`.
+- **Dependency-specific readiness**: `GET /readyz` now reports per-dependency states
+  (`storage`, `schema`, `vector_backend`, `worker_runtime`, `llm_provider`,
+  `embedding_provider`) — each `ok`/`skipped`/`error` — instead of one combined
+  detail string; `ready` is false iff a dependency is in `error`. All probes no-throw.
 
 ## v2.2 — Public Benchmark + Examples
 Additive under the `1.x` compatibility promise. Turns MemoryOps' *measured* governance

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -17,7 +17,7 @@ For the inverse (what is *not* claimed), see [limitations.md](limitations.md).
 | 4 | Graceful degradation | Retrieval failure degrades to keyword-only; workers never raise into chat |
 | 5 | Policy-before-storage | Policy broker runs before any write; LLM output is advisory |
 | 6 | Temporary chat | `temporary_chat=true` reads/writes nothing |
-| 7 | Auditability | Every lifecycle action appends an append-only audit event |
+| 7 | Auditability | Every lifecycle mutation and its audit event commit atomically in one `repo.transaction()` (append-only, fork-proof; ADR-027) |
 
 ## Cross-cutting planes
 
@@ -47,10 +47,35 @@ For the inverse (what is *not* claimed), see [limitations.md](limitations.md).
 | Workers | Lease/scheduler runtime (`services/worker`) | One-shot `runner.py` invocations |
 | Client | Typed Python SDK (`memoryops-sdk`) | Example scripts |
 
+## Production profile (fail-closed startup)
+
+The defaults are demo-friendly so the app runs with zero infra (in-memory store,
+`auth_mode=none`, open CORS). Set **`MEMORYOPS_PROFILE=production`** on real
+deployments: the API then **refuses to start** while any of those insecure defaults
+remain, instead of silently serving production traffic with them. It rejects:
+
+| Rejected setting | Fix |
+|------------------|-----|
+| `MEMORYOPS_STORAGE=memory` (no durability, no RLS) | `MEMORYOPS_STORAGE=postgres` |
+| `MEMORYOPS_AUTH_MODE=none` (unauthenticated) | `MEMORYOPS_AUTH_MODE=jwt` \| `trusted_header` |
+| open CORS (`*`) | `MEMORYOPS_CORS_ALLOW_ORIGINS=https://app.example.com,…` |
+| bundled demo DB credentials / `localhost` DSN | real `MEMORYOPS_DATABASE_URL` / `DATABASE_URL` |
+| `MEMORYOPS_PUBLIC_EVALS=true` (denial-of-wallet) | `MEMORYOPS_PUBLIC_EVALS=false` |
+
+The check is enforced only under the production profile (`dev` is unchanged) and is
+implemented in `Settings.production_readiness_errors()` — see `tests/test_production_profile.py`.
+
+**Readiness** (`GET /readyz`) reports **dependency-specific** states rather than one
+combined string: `storage`, `schema` (migration revision), `vector_backend`,
+`worker_runtime`, `llm_provider`, `embedding_provider` — each `ok` / `skipped` /
+`error`. `ready` is false iff any dependency is in `error` (a `skipped` backend that
+isn't selected never blocks readiness). Every probe is no-throw (invariant #4).
+
 ## Deploying
 
 Railway-only: one project, five core services (web/api/worker + Postgres + Redis).
-Run migrations from `infra/db/migrations`; set `MEMORYOPS_STORAGE=postgres`.
+Run migrations from `infra/db/migrations`; set `MEMORYOPS_STORAGE=postgres` and
+`MEMORYOPS_PROFILE=production`.
 Configure authentication: either enable a built-in auth adapter
 (`MEMORYOPS_AUTH_MODE=jwt` or `trusted_header`, which verify identity and enforce
 tenant/user scope — see [auth-adapters.md](auth-adapters.md)), or, with the default

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -18,6 +18,19 @@ class Settings(BaseSettings):
     service_name: str = "memoryops-api"
     log_level: str = "INFO"
 
+    # Deployment profile (v2.3). "dev" keeps the demo-friendly defaults (in-memory
+    # store, auth off, open CORS) so the app runs with no infra. "production" turns
+    # those same defaults into *fail-closed startup errors*: the app refuses to boot
+    # until storage, auth, CORS, credentials, and the public-eval trigger are set to
+    # safe values (see `production_readiness_errors`). Set MEMORYOPS_PROFILE=production
+    # on real deployments. See docs/production-readiness.md.
+    profile: Literal["dev", "production"] = "dev"
+
+    # CORS allow-list. "*" (default) is fine for the public demo but is rejected under
+    # the production profile. Comma-separated origins, e.g.
+    # "https://app.example.com,https://admin.example.com".
+    cors_allow_origins: str = "*"
+
     # Public eval trigger (security). POST /api/evals/run executes the full eval
     # harness on demand — a denial-of-wallet / compute-abuse vector if exposed
     # unauthenticated on a public deployment. OFF by default: the trigger returns
@@ -224,6 +237,57 @@ class Settings(BaseSettings):
     circuit_breaker_threshold: int = 5
     circuit_breaker_reset_seconds: float = 30.0
 
+    # ── derived helpers ──────────────────────────────────────────────────────
+    def cors_origins_list(self) -> list[str]:
+        """CORS allow-list as a list. '*' stays a single wildcard entry."""
+        raw = self.cors_allow_origins.strip()
+        if not raw or raw == "*":
+            return ["*"]
+        return [o.strip() for o in raw.split(",") if o.strip()]
+
+    def production_readiness_errors(self) -> list[str]:
+        """Fail-closed startup checks for the production profile.
+
+        Returns a list of human-readable violations. Empty means the current
+        settings are safe to serve production traffic. This is intentionally
+        conservative: every insecure *default* that is convenient for the demo is
+        a hard error here, so a real deployment cannot silently inherit them.
+        Only enforced when ``profile == "production"``; callers should no-op
+        otherwise. See docs/production-readiness.md and invariants #1/#5.
+        """
+        if self.profile != "production":
+            return []
+        errors: list[str] = []
+        if self.storage != "postgres":
+            errors.append(
+                f"storage={self.storage!r}: the in-memory store loses all data on "
+                "restart and has no RLS — set MEMORYOPS_STORAGE=postgres."
+            )
+        if self.auth_mode == "none":
+            errors.append(
+                "auth_mode='none': every request would be trusted unauthenticated — "
+                "set MEMORYOPS_AUTH_MODE=trusted_header|jwt."
+            )
+        if "*" in self.cors_origins_list():
+            errors.append(
+                "cors_allow_origins='*': any origin could call the API from a browser — "
+                "set MEMORYOPS_CORS_ALLOW_ORIGINS to an explicit allow-list."
+            )
+        # Demo credentials shipped in the default database_url must never reach prod.
+        if self.storage == "postgres" and (
+            "memoryops:memoryops@" in self.database_url or "@localhost" in self.database_url
+        ):
+            errors.append(
+                "database_url uses the bundled demo credentials / localhost — "
+                "point MEMORYOPS_DATABASE_URL / DATABASE_URL at the real database."
+            )
+        if self.public_evals:
+            errors.append(
+                "public_evals=true: the eval trigger is a denial-of-wallet vector when "
+                "public — set MEMORYOPS_PUBLIC_EVALS=false."
+            )
+        return errors
+
 
 @lru_cache
 def get_settings() -> Settings:
@@ -285,6 +349,14 @@ def get_settings() -> Settings:
         overrides["output_gate_mode"] = val
     if (val := os.getenv("MEMORYOPS_STORAGE")) in ("memory", "postgres"):
         overrides["storage"] = val
+    # v2.3 deployment profile + CORS allow-list. Public operator knobs.
+    if (val := os.getenv("MEMORYOPS_PROFILE")) in ("dev", "production"):
+        overrides["profile"] = val
+    if (val := os.getenv("MEMORYOPS_CORS_ALLOW_ORIGINS")) is not None:
+        overrides["cors_allow_origins"] = val
+    # Honor the conventional DATABASE_URL (Railway/Heroku-style) if MEMORYOPS_* unset.
+    if (val := os.getenv("MEMORYOPS_DATABASE_URL") or os.getenv("DATABASE_URL")):
+        overrides["database_url"] = val
     # v1.7 pluggable vector index (ADR-021). Public operator toggles; default "memory".
     if (val := os.getenv("MEMORYOPS_VECTOR_INDEX")) in ("memory", "qdrant", "lancedb", "weaviate"):
         overrides["vector_index"] = val

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -36,6 +36,21 @@ settings = get_settings()
 setup_logging(settings.log_level)
 logger = get_logger("memoryops.http")
 
+# Fail-closed production guard (v2.3). Under MEMORYOPS_PROFILE=production the
+# demo-friendly defaults (in-memory store, auth off, open CORS, demo creds,
+# public evals) become hard startup errors — the process refuses to boot rather
+# than silently serve production traffic with dev defaults. No-op for "dev".
+_prod_errors = settings.production_readiness_errors()
+if _prod_errors:
+    logger.error(
+        "refusing to start under MEMORYOPS_PROFILE=production",
+        extra={"event": "startup_blocked", "violations": _prod_errors},
+    )
+    raise RuntimeError(
+        "MEMORYOPS_PROFILE=production but insecure settings remain:\n  - "
+        + "\n  - ".join(_prod_errors)
+    )
+
 app = FastAPI(
     title="MemoryOps AI API",
     version=__version__,
@@ -44,7 +59,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # tighten per-environment in production
+    allow_origins=settings.cors_origins_list(),  # "*" in dev; explicit list in production
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/services/api/app/routes/health.py
+++ b/services/api/app/routes/health.py
@@ -55,20 +55,88 @@ def workers_health() -> dict:
 
 @router.get("/readyz")
 def readyz() -> dict:
+    """Readiness probe with *dependency-specific* states (v2.3).
+
+    Rather than a single combined detail string, each backing dependency reports
+    its own ``{"status": ok|error|skipped, ...}`` so an operator can see *which*
+    dependency is unhealthy. Every probe is no-throw (invariant #4); the top-level
+    ``ready`` is false iff any dependency is in an ``error`` state (``skipped`` —
+    e.g. a backend not selected — never blocks readiness).
+    """
     settings = get_settings()
-    ready = True
-    detail = "ready"
-    try:
-        # Touch the repository so a misconfigured DB surfaces as not-ready.
-        get_repository().metrics("__readiness_probe__")
-    except Exception as exc:  # noqa: BLE001
-        ready = False
-        detail = f"repository unavailable: {type(exc).__name__}"
+    checks: dict[str, dict] = {
+        "storage": _check_storage(settings),
+        "schema": _check_schema(settings),
+        "vector_backend": _check_vector_backend(settings),
+        "worker_runtime": _check_worker_runtime(settings),
+        "llm_provider": {"status": "ok", "provider": settings.llm_provider},
+        "embedding_provider": {
+            "status": "ok",
+            "provider": settings.embeddings_provider,
+            "dim": settings.embedding_dim,
+        },
+    }
+    ready = all(c["status"] != "error" for c in checks.values())
     return {
         "ready": ready,
+        "profile": settings.profile,
         "storage": settings.storage,
-        "llm_provider": settings.llm_provider,
-        "embeddings_provider": settings.embeddings_provider,
-        "embedding_dim": settings.embedding_dim,
-        "detail": detail,
+        "checks": checks,
     }
+
+
+def _check_storage(settings) -> dict:
+    try:
+        # Touch the repository so a misconfigured DB/pool surfaces as not-ready.
+        get_repository().metrics("__readiness_probe__")
+        return {"status": "ok", "backend": settings.storage}
+    except Exception as exc:  # noqa: BLE001 — readiness must not raise
+        return {"status": "error", "backend": settings.storage, "detail": type(exc).__name__}
+
+
+def _check_schema(settings) -> dict:
+    if settings.storage != "postgres":
+        return {"status": "skipped", "detail": "in-memory store has no schema revision"}
+    # get_repository() validates the applied migration at construction and raises if
+    # outdated; if _check_storage passed, the expected revision is applied.
+    try:
+        from ..db.postgres_repo import _CURRENT_SCHEMA_VERSION
+
+        get_repository()
+        return {"status": "ok", "revision": _CURRENT_SCHEMA_VERSION}
+    except Exception as exc:  # noqa: BLE001 — readiness must not raise
+        return {"status": "error", "detail": type(exc).__name__}
+
+
+def _check_vector_backend(settings) -> dict:
+    if settings.vector_index == "memory":
+        return {"status": "ok", "backend": "memory"}
+    # External backends degrade to keyword-only if unreachable (never fatal), so this
+    # is informational: report the selected backend without failing readiness.
+    return {
+        "status": "ok",
+        "backend": settings.vector_index,
+        "note": "degrades to keyword-only if unreachable",
+    }
+
+
+def _check_worker_runtime(settings) -> dict:
+    if not settings.operational_database_url:
+        return {
+            "status": "skipped",
+            "detail": "operational access not configured (global worker health disabled)",
+        }
+    from ..db.entities import OperationalAccessUnavailable
+    from ..workers.orchestrator import summarize_runtime_health
+
+    try:
+        summary = summarize_runtime_health(get_repository(), limit=1)
+        return {
+            "status": "ok",
+            "dead_letter_count": summary.get("dead_letter_count", 0),
+            "failed_count": summary.get("failed_count", 0),
+        }
+    except OperationalAccessUnavailable:
+        return {"status": "skipped", "detail": "operational access not configured"}
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "error", "detail": type(exc).__name__}

--- a/services/api/tests/test_production_profile.py
+++ b/services/api/tests/test_production_profile.py
@@ -1,0 +1,138 @@
+"""Production profile guard (v2.3).
+
+``Settings.production_readiness_errors()`` turns every demo-friendly *default*
+into a hard error under ``MEMORYOPS_PROFILE=production`` and stays silent when the
+settings are actually safe — and ``app.main`` refuses to import when the guard has
+violations (fail-closed startup). Dependency-specific readiness is covered
+separately in ``test_readiness_probes.py``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from app.core.config import Settings
+
+
+# ── production readiness guard ───────────────────────────────────────────────
+def test_dev_profile_never_errors():
+    # The default (demo) profile must boot with zero infra — no violations.
+    assert Settings().production_readiness_errors() == []
+    assert Settings(storage="memory", auth_mode="none").production_readiness_errors() == []
+
+
+def test_production_profile_rejects_insecure_defaults():
+    errors = Settings(profile="production").production_readiness_errors()
+    blob = " ".join(errors).lower()
+    # in-memory store, auth off, and open CORS are each independently fatal.
+    assert any("storage" in e for e in errors)
+    assert any("auth_mode" in e for e in errors)
+    assert any("cors" in e for e in errors)
+    assert "public_evals" not in blob  # default is already safe
+
+
+def test_production_profile_flags_demo_creds_and_public_evals():
+    errors = Settings(
+        profile="production",
+        storage="postgres",
+        auth_mode="jwt",
+        cors_allow_origins="https://app.example.com",
+        public_evals=True,
+        # still the bundled demo DSN → must be flagged
+    ).production_readiness_errors()
+    assert any("demo credentials" in e or "localhost" in e for e in errors)
+    assert any("public_evals" in e for e in errors)
+
+
+def test_production_profile_passes_when_hardened():
+    safe = Settings(
+        profile="production",
+        storage="postgres",
+        auth_mode="jwt",
+        cors_allow_origins="https://app.example.com,https://admin.example.com",
+        database_url="postgresql+psycopg://real:secret@db.internal:5432/memoryops",
+        public_evals=False,
+    )
+    assert safe.production_readiness_errors() == []
+
+
+def test_cors_origins_parsing():
+    assert Settings(cors_allow_origins="*").cors_origins_list() == ["*"]
+    assert Settings(cors_allow_origins="").cors_origins_list() == ["*"]
+    assert Settings(cors_allow_origins="https://a.com, https://b.com").cors_origins_list() == [
+        "https://a.com",
+        "https://b.com",
+    ]
+
+
+def test_app_refuses_to_import_under_insecure_production_profile():
+    """Fail-closed startup: importing app.main with the production profile and
+    insecure defaults raises rather than serving traffic."""
+    proc = subprocess.run(
+        [sys.executable, "-c", "import app.main"],
+        cwd=_api_dir(),
+        env={**_env(), "MEMORYOPS_PROFILE": "production"},
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "MEMORYOPS_PROFILE=production" in proc.stderr
+
+
+def test_app_imports_under_hardened_production_profile():
+    proc = subprocess.run(
+        [sys.executable, "-c", "import app.main; print('ok')"],
+        cwd=_api_dir(),
+        env={
+            **_env(),
+            "MEMORYOPS_PROFILE": "production",
+            "MEMORYOPS_STORAGE": "postgres",
+            "MEMORYOPS_AUTH_MODE": "trusted_header",
+            "MEMORYOPS_CORS_ALLOW_ORIGINS": "https://app.example.com",
+            "MEMORYOPS_DATABASE_URL": "postgresql+psycopg://real:secret@db.internal:5432/memoryops",
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout
+
+
+# ── DATABASE_URL fallback precedence ─────────────────────────────────────────
+def test_database_url_precedence_is_deterministic(monkeypatch):
+    """MEMORYOPS_DATABASE_URL wins; DATABASE_URL is the fallback; neither → default."""
+    from app.core import config
+
+    def _load(**env):
+        for k in ("MEMORYOPS_DATABASE_URL", "DATABASE_URL"):
+            monkeypatch.delenv(k, raising=False)
+        for k, v in env.items():
+            monkeypatch.setenv(k, v)
+        config.get_settings.cache_clear()
+        return config.get_settings().database_url
+
+    try:
+        prefixed = "postgresql+psycopg://a:b@memoryops-prefixed/db"
+        plain = "postgresql+psycopg://a:b@plain-fallback/db"
+        # Both set → the MEMORYOPS_-prefixed knob takes precedence.
+        assert _load(MEMORYOPS_DATABASE_URL=prefixed, DATABASE_URL=plain) == prefixed
+        # Only the conventional var set → it is honored.
+        assert _load(DATABASE_URL=plain) == plain
+        # Neither set → the built-in default.
+        assert _load() == config.Settings().database_url
+    finally:
+        config.get_settings.cache_clear()
+
+
+def _api_dir() -> str:
+    import pathlib
+
+    return str(pathlib.Path(__file__).resolve().parents[1])
+
+
+def _env() -> dict:
+    import os
+
+    # Inherit PATH/PYTHONPATH etc. but drop any MEMORYOPS_* the caller set.
+    return {k: v for k, v in os.environ.items() if not k.startswith("MEMORYOPS_")}

--- a/services/api/tests/test_readiness_probes.py
+++ b/services/api/tests/test_readiness_probes.py
@@ -1,0 +1,77 @@
+"""Dependency-specific readiness probe (v2.3).
+
+``GET /readyz`` reports one ``{"status": ok|skipped|error}`` per backing
+dependency instead of a single combined string, never raises, and never leaks
+credentials, DSNs, API keys, or raw exception text.
+"""
+
+from __future__ import annotations
+
+import json
+
+_DEPENDENCIES = (
+    "storage",
+    "schema",
+    "vector_backend",
+    "worker_runtime",
+    "llm_provider",
+    "embedding_provider",
+)
+
+
+def test_readyz_reports_per_dependency_states(api_client):
+    client, _repo = api_client
+    r = client.get("/readyz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ready"] is True
+    assert body["profile"] == "dev"
+    checks = body["checks"]
+    for name in _DEPENDENCIES:
+        assert name in checks, name
+        assert checks[name]["status"] in ("ok", "skipped", "error")
+    # In-memory dev store: schema + worker runtime are not applicable → skipped,
+    # not error (an unselected/optional dependency must never block readiness).
+    assert checks["schema"]["status"] == "skipped"
+    assert checks["worker_runtime"]["status"] == "skipped"
+    assert checks["storage"]["status"] == "ok"
+
+
+def test_readyz_error_in_a_required_dependency_sets_not_ready(api_client, monkeypatch):
+    """If a required dependency probe fails, ready=false — but the endpoint still
+    returns 200 with a structured body (no-throw)."""
+    client, _repo = api_client
+    from app.routes import health
+
+    def _boom(_settings):
+        return {"status": "error", "backend": "postgres", "detail": "OperationalError"}
+
+    monkeypatch.setattr(health, "_check_storage", _boom)
+    r = client.get("/readyz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ready"] is False
+    assert body["checks"]["storage"]["status"] == "error"
+
+
+def test_readyz_never_leaks_secrets(api_client, monkeypatch):
+    """Even when a probe fails with a secret-bearing exception, the response must
+    carry only the exception *type*, never its message/DSN/credentials."""
+    client, _repo = api_client
+    from app.routes import health
+
+    secret_dsn = "postgresql+psycopg://admin:SUP3RSECRET@db.internal:5432/prod"
+
+    def _raises(*_a, **_k):
+        raise RuntimeError(f"could not connect to {secret_dsn} apikey=sk-DEADBEEF")
+
+    # Force the real _check_storage to hit a raising repository probe.
+    monkeypatch.setattr(health, "get_repository", _raises)
+    r = client.get("/readyz")
+    assert r.status_code == 200
+    blob = json.dumps(r.json())
+    for secret in ("SUP3RSECRET", "sk-DEADBEEF", secret_dsn, "admin:"):
+        assert secret not in blob
+    # The failing dependency is still reported as an error, by type only.
+    assert r.json()["checks"]["storage"]["status"] == "error"
+    assert r.json()["checks"]["storage"]["detail"] == "RuntimeError"


### PR DESCRIPTION
## Production guardrails (v2.3 follow-through)

The transactional-evidence work (atomic mutation+audit, fork-proof audit chain,
RLS-preserving operational worker health) already landed on `main` via #76, and the
async-decision doc via #75. This PR adds the two remaining v2.3 items — the
production-safe startup validation and dependency-aware readiness — as focused,
independently reviewable commits.

### 1. Fail-closed production profile — `feat(config)`
`MEMORYOPS_PROFILE=production` turns the demo-friendly defaults into **hard startup
errors**: the API refuses to boot while

- storage is in-memory (no durability, no RLS),
- `auth_mode=none` (unauthenticated),
- CORS is wildcard (`*`),
- the DSN uses the bundled demo/`localhost` credentials, or
- the public-eval trigger is enabled (denial-of-wallet).

Also adds `MEMORYOPS_CORS_ALLOW_ORIGINS` (a real CORS allow-list, replacing the
hardcoded `*`) and a deterministic `DATABASE_URL` fallback
(`MEMORYOPS_DATABASE_URL` > `DATABASE_URL` > default). **`dev` is unchanged** — the
app still runs with zero infra.

### 2. Dependency-specific readiness — `feat(ops)`
`GET /readyz` now reports one `ok`/`skipped`/`error` state **per backing dependency**
(storage, schema revision, vector backend, worker runtime, LLM provider, embedding
provider) instead of a single combined string. `ready` is false iff a dependency is
in `error`; an unselected/optional dependency reports `skipped`, never blocking
readiness. Every probe is no-throw and surfaces only the exception **type** — never
DSNs, credentials, API keys, or raw exception text.

### Acceptance checks (all covered by tests)
- Dev defaults unchanged; production rejects in-memory storage / `auth_mode=none` /
  wildcard CORS / demo-localhost DB / public evals; a fully valid production config boots.
- `/readyz` never throws; a required-dependency failure sets `ready=false`;
  optional/unused dependencies report `skipped`; output never leaks secrets.
- `DATABASE_URL` fallback precedence is deterministic and tested.

Tests: `services/api/tests/test_production_profile.py`,
`services/api/tests/test_readiness_probes.py`. Docs:
`docs/production-readiness.md`, `.env.example`, `CHANGELOG.md`.

> **Railway note:** do **not** set `MEMORYOPS_PROFILE=production` until Postgres
> storage, a valid `DATABASE_URL`, JWT/trusted-header auth, explicit CORS origins,
> and `public_evals=false` are all configured — the guard is deliberately fail-closed
> and will block startup otherwise.
