### PR TITLE
docs(v2.3): scope auditability claim to API/governance + restore /readyz compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ Full design, diagrams, and where each invariant is enforced:
 4. **Graceful degradation** — retrieval failure never blocks a response.
 5. **Policy-before-storage** — unsafe/secret-like content is filtered before storage.
 6. **Temporary chat** — temporary sessions never read or write memory.
-7. **Auditability** — every lifecycle mutation and its audit event commit together in
-   one transaction (atomic under partial failure), as an append-only, tamper-evident chain.
+7. **Auditability** — user-facing and governance-API mutations commit atomically with
+   their audit evidence in one transaction, as an append-only, tamper-evident chain.
+   Background lifecycle-worker transaction hardening remains in progress.
 8. **Explainability** — the system can show which memories affected a response.
 9. **Typed memory** — episodic/semantic/procedural/project/knowledge/system differ.
 10. **Evaluation** — memory quality is testable via a golden set, not manual inspection.

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -202,7 +202,14 @@ See [docs/enterprise-evidence.md](enterprise-evidence.md), ADR-024.
   (v2.3, ADR-027). When that connection is unconfigured it returns
   `{ healthy: null, detail: "operational access not configured", hint: … }` — an
   actionable, non-fatal state, not a `500`.
-- `GET /readyz` → `{ ready, storage, llm_provider, embeddings_provider, embedding_dim, detail }`
+- `GET /readyz` → `{ ready, profile, storage, llm_provider, embeddings_provider,
+  embedding_dim, detail, checks }` (v2.3). `checks` is a per-dependency map —
+  `storage`, `schema`, `vector_backend`, `worker_runtime`, `llm_provider`,
+  `embedding_provider` — each `{ status: ok|skipped|error, … }`; `ready` is false iff
+  any dependency is in `error` (a `skipped`, unselected backend never blocks it). The
+  pre-v2.3 top-level fields (`storage`, `llm_provider`, `embeddings_provider`,
+  `embedding_dim`, `detail`) are **retained** alongside `profile`/`checks` so the
+  response stays additive under the `1.x` promise. Every probe is no-throw.
 - `GET /metrics` → **Prometheus text exposition** (v1.1; format `0.0.4`). Process-wide,
   content-free, low-cardinality (no `tenant_id`/`user_id` labels): HTTP traffic,
   retrieval latency/mode, policy-decision rate, worker run counts. Toggle with

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -11,10 +11,10 @@ questions and move independently, so a single number would be misleading:
 
 | Track | Where it lives | Current | Meaning |
 |-------|----------------|---------|---------|
-| **Platform release** | git tags `vX.Y`, the README release badge, `CHANGELOG.md` | **v2.2** | "What shipped" — the feature-set milestone of the whole repo (API + workers + SDK + docs + demos). |
+| **Platform release** | git tags `vX.Y`, the README release badge, `CHANGELOG.md` | **v2.3** | "What shipped" — the feature-set milestone of the whole repo (API + workers + SDK + docs + demos). |
 | **Public API + SDK contract** | `app.__version__`, `packages/memoryops-sdk` `version` | **1.0.0** | The compatibility promise of the public HTTP API and Python SDK. Stays `1.x` as long as the surface is additive-compatible. |
 
-So platform **v2.2** ships the **1.0.0** API/SDK contract: the milestone counter has
+So platform **v2.3** ships the **1.0.0** API/SDK contract: the milestone counter has
 advanced through many feature phases while the *public surface* has only grown
 additively and so remains `1.x`. `app.__version__` and the SDK package version are
 kept in lock-step; the platform milestone is independent.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -71,13 +71,15 @@ re-deriving their own caveats.
   **Langfuse** LLM-trace integration) is left to the operator, not in the box.
 - Workers run on a thin lease/scheduler runtime, not Celery/Temporal; there is no
   external queue/broker.
-- **Write + audit are not yet a single transaction.** On the Postgres backend the
-  memory write (`create_memory`) and its audit event (`add_audit`) commit separately,
-  so a process crash *between* them could leave a stored memory without its audit row
-  (an invariant #7 gap under partial failure — surfaced by `tests/test_chaos.py`). The
-  happy path always audits; the fix is a repository unit-of-work that spans both
-  writes, tracked for a future release. Retrieval/degradation and the deletion
-  guarantee are already proven under injected failure (`tests/test_chaos.py`).
+- **API + governance mutations commit atomically with their audit evidence** (v2.3,
+  ADR-027): each write path runs inside one `repo.transaction(...)`, so a crash between
+  the memory write (`create_memory`) and its audit event (`add_audit`) can no longer
+  persist one without the other, and the audit hash chain is fork-proof under
+  concurrency. **Background lifecycle workers still mutate then audit separately** —
+  decay/archive/retention/deletion-compaction do not yet share a single transaction
+  boundary — so the invariant #7 partial-failure gap remains *on the worker paths only*,
+  tracked as the next hardening item. Retrieval/degradation and the deletion guarantee
+  are already proven under injected failure (`tests/test_chaos.py`).
 
 ## Demo surfaces
 

--- a/services/api/app/__init__.py
+++ b/services/api/app/__init__.py
@@ -2,5 +2,5 @@
 
 # Public API-contract version (the `1.x` stable surface), kept in lock-step with the
 # SDK's package version. This is NOT the platform release milestone (git tags `vX.Y`,
-# e.g. v2.2) — see docs/api-stability.md "Two version tracks".
+# e.g. v2.3) — see docs/api-stability.md "Two version tracks".
 __version__ = "1.0.0"

--- a/services/api/app/routes/health.py
+++ b/services/api/app/routes/health.py
@@ -62,6 +62,11 @@ def readyz() -> dict:
     dependency is unhealthy. Every probe is no-throw (invariant #4); the top-level
     ``ready`` is false iff any dependency is in an ``error`` state (``skipped`` —
     e.g. a backend not selected — never blocks readiness).
+
+    The pre-v2.3 top-level fields (``storage``, ``llm_provider``,
+    ``embeddings_provider``, ``embedding_dim``, ``detail``) are retained alongside the
+    new ``profile`` + ``checks`` so the response stays additive under the ``1.x``
+    compatibility promise — existing consumers keep working, new ones read ``checks``.
     """
     settings = get_settings()
     checks: dict[str, dict] = {
@@ -77,10 +82,18 @@ def readyz() -> dict:
         },
     }
     ready = all(c["status"] != "error" for c in checks.values())
+    errored = [name for name, c in checks.items() if c["status"] == "error"]
+    detail = "ready" if ready else "not ready: " + ", ".join(errored)
     return {
         "ready": ready,
         "profile": settings.profile,
+        # ── retained pre-v2.3 top-level fields (additive-compat) ──────────────
         "storage": settings.storage,
+        "llm_provider": settings.llm_provider,
+        "embeddings_provider": settings.embeddings_provider,
+        "embedding_dim": settings.embedding_dim,
+        "detail": detail,
+        # ── v2.3 dependency-specific view ─────────────────────────────────────
         "checks": checks,
     }
 

--- a/services/api/tests/test_readiness_probes.py
+++ b/services/api/tests/test_readiness_probes.py
@@ -37,6 +37,18 @@ def test_readyz_reports_per_dependency_states(api_client):
     assert checks["storage"]["status"] == "ok"
 
 
+def test_readyz_retains_legacy_top_level_fields(api_client):
+    """1.x additive-compat: the pre-v2.3 top-level fields are still present alongside
+    the new ``profile`` + ``checks`` (responses only gain fields, never lose them)."""
+    client, _repo = api_client
+    body = client.get("/readyz").json()
+    for legacy in ("ready", "storage", "llm_provider", "embeddings_provider",
+                   "embedding_dim", "detail"):
+        assert legacy in body, legacy
+    assert body["detail"] == "ready"  # nothing errored in the dev stack
+    assert isinstance(body["embedding_dim"], int)
+
+
 def test_readyz_error_in_a_required_dependency_sets_not_ready(api_client, monkeypatch):
     """If a required dependency probe fails, ready=false — but the endpoint still
     returns 200 with a structured body (no-throw)."""


### PR DESCRIPTION
## v2.3 scope corrections (docs) + `/readyz` compat restore

Follow-up to v2.3. The release wording overstated one boundary and its `/readyz`
change dropped documented fields. No new features; the `v2.3` tag/release is
untouched.

### The overstatement
v2.3 said *"every lifecycle mutation and its audit event commit together in one
transaction."* That is true for the **chat write-service and the API governance
routes**, but the **background lifecycle workers still mutate then audit
separately** (decay/archive/retention/deletion-compaction). Corrected:

- **README** invariant #7 — scoped to user-facing/governance-API mutations; notes
  worker transaction hardening is in progress.
- **docs/limitations.md** — replaces the now-stale "write+audit not a single
  transaction" gap with the accurate split (API/governance done via `repo.transaction`
  + fork-proof chain; workers pending).
- **docs/api-stability.md** + **app/__init__.py** comment — platform release `v2.2` → `v2.3`.

### `/readyz` additive-compat (the one code change)
v2.3 replaced the flat `/readyz` body with `{ ready, profile, storage, checks }`,
which **removed** `llm_provider`, `embeddings_provider`, `embedding_dim`, and `detail`
— a non-additive change to a documented response under the `1.x` promise. This PR
**restores those top-level fields alongside** `profile`/`checks` (superset, nothing
removed) and documents the real shape in **docs/api-contracts.md**. New test:
`test_readyz_retains_legacy_top_level_fields`.

### Validation
`pytest -q` green (full suite), `ruff check app` clean.

> Worker mutation atomicity (wrapping each worker mutate+audit in `repo.transaction`)
> is the first real implementation item after this — tracked separately.
