### PR TITLE
feat(workers): commit each worker mutation and its audit atomically (closes #80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable releases. Git tags + GitHub Releases are the source of truth; this
 file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
 
+## Unreleased — worker mutation atomicity
+Additive; completes invariant #7 across the whole system.
+
+- **Background workers now commit mutation + audit atomically.** v2.3 made the
+  API/governance write paths transactional but the lifecycle workers still mutated
+  memory and then wrote the audit event as two separate commits. `LifecycleWorker._atomic`
+  now wraps each worker's mutation and its audit evidence in one `repo.transaction(...)`
+  — opened *before* the in-place mutation so the in-memory backend's rollback snapshot
+  predates it. Covers decay, archive, retention (held + expired/consent soft-delete),
+  and deletion-compaction (destructive content/vector clear + evidence);
+  verification/conflict-scan/reflection are audit-only. Proven by
+  `tests/test_worker_atomicity.py` (injected audit failure → neither the mutation nor
+  its evidence survives). README/limitations/CLAUDE invariant #7 updated to reflect that
+  the guarantee now holds on the worker paths too.
+
 ## v2.3 — Transactional Evidence + Production Guardrails (2026-07-26)
 Additive under the `1.x` compatibility promise. Closes the gap between the
 auditability *claim* and the transaction *boundary*, makes insecure defaults

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,8 @@ wrapped by Security, Governance, Observability, Reliability, Evaluation planes.
 5. Policy-before-storage — the policy broker runs before any write.
 6. Temporary chat — `temporary_chat=true` writes/reads nothing.
 7. Auditability — every lifecycle mutation and its audit event commit atomically in one
-   `repo.transaction()` (append-only, tamper-evident, fork-proof under concurrency; ADR-027).
+   `repo.transaction()`, across both the API/governance write paths and the background
+   lifecycle workers (append-only, tamper-evident, fork-proof under concurrency; ADR-027).
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ Full design, diagrams, and where each invariant is enforced:
 4. **Graceful degradation** — retrieval failure never blocks a response.
 5. **Policy-before-storage** — unsafe/secret-like content is filtered before storage.
 6. **Temporary chat** — temporary sessions never read or write memory.
-7. **Auditability** — user-facing and governance-API mutations commit atomically with
-   their audit evidence in one transaction, as an append-only, tamper-evident chain.
-   Background lifecycle-worker transaction hardening remains in progress.
+7. **Auditability** — every lifecycle mutation and its audit event commit together in
+   one transaction, across both the API/governance write paths and the background
+   lifecycle workers, as an append-only, tamper-evident chain.
 8. **Explainability** — the system can show which memories affected a response.
 9. **Typed memory** — episodic/semantic/procedural/project/knowledge/system differ.
 10. **Evaluation** — memory quality is testable via a golden set, not manual inspection.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -71,15 +71,15 @@ re-deriving their own caveats.
   **Langfuse** LLM-trace integration) is left to the operator, not in the box.
 - Workers run on a thin lease/scheduler runtime, not Celery/Temporal; there is no
   external queue/broker.
-- **API + governance mutations commit atomically with their audit evidence** (v2.3,
-  ADR-027): each write path runs inside one `repo.transaction(...)`, so a crash between
-  the memory write (`create_memory`) and its audit event (`add_audit`) can no longer
-  persist one without the other, and the audit hash chain is fork-proof under
-  concurrency. **Background lifecycle workers still mutate then audit separately** —
-  decay/archive/retention/deletion-compaction do not yet share a single transaction
-  boundary — so the invariant #7 partial-failure gap remains *on the worker paths only*,
-  tracked as the next hardening item. Retrieval/degradation and the deletion guarantee
-  are already proven under injected failure (`tests/test_chaos.py`).
+- **Mutation + audit atomicity is complete** (v2.3, ADR-027) — no longer a gap. Every
+  write path runs inside one `repo.transaction(...)`, so a crash between the memory
+  write (`create_memory`) and its audit event (`add_audit`) can no longer persist one
+  without the other, and the audit hash chain is fork-proof under concurrency. This now
+  covers **both** the API/governance routes **and** the background lifecycle workers
+  (decay/archive/retention/deletion-compaction), each proven by injected-failure
+  rollback tests (`tests/test_worker_atomicity.py`, `tests/test_transactional_evidence.py`).
+  Retrieval/degradation and the deletion guarantee are likewise proven under injected
+  failure (`tests/test_chaos.py`).
 
 ## Demo surfaces
 

--- a/services/api/app/workers/archive.py
+++ b/services/api/app/workers/archive.py
@@ -101,18 +101,21 @@ class ArchiveWorker(LifecycleWorker):
                 result.changed_count += 1  # candidate proposed
                 continue
 
-            memory.status = Status.archived
-            memory.archived_at = ctx.now
-            set_lifecycle_meta(memory, {"archived_by_worker": True})
-            self._repo.update_memory(memory)
-            event = self._audit.record(
-                tenant_id=ctx.tenant_id,
-                user_id=ctx.user_id,
-                action=MEMORY_ARCHIVED_BY_WORKER,
-                reason="stale memory archived by lifecycle worker",
-                memory_id=memory.id,
-                trace_id=ctx.trace_id,
-                metadata={"age_days": age_days(memory, ctx.now)},
-            )
+            # Atomic (invariant #7): archival + its audit event commit together;
+            # opened before the in-place mutation (see LifecycleWorker._atomic).
+            with self._atomic(ctx):
+                memory.status = Status.archived
+                memory.archived_at = ctx.now
+                set_lifecycle_meta(memory, {"archived_by_worker": True})
+                self._repo.update_memory(memory)
+                event = self._audit.record(
+                    tenant_id=ctx.tenant_id,
+                    user_id=ctx.user_id,
+                    action=MEMORY_ARCHIVED_BY_WORKER,
+                    reason="stale memory archived by lifecycle worker",
+                    memory_id=memory.id,
+                    trace_id=ctx.trace_id,
+                    metadata={"age_days": age_days(memory, ctx.now)},
+                )
             result.audit_event_ids.append(event.id)
             result.changed_count += 1

--- a/services/api/app/workers/decay.py
+++ b/services/api/app/workers/decay.py
@@ -75,25 +75,30 @@ class DecayWorker(LifecycleWorker):
                 result.skipped_count += 1
                 continue
 
-            memory.importance = new_importance
-            set_lifecycle_meta(
-                memory,
-                {"decayed": True, "decay_age_days": age, "decay_from_importance": old_importance},
-            )
-            self._repo.update_memory(memory)
-            event = self._audit.record(
-                tenant_id=ctx.tenant_id,
-                user_id=ctx.user_id,
-                action=MEMORY_DECAY_APPLIED,
-                reason="importance decayed for aged/low-confidence memory",
-                memory_id=memory.id,
-                trace_id=ctx.trace_id,
-                metadata={
-                    "old_importance": old_importance,
-                    "new_importance": new_importance,
-                    "age_days": age,
-                    "low_confidence": memory.confidence < self._min_confidence,
-                },
-            )
+            # Atomic (invariant #7): the importance change and its audit event
+            # commit together. Opened before the in-place mutation so an in-memory
+            # rollback undoes it (see LifecycleWorker._atomic).
+            with self._atomic(ctx):
+                memory.importance = new_importance
+                set_lifecycle_meta(
+                    memory,
+                    {"decayed": True, "decay_age_days": age,
+                     "decay_from_importance": old_importance},
+                )
+                self._repo.update_memory(memory)
+                event = self._audit.record(
+                    tenant_id=ctx.tenant_id,
+                    user_id=ctx.user_id,
+                    action=MEMORY_DECAY_APPLIED,
+                    reason="importance decayed for aged/low-confidence memory",
+                    memory_id=memory.id,
+                    trace_id=ctx.trace_id,
+                    metadata={
+                        "old_importance": old_importance,
+                        "new_importance": new_importance,
+                        "age_days": age,
+                        "low_confidence": memory.confidence < self._min_confidence,
+                    },
+                )
             result.audit_event_ids.append(event.id)
             result.changed_count += 1

--- a/services/api/app/workers/deletion_compaction.py
+++ b/services/api/app/workers/deletion_compaction.py
@@ -127,13 +127,41 @@ class DeletionCompactionWorker(LifecycleWorker):
                 result.changed_count += 1  # candidate only; nothing cleared
                 continue
 
-            row = self._repo.compact_deleted_memory(
-                ctx.tenant_id,
-                ctx.user_id,
-                memory.id,
-                reason=_COMPACTION_REASON,
-                now=ctx.now,
-            )
+            # Atomic (invariant #7): the destructive content/vector clear and its
+            # primary evidence (content-compacted + vector-purge-attempted) commit
+            # together — a crash can't clear content without recording that it did.
+            # The read-back verification below is separate (it audits a check, not a
+            # mutation).
+            with self._atomic(ctx):
+                row = self._repo.compact_deleted_memory(
+                    ctx.tenant_id,
+                    ctx.user_id,
+                    memory.id,
+                    reason=_COMPACTION_REASON,
+                    now=ctx.now,
+                )
+                if row is not None:
+                    result.audit_event_ids.append(
+                        self._audit.record(
+                            tenant_id=ctx.tenant_id,
+                            user_id=ctx.user_id,
+                            action=MEMORY_CONTENT_COMPACTED,
+                            reason="retrievable content cleared for soft-deleted memory",
+                            memory_id=memory.id,
+                            trace_id=ctx.trace_id,
+                            metadata={"deleted_age_days": self._deleted_age_days(memory, ctx.now)},
+                        ).id
+                    )
+                    result.audit_event_ids.append(
+                        self._audit.record(
+                            tenant_id=ctx.tenant_id,
+                            user_id=ctx.user_id,
+                            action=MEMORY_VECTOR_PURGE_ATTEMPTED,
+                            reason="vector material cleared; verifying exclusion",
+                            memory_id=memory.id,
+                            trace_id=ctx.trace_id,
+                        ).id
+                    )
             if row is None:
                 # Lost a race (no longer deleted): skip rather than force.
                 result.skipped_count += 1
@@ -141,27 +169,6 @@ class DeletionCompactionWorker(LifecycleWorker):
 
             compacted += 1
             result.changed_count += 1
-            result.audit_event_ids.append(
-                self._audit.record(
-                    tenant_id=ctx.tenant_id,
-                    user_id=ctx.user_id,
-                    action=MEMORY_CONTENT_COMPACTED,
-                    reason="retrievable content cleared for soft-deleted memory",
-                    memory_id=memory.id,
-                    trace_id=ctx.trace_id,
-                    metadata={"deleted_age_days": self._deleted_age_days(memory, ctx.now)},
-                ).id
-            )
-            result.audit_event_ids.append(
-                self._audit.record(
-                    tenant_id=ctx.tenant_id,
-                    user_id=ctx.user_id,
-                    action=MEMORY_VECTOR_PURGE_ATTEMPTED,
-                    reason="vector material cleared; verifying exclusion",
-                    memory_id=memory.id,
-                    trace_id=ctx.trace_id,
-                ).id
-            )
 
             check = verify_purged(
                 self._repo,

--- a/services/api/app/workers/lifecycle.py
+++ b/services/api/app/workers/lifecycle.py
@@ -21,6 +21,8 @@ or create active memory.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
@@ -96,6 +98,24 @@ class LifecycleWorker(ABC):
     # must NOT touch deleted memory and must stay within the ctx scope.
     @abstractmethod
     def _execute(self, ctx: WorkerContext, result: WorkerJobResult) -> None: ...
+
+    @contextmanager
+    def _atomic(self, ctx: WorkerContext) -> Iterator[None]:
+        """Commit a memory mutation and its audit event(s) as one unit (invariant #7).
+
+        Extends the transactional-evidence guarantee (ADR-027) to the background
+        workers: a crash between a worker's mutation and its audit event can no
+        longer persist one without the other. Scope is **per item**, so earlier
+        items in a batch stay committed and a re-run finishes the rest idempotently.
+
+        Open this *before* the first in-place field mutation of the memory object:
+        the in-memory backend's rollback snapshot is taken at ``transaction()`` entry
+        and the store hands back live references, so a mutation made before entry
+        would survive a rollback (mirrors the write path — see write_service). On
+        Postgres it shares one session + commit.
+        """
+        with self._repo.transaction(ctx.tenant_id, ctx.user_id):
+            yield
 
     def run(self, ctx: WorkerContext) -> WorkerJobResult:
         result = WorkerJobResult(

--- a/services/api/app/workers/retention.py
+++ b/services/api/app/workers/retention.py
@@ -90,44 +90,50 @@ class RetentionWorker(LifecycleWorker):
             result.scanned_count += 1
             decision = evaluate(memory, now=ctx.now, policy=self._policy)
 
-            # Stamp the computed window so the API/admin can read it without re-evaluating.
-            gov.set_retention(
-                memory, policy=self._policy.name,
-                expires_at=decision.retention_expires_at, now=ctx.now,
-            )
+            # Each item's decision/outcome audit and its persistence (stamped window
+            # or soft-delete) commit together (invariant #7, ADR-027). The transaction
+            # is opened before `gov.set_retention` mutates the memory in place, so an
+            # in-memory rollback undoes it (see LifecycleWorker._atomic).
+            with self._atomic(ctx):
+                # Stamp the computed window so the API/admin can read it without
+                # re-evaluating.
+                gov.set_retention(
+                    memory, policy=self._policy.name,
+                    expires_at=decision.retention_expires_at, now=ctx.now,
+                )
 
-            if decision.outcome is RetentionOutcome.held:
-                held += 1
-                result.skipped_count += 1
-                self._record_decision(ctx, result, decision, MEMORY_RETENTION_HOLD_RESPECTED)
-                if not preview_only:
-                    self._repo.update_memory(memory)
-                continue
+                if decision.outcome is RetentionOutcome.held:
+                    held += 1
+                    result.skipped_count += 1
+                    self._record_decision(ctx, result, decision, MEMORY_RETENTION_HOLD_RESPECTED)
+                    if not preview_only:
+                        self._repo.update_memory(memory)
+                    continue
 
-            if not decision.eligible_for_deletion:
-                result.skipped_count += 1
-                if not preview_only:
-                    self._repo.update_memory(memory)  # persist stamped retention window
-                continue
+                if not decision.eligible_for_deletion:
+                    result.skipped_count += 1
+                    if not preview_only:
+                        self._repo.update_memory(memory)  # persist stamped window
+                    continue
 
-            # Eligible: expired window or revoked consent.
-            if decision.outcome is RetentionOutcome.expired:
-                expired += 1
-            else:
-                consent_revoked += 1
+                # Eligible: expired window or revoked consent.
+                if decision.outcome is RetentionOutcome.expired:
+                    expired += 1
+                else:
+                    consent_revoked += 1
 
-            self._record_decision(ctx, result, decision, _OUTCOME_ACTION[decision.outcome])
+                self._record_decision(ctx, result, decision, _OUTCOME_ACTION[decision.outcome])
 
-            if preview_only:
-                result.changed_count += 1  # candidate only; nothing deleted
-                continue
+                if preview_only:
+                    result.changed_count += 1  # candidate only; nothing deleted
+                    continue
 
-            row = self._repo.soft_delete(ctx.tenant_id, ctx.user_id, memory.id)
-            if row is None:
-                result.skipped_count += 1
-                continue
-            deleted += 1
-            result.changed_count += 1
+                row = self._repo.soft_delete(ctx.tenant_id, ctx.user_id, memory.id)
+                if row is None:
+                    result.skipped_count += 1
+                    continue
+                deleted += 1
+                result.changed_count += 1
 
         result.details = {
             "policy": self._policy.name,

--- a/services/api/tests/test_worker_atomicity.py
+++ b/services/api/tests/test_worker_atomicity.py
@@ -1,0 +1,133 @@
+"""Worker mutation + audit atomicity (invariant #7 extended to workers).
+
+Each background worker's mutate-then-audit pair now runs inside one
+``repo.transaction(...)``. If the audit write fails *after* the mutation, the
+mutation must roll back too — neither side survives a partial failure. These tests
+inject an audit failure on the specific action a worker emits alongside its
+mutation and assert the store is untouched (no half-applied change, no orphan
+evidence), while unrelated audit actions (worker started/failed) still commit.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.db.entities import StoredAudit
+from app.db.memory_repo import InMemoryRepository
+from app.schemas.memory import Sensitivity, Status
+from app.workers.archive import ArchiveWorker
+from app.workers.decay import DecayWorker
+from app.workers.deletion_compaction import DeletionCompactionWorker
+from app.workers.lifecycle import WorkerContext, lifecycle_meta
+from app.workers.retention import RetentionWorker
+from app.workers.schemas import (
+    MEMORY_ARCHIVED_BY_WORKER,
+    MEMORY_CONTENT_COMPACTED,
+    MEMORY_DECAY_APPLIED,
+    MEMORY_RETENTION_EXPIRED,
+    WorkerRunStatus,
+)
+
+from ._worker_helpers import seed_memory
+
+NOW = datetime(2026, 6, 21, tzinfo=UTC)
+
+
+class _CrashOnAction(InMemoryRepository):
+    """In-memory repo that raises when an audit event of ``action`` is written —
+    simulating a process/store failure *between* a worker's mutation and its audit."""
+
+    def __init__(self, action: str) -> None:
+        super().__init__()
+        self._crash_action = action
+        self.crashed = False
+
+    def add_audit(self, event: StoredAudit) -> StoredAudit:
+        if event.action == self._crash_action:
+            self.crashed = True
+            raise RuntimeError("injected audit failure")
+        return super().add_audit(event)
+
+
+def _ctx(**kw) -> WorkerContext:
+    kw.setdefault("tenant_id", "t1")
+    kw.setdefault("user_id", "u1")
+    kw.setdefault("now", NOW)
+    return WorkerContext(**kw)
+
+
+def _actions_for(repo, memory_id):
+    return [a.action for a in repo.list_audit("t1", "u1", memory_id=memory_id)]
+
+
+# ── decay ────────────────────────────────────────────────────────────────────
+def test_decay_rolls_back_mutation_when_audit_fails() -> None:
+    repo = _CrashOnAction(MEMORY_DECAY_APPLIED)
+    mem = seed_memory(repo, importance=8, age_days=300)
+
+    result = DecayWorker(repo, age_threshold_days=90, importance_step=2).run(_ctx())
+
+    assert repo.crashed
+    assert result.status == WorkerRunStatus.failed.value
+    got = repo.get_memory("t1", "u1", mem.id)
+    assert got.importance == 8  # mutation rolled back — not decayed to 6
+    assert not lifecycle_meta(got).get("decayed")  # marker rolled back too
+    assert MEMORY_DECAY_APPLIED not in _actions_for(repo, mem.id)  # no orphan evidence
+
+
+# ── archive ──────────────────────────────────────────────────────────────────
+def test_archive_rolls_back_mutation_when_audit_fails() -> None:
+    repo = _CrashOnAction(MEMORY_ARCHIVED_BY_WORKER)
+    mem = seed_memory(repo, age_days=400)
+
+    result = ArchiveWorker(repo, age_threshold_days=180).run(_ctx())
+
+    assert repo.crashed
+    assert result.status == WorkerRunStatus.failed.value
+    got = repo.get_memory("t1", "u1", mem.id)
+    assert got.status == Status.active  # not archived — rolled back
+    assert got.archived_at is None
+    assert MEMORY_ARCHIVED_BY_WORKER not in _actions_for(repo, mem.id)
+
+
+# ── retention (soft-delete) ──────────────────────────────────────────────────
+def test_retention_rolls_back_soft_delete_when_audit_fails() -> None:
+    # The expired-outcome audit fails → the soft-delete in the same transaction
+    # must roll back, leaving the memory active (deletion guarantee not tripped by
+    # a half-applied delete).
+    repo = _CrashOnAction(MEMORY_RETENTION_EXPIRED)
+    mem = seed_memory(repo, sensitivity=Sensitivity.high, age_days=200)
+
+    result = RetentionWorker(repo, enabled=True).run(_ctx())
+
+    assert repo.crashed
+    assert result.status == WorkerRunStatus.failed.value
+    assert repo.get_memory("t1", "u1", mem.id).status == Status.active  # not deleted
+    assert MEMORY_RETENTION_EXPIRED not in _actions_for(repo, mem.id)
+
+
+# ── deletion compaction (destructive clear) ──────────────────────────────────
+def test_compaction_rolls_back_content_clear_when_audit_fails() -> None:
+    repo = _CrashOnAction(MEMORY_CONTENT_COMPACTED)
+    mem = seed_memory(repo, content="secret note", status=Status.deleted)
+
+    result = DeletionCompactionWorker(repo, min_age_days=0).run(_ctx())
+
+    assert repo.crashed
+    assert result.status == WorkerRunStatus.failed.value
+    got = repo.get_memory("t1", "u1", mem.id)
+    assert got.status == Status.deleted  # still deleted (never resurrected)
+    assert got.content == "secret note"  # content NOT cleared — rolled back
+    assert MEMORY_CONTENT_COMPACTED not in _actions_for(repo, mem.id)
+
+
+# ── happy path still commits both sides ──────────────────────────────────────
+def test_decay_commits_mutation_and_audit_together() -> None:
+    repo = InMemoryRepository()
+    mem = seed_memory(repo, importance=8, age_days=300)
+
+    result = DecayWorker(repo, age_threshold_days=90, importance_step=2).run(_ctx())
+
+    assert result.status == WorkerRunStatus.completed.value
+    assert repo.get_memory("t1", "u1", mem.id).importance == 6  # applied
+    assert MEMORY_DECAY_APPLIED in _actions_for(repo, mem.id)  # and audited


### PR DESCRIPTION
Closes #80.

## Worker mutation + audit atomicity — completes invariant #7

v2.3 made the **API/governance write paths** transactional (mutation + audit in one
`repo.transaction(...)`, ADR-027), but the **background lifecycle workers** still
mutated memory and then wrote the audit event as **two separate commits** — a crash
between them could persist a mutation without its audit row (invariant #7 gap on the
worker paths only). This closes that gap.

### Change
- **`LifecycleWorker._atomic(ctx)`** wraps each worker's mutation + its audit
  event(s) in one `repo.transaction(...)`, **opened before the in-place mutation** so
  the in-memory backend's rollback snapshot predates it (the store hands back live
  references — the same subtlety the write path handles). On Postgres it shares one
  session + commit.
- Applied to: **decay**, **archive**, **retention** (held + expired/consent
  soft-delete), **deletion-compaction** (destructive content/vector clear + its
  content-compacted / vector-purge-attempted evidence). The read-back purge
  verification stays a separate audit (it records a check, not a mutation).
  `deletion_verification` / `conflict_scan` / `reflection` are audit-only — no pair.

### Proof
`tests/test_worker_atomicity.py` injects an audit failure on the exact action each
worker emits with its mutation and asserts **neither** the mutation **nor** its
evidence survives the rollback (importance unchanged, not archived, not soft-deleted,
content not cleared), while the happy path still commits both. Per-item scope: earlier
items in a batch stay committed and a re-run finishes the rest idempotently.

### Docs
README invariant #7, `docs/limitations.md`, and `CLAUDE.md` #7 flipped from the v2.3
"workers still mutate then audit separately / in progress" wording to done; CHANGELOG
Unreleased entry added.

### Validation
`pytest -q` — 429 passed / 2 skipped; `ruff check app tests` — clean.
