### PR TITLE
docs(release): finalize v2.3 — Transactional Evidence + Production Guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,39 @@
 All notable releases. Git tags + GitHub Releases are the source of truth; this
 file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
 
-## Unreleased — post-v2.2 hardening
-Additive under the `1.x` compatibility promise. Consolidates the operational and
-evidence hardening that landed after the v2.2 tag but has not yet been cut as a release:
+## v2.3 — Transactional Evidence + Production Guardrails (2026-07-26)
+Additive under the `1.x` compatibility promise. Closes the gap between the
+auditability *claim* and the transaction *boundary*, makes insecure defaults
+fail-closed in production, and consolidates the operational + evidence hardening
+that landed after the v2.2 tag.
 
+### Transactional evidence
+- **Atomic mutation + audit**: every mutation-plus-evidence path (save/update/merge,
+  approve/reject/archive, manual edit, soft-delete + tombstone, legal-hold, pin,
+  protect, consent) now runs inside a single `repo.transaction(...)` — a crash between
+  the memory write and its audit event can no longer persist one without the other.
+- **Fork-proof audit chain**: a tenant-locked `audit_chain_heads` table (migration 011)
+  with `SELECT ... FOR UPDATE` serializes concurrent audited mutations onto one
+  continuous hash chain (the in-memory backend uses an equivalent per-repo lock).
+- **Worker-health regression fixed**: global worker health reads via an explicit
+  cross-tenant *operational* connection (`OPERATIONAL_DATABASE_URL`, a monitoring role),
+  fail-closed and clearly reported when unconfigured — never weakening tenant RLS.
+- **Teeth**: `tests/test_transactional_evidence.py` proves rollback (neither side
+  survives a partial failure) and chain continuity under 40 concurrent appends.
+
+### Production guardrails
+- **Production profile (fail-closed startup)**: `MEMORYOPS_PROFILE=production` makes
+  the demo-friendly defaults hard startup errors — the API refuses to boot while the
+  store is in-memory, auth is off, CORS is open (`*`), the DSN uses the bundled demo
+  credentials, or the public-eval trigger is enabled. `MEMORYOPS_CORS_ALLOW_ORIGINS`
+  now drives the real CORS allow-list. `dev` is unchanged. See
+  `Settings.production_readiness_errors()` + `tests/test_production_profile.py`.
+- **Dependency-specific readiness**: `GET /readyz` now reports per-dependency states
+  (`storage`, `schema`, `vector_backend`, `worker_runtime`, `llm_provider`,
+  `embedding_provider`) — each `ok`/`skipped`/`error` — instead of one combined
+  detail string; `ready` is false iff a dependency is in `error`. All probes no-throw.
+
+### Operational + evidence hardening
 - **SDK published** to PyPI (`memoryops-sdk`) with a tag-only, version-locked
   publish workflow (`.github/workflows/publish-sdk.yml`).
 - **Dependency security fixes**, including the PyJWT/`pyjwt[crypto]` path for the
@@ -22,32 +51,6 @@ evidence hardening that landed after the v2.2 tag but has not yet been cut as a 
 - **Async decision recorded**: defer a blanket async conversion; tune and measure the
   synchronous path against real Postgres/provider workloads first
   (`docs/performance.md`, ADR).
-
-### In progress — v2.3 Transactional Evidence (this branch, not yet tagged)
-Closes the gap between the auditability *claim* and the transaction *boundary*:
-
-- **Atomic mutation + audit**: every mutation-plus-evidence path (save/update/merge,
-  approve/reject/archive, manual edit, soft-delete + tombstone, legal-hold, pin,
-  protect, consent) now runs inside a single `repo.transaction(...)` — a crash between
-  the memory write and its audit event can no longer persist one without the other.
-- **Fork-proof audit chain**: a tenant-locked `audit_chain_heads` table (migration 011)
-  with `SELECT ... FOR UPDATE` serializes concurrent audited mutations onto one
-  continuous hash chain (the in-memory backend uses an equivalent per-repo lock).
-- **Worker-health regression fixed**: global worker health reads via an explicit
-  cross-tenant *operational* connection (`OPERATIONAL_DATABASE_URL`, a monitoring role),
-  fail-closed and clearly reported when unconfigured — never weakening tenant RLS.
-- **Teeth**: `tests/test_transactional_evidence.py` proves rollback (neither side
-  survives a partial failure) and chain continuity under 40 concurrent appends.
-- **Production profile (fail-closed startup)**: `MEMORYOPS_PROFILE=production` makes
-  the demo-friendly defaults hard startup errors — the API refuses to boot while the
-  store is in-memory, auth is off, CORS is open (`*`), the DSN uses the bundled demo
-  credentials, or the public-eval trigger is enabled. `MEMORYOPS_CORS_ALLOW_ORIGINS`
-  now drives the real CORS allow-list. `dev` is unchanged. See
-  `Settings.production_readiness_errors()` + `tests/test_production_profile.py`.
-- **Dependency-specific readiness**: `GET /readyz` now reports per-dependency states
-  (`storage`, `schema`, `vector_backend`, `worker_runtime`, `llm_provider`,
-  `embedding_provider`) — each `ok`/`skipped`/`error` — instead of one combined
-  detail string; `ready` is false iff a dependency is in `error`. All probes no-throw.
 
 ## v2.2 — Public Benchmark + Examples
 Additive under the `1.x` compatibility promise. Turns MemoryOps' *measured* governance

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ governed state, not just a vector database.
 &nbsp;![License](https://img.shields.io/badge/license-MIT-green)
 &nbsp;![API](https://img.shields.io/badge/API%20%2B%20SDK-1.x%20stable-green)
 
-> **Two version tracks:** the **platform release** (`v2.2`, the repo's feature
+> **Two version tracks:** the **platform release** (`v2.3`, the repo's feature
 > milestone) is separate from the **public API + SDK contract** (`1.x`, an additive-
 > compatibility promise). See [docs/api-stability.md](docs/api-stability.md#two-version-tracks).
 
@@ -106,13 +106,15 @@ Postgres + pgvector in CI (the `api-postgres` job). Current
 
 ## What's shipped
 
-All capabilities v1.3 → v2.2 are shipped: Context Admission Gate + Memory Usage Trace,
+All capabilities v1.3 → v2.3 are shipped: Context Admission Gate + Memory Usage Trace,
 deletion-proof tombstone lineage, deleted-memory leakage evals, auth/authorization
 adapters (JWT/JWKS + trusted header), vector-backend abstraction (Postgres/pgvector ·
 in-memory · Qdrant · LanceDB · Weaviate), distributed tracing + Prometheus metrics,
 Recall/Output gates, the Enterprise Evidence Layer (tamper-evident audit + evidence
-bundles), agent-framework integrations, and a public governance benchmark. Details in
-the **[CHANGELOG](CHANGELOG.md)** and **[docs/architecture.md](docs/architecture.md)**.
+bundles), agent-framework integrations, a public governance benchmark, transactional
+mutation+audit with a fork-proof audit chain, and a fail-closed production profile
+(`MEMORYOPS_PROFILE=production`) with dependency-aware readiness. Details in the
+**[CHANGELOG](CHANGELOG.md)** and **[docs/architecture.md](docs/architecture.md)**.
 
 **Adapter honesty:** Postgres/pgvector and in-memory are *fully tested in CI* (suite +
 evals + benchmark + enforced RLS). Qdrant/LanceDB/Weaviate are *contract-tested*.


### PR DESCRIPTION
Release-finalization doc-only PR. Consolidates the post-v2.2 hardening + in-progress v2.3 notes into a single dated `## v2.3` CHANGELOG section, and bumps the README platform-release references `v2.2` → `v2.3`. No code changes — the v2.3 code is already on main (#76, #77). Follows with the `v2.3` tag + GitHub Release.

Release gate (main): pytest rc=0 (2 skipped), ruff clean, `evals/run_evals.py` PASS.