### PR TITLE
feat(config): governance profile switch (S0-U + Experiment-C ablation apparatus)

### DIFF
--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -18,6 +18,22 @@ class Settings(BaseSettings):
     service_name: str = "memoryops-api"
     log_level: str = "INFO"
 
+    # Governance profile (paper study apparatus). "full" (default) is the frozen,
+    # fully-governed system (== tag paper-v0.1-governance-runtime — no behavior change).
+    # "disabled" produces the mechanism-matched *ungoverned* twin (S0-U) and is the
+    # umbrella the Experiment-C ablations build on: it turns OFF policy-broker
+    # enforcement, the admission/recall/output gates, transactional audit evidence, and
+    # tombstone propagation, while keeping the SAME extractor, embeddings, storage,
+    # retrieval, top-k, prompt, LLM, and temperature. Per-control flags below default
+    # from the profile so a single ablation can be toggled independently. Off by
+    # default → the frozen subject is untouched. See paper/protocol.md §3.
+    governance_profile: Literal["full", "disabled"] = "full"
+    # Resolved per-control switches (default True; the profile / env can force off).
+    # Kept as real fields so an ablation can disable exactly one mechanism.
+    govern_policy_enforcement: bool = True
+    govern_transactional_evidence: bool = True
+    govern_tombstone_propagation: bool = True
+
     # Deployment profile (v2.3). "dev" keeps the demo-friendly defaults (in-memory
     # store, auth off, open CORS) so the app runs with no infra. "production" turns
     # those same defaults into *fail-closed startup errors*: the app refuses to boot
@@ -347,6 +363,40 @@ def get_settings() -> Settings:
         overrides["output_gate_enabled"] = val.lower() not in ("0", "false", "no")
     if (val := os.getenv("MEMORYOPS_OUTPUT_GATE_MODE")) in ("redact", "refuse"):
         overrides["output_gate_mode"] = val
+    # Governance profile (paper study apparatus). MEMORYOPS_GOVERNANCE_PROFILE=disabled
+    # produces the ungoverned twin S0-U; "full" (default) is the frozen behavior. The
+    # profile sets the per-control defaults; an individual MEMORYOPS_ABLATE_* env var
+    # then overrides exactly one control (Experiment C). A control is *off* when the
+    # profile is disabled OR its ablation flag is set.
+    profile_disabled = os.getenv("MEMORYOPS_GOVERNANCE_PROFILE") == "disabled"
+    if os.getenv("MEMORYOPS_GOVERNANCE_PROFILE") in ("full", "disabled"):
+        overrides["governance_profile"] = os.getenv("MEMORYOPS_GOVERNANCE_PROFILE")
+
+    def _ablated(control_env: str) -> bool:
+        v = os.getenv(control_env)
+        return profile_disabled or (v is not None and v.lower() not in ("0", "false", "no"))
+
+    if profile_disabled or os.getenv("MEMORYOPS_ABLATE_POLICY_BROKER") is not None:
+        overrides["govern_policy_enforcement"] = not _ablated("MEMORYOPS_ABLATE_POLICY_BROKER")
+    if profile_disabled or os.getenv("MEMORYOPS_ABLATE_TRANSACTIONAL_EVIDENCE") is not None:
+        overrides["govern_transactional_evidence"] = not _ablated(
+            "MEMORYOPS_ABLATE_TRANSACTIONAL_EVIDENCE"
+        )
+    if profile_disabled or os.getenv("MEMORYOPS_ABLATE_TOMBSTONE_PROPAGATION") is not None:
+        overrides["govern_tombstone_propagation"] = not _ablated(
+            "MEMORYOPS_ABLATE_TOMBSTONE_PROPAGATION"
+        )
+    # The disabled profile also turns the context gates off (unless an env var already
+    # set them). Individual gate toggles remain the per-control ablation knobs.
+    if profile_disabled:
+        for env_name, field_name in (
+            ("MEMORYOPS_ADMISSION_GATE", "admission_gate_enabled"),
+            ("MEMORYOPS_RECALL_GATE", "recall_gate_enabled"),
+            ("MEMORYOPS_OUTPUT_GATE", "output_gate_enabled"),
+        ):
+            if os.getenv(env_name) is None:
+                overrides[field_name] = False
+
     if (val := os.getenv("MEMORYOPS_STORAGE")) in ("memory", "postgres"):
         overrides["storage"] = val
     # v2.3 deployment profile + CORS allow-list. Public operator knobs.

--- a/services/api/app/db/memory_repo.py
+++ b/services/api/app/db/memory_repo.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from datetime import UTC, datetime
 
+from ..core.config import get_settings as get_app_settings
 from ..loops.metrics import summarize_loop_runs
 from ..loops.types import LoopEvent, LoopRun
 from .entities import (
@@ -83,6 +84,12 @@ class InMemoryRepository(Repository):
         mutation also takes it, no other thread can mutate the store while it is
         being deep-copied (which would otherwise raise "dictionary changed size
         during iteration" under concurrent load)."""
+        # Ablation / S0-U: transactional evidence disabled → passthrough (no snapshot,
+        # no rollback); mutations + audits commit independently. Frozen default keeps
+        # the atomic unit of work.
+        if not get_app_settings().govern_transactional_evidence:
+            yield
+            return
         with self._lock:
             if self._transaction_depth:
                 self._transaction_depth += 1

--- a/services/api/app/db/postgres_repo.py
+++ b/services/api/app/db/postgres_repo.py
@@ -177,6 +177,12 @@ class PostgresRepository(Repository):
 
     @contextmanager
     def transaction(self, tenant_id: str, user_id: str = "") -> Iterator[None]:
+        # Ablation / S0-U: with transactional evidence disabled the unit of work is a
+        # passthrough — no shared session, so each nested repo call commits on its own
+        # (the pre-v2.3, non-atomic behavior). Frozen default keeps it enabled.
+        if not get_settings().govern_transactional_evidence:
+            yield
+            return
         active = self._active_session.get()
         if active is not None:
             self._validate_active_scope(tenant_id, user_id)

--- a/services/api/app/services/policy_broker.py
+++ b/services/api/app/services/policy_broker.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ..core.config import get_settings as get_app_settings
 from ..core.redaction import scan
 from ..db.entities import StoredSettings
 from ..db.repository import Repository
@@ -39,6 +40,13 @@ class PolicyBroker:
         user_id: str,
         settings: StoredSettings,
     ) -> PolicyOutcome:
+        # Ablation / S0-U (paper study): with policy enforcement disabled the broker is
+        # permissive — no secret/injection block, no sensitivity elevation, no dedup or
+        # approval — the "no policy broker" ablation. Frozen default enforces as before.
+        if not get_app_settings().govern_policy_enforcement:
+            return PolicyOutcome(
+                Decision.SAVE, candidate, "policy enforcement disabled (ablation / S0-U)"
+            )
         scan_result = scan(candidate.content)
 
         # 1) Hard safety rules (deterministic, verifiable).

--- a/services/api/tests/test_governance_profile.py
+++ b/services/api/tests/test_governance_profile.py
@@ -1,0 +1,106 @@
+"""Governance profile switch — S0-U / Experiment-C ablation apparatus (paper Phase 2).
+
+`governance_profile=full` (default) is the frozen, fully-governed behavior — the
+entire existing suite is the equivalence proof that the default changes nothing.
+`governance_profile=disabled` turns off policy-broker enforcement, the context gates,
+transactional evidence, and tombstone propagation: the mechanism-matched ungoverned
+twin. Individual `MEMORYOPS_ABLATE_*` flags disable exactly one control for Experiment
+C without flipping the whole profile.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core import config
+from app.db.memory_repo import InMemoryRepository
+from app.schemas.memory import CandidateMemory, Decision
+from app.services.policy_broker import PolicyBroker
+from app.workers.decay import DecayWorker
+from app.workers.lifecycle import WorkerContext
+from app.workers.schemas import MEMORY_DECAY_APPLIED, WorkerRunStatus
+
+from ._worker_helpers import NOW, seed_memory
+from .test_worker_atomicity import _CrashOnAction
+
+
+@pytest.fixture
+def load_settings(monkeypatch):
+    """Load Settings under a given env, isolating the lru_cache."""
+
+    def _load(**env):
+        for k, v in env.items():
+            monkeypatch.setenv(k, v)
+        config.get_settings.cache_clear()
+        return config.get_settings()
+
+    yield _load
+    config.get_settings.cache_clear()
+
+
+# ── resolution ───────────────────────────────────────────────────────────────
+def test_default_profile_is_full_and_fully_governed(load_settings):
+    s = load_settings()  # no env → frozen default
+    assert s.governance_profile == "full"
+    assert s.govern_policy_enforcement
+    assert s.govern_transactional_evidence
+    assert s.govern_tombstone_propagation
+    assert s.admission_gate_enabled and s.recall_gate_enabled and s.output_gate_enabled
+
+
+def test_disabled_profile_turns_all_governance_off(load_settings):
+    s = load_settings(MEMORYOPS_GOVERNANCE_PROFILE="disabled")
+    assert s.governance_profile == "disabled"
+    assert not s.govern_policy_enforcement
+    assert not s.govern_transactional_evidence
+    assert not s.govern_tombstone_propagation
+    assert not s.admission_gate_enabled
+    assert not s.recall_gate_enabled
+    assert not s.output_gate_enabled
+
+
+def test_single_control_ablation_leaves_profile_full(load_settings):
+    s = load_settings(MEMORYOPS_ABLATE_TRANSACTIONAL_EVIDENCE="true")
+    assert s.governance_profile == "full"
+    assert s.govern_policy_enforcement  # untouched
+    assert s.govern_tombstone_propagation  # untouched
+    assert not s.govern_transactional_evidence  # the one ablated control
+
+
+# ── behavioral: policy broker becomes permissive ─────────────────────────────
+def test_policy_broker_blocks_secret_when_full_but_saves_when_disabled(load_settings):
+    repo = InMemoryRepository()
+    broker = PolicyBroker(repo)
+    stored = repo.get_settings("t1", "u1")
+    secret = CandidateMemory(content="my key is sk-ABCDEF012345678 keep it safe")
+
+    load_settings()  # full
+    assert broker.evaluate(
+        secret, tenant_id="t1", user_id="u1", settings=stored
+    ).decision == Decision.BLOCK
+
+    load_settings(MEMORYOPS_GOVERNANCE_PROFILE="disabled")  # ungoverned
+    assert broker.evaluate(
+        secret, tenant_id="t1", user_id="u1", settings=stored
+    ).decision == Decision.SAVE
+
+
+# ── behavioral: transactional evidence off → no rollback ─────────────────────
+def _ctx() -> WorkerContext:
+    return WorkerContext(tenant_id="t1", user_id="u1", now=NOW)
+
+
+def test_transaction_passthrough_when_evidence_disabled(load_settings):
+    # The mirror of test_worker_atomicity: with transactional evidence OFF, a worker
+    # mutation is NOT rolled back when its audit fails — proving the switch really
+    # disables the atomic unit of work (the frozen default keeps it atomic).
+    load_settings(MEMORYOPS_GOVERNANCE_PROFILE="disabled")
+    repo = _CrashOnAction(MEMORY_DECAY_APPLIED)
+    mem = seed_memory(repo, importance=8, age_days=300)
+
+    result = DecayWorker(repo, age_threshold_days=90, importance_step=2).run(_ctx())
+
+    assert repo.crashed
+    assert result.status == WorkerRunStatus.failed.value
+    # No transaction → the importance change persisted despite the audit failure.
+    assert repo.get_memory("t1", "u1", mem.id).importance == 6


### PR DESCRIPTION
Phase 2 apparatus for the governance-runtime study. Adds the **governance profile
switch** that produces the mechanism-matched ungoverned twin **S0-U** (protocol §3)
and powers the **Experiment-C ablations** — additive and **default-off**, so the
frozen subject (`paper-v0.1-governance-runtime`) is unchanged.

### Behavior
- `MEMORYOPS_GOVERNANCE_PROFILE=full` (default) — the frozen, fully-governed system.
  **Equivalence proof:** the entire existing suite passes unchanged (436 tests, rc=0).
- `MEMORYOPS_GOVERNANCE_PROFILE=disabled` — **S0-U**: policy-broker enforcement, the
  admission/recall/output gates, transactional audit evidence, and tombstone
  propagation are OFF; extractor / embeddings / storage / retrieval / top-k / prompt /
  LLM / temperature are identical to S0.
- `MEMORYOPS_ABLATE_{POLICY_BROKER,TRANSACTIONAL_EVIDENCE,TOMBSTONE_PROPAGATION}` —
  disable exactly one mechanism without flipping the whole profile (Experiment C).

### Seams (minimal, contained)
- `PolicyBroker.evaluate` → permissive `SAVE` when enforcement is off (the "no policy
  broker" ablation).
- `repo.transaction()` (in-memory + Postgres) → passthrough when transactional evidence
  is off (mutations/audits commit independently — pre-v2.3 semantics).
- Gates default off under the disabled profile via config resolution (no gateway edit).
- Tombstone-propagation disable is wired as a flag; its deletion-path effect lands with
  the deletion ablation cases.

### Tests
`tests/test_governance_profile.py`: resolution (full / disabled / single-control
ablation) + behavioral — a secret is **BLOCK**ed under `full` but **SAVE**d under
`disabled`, and the transaction passthrough is proven by the mirror of the atomicity
test (audit failure does **not** roll back the mutation when evidence is off). `ruff
check app` clean.

> Freeze integrity: the default (`full`) path is byte-for-byte the prior behavior; the
> disabled path is experimental apparatus (S0-U + ablations), not a change to the
> governance logic being measured. The tag remains the reference.
