### PR TITLE
paper(harness): neutral MemorySystemAdapter contract + types (Phase 2 foundation)

### DIFF
--- a/paper/harness/__init__.py
+++ b/paper/harness/__init__.py
@@ -1,0 +1,35 @@
+"""Neutral benchmark harness for the governance-runtime study (paper Phase 2).
+
+Public surface: the ``MemorySystemAdapter`` contract + the neutral result/capability/
+manifest types. System adapters (S0, S0-U, S1–S4) and the runner build on these.
+"""
+
+from .adapter import MemorySystemAdapter
+from .types import (
+    Capability,
+    EvidenceResult,
+    ForgetResult,
+    IngestResult,
+    MemoryRef,
+    OpStatus,
+    Outcome,
+    QueryResult,
+    RunManifest,
+    Scope,
+    UpdateResult,
+)
+
+__all__ = [
+    "MemorySystemAdapter",
+    "Capability",
+    "OpStatus",
+    "Outcome",
+    "Scope",
+    "MemoryRef",
+    "IngestResult",
+    "QueryResult",
+    "ForgetResult",
+    "UpdateResult",
+    "EvidenceResult",
+    "RunManifest",
+]

--- a/paper/harness/adapter.py
+++ b/paper/harness/adapter.py
@@ -1,0 +1,61 @@
+"""The neutral ``MemorySystemAdapter`` contract (protocol §3, Phase 2).
+
+Every system under test implements this Protocol so the runner can give each the
+*identical* conversation history, scope, mutation sequence, and query set, and score
+them with the identical rubric. The adapter is a thin, honest wrapper: it performs an
+operation and reports an ``OpStatus`` — it does **not** grade correctness, and it must
+report ``OpStatus.unsupported`` (never fake a success or a failure) for a capability
+the underlying system genuinely lacks.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .types import (
+    Capability,
+    EvidenceResult,
+    ForgetResult,
+    IngestResult,
+    QueryResult,
+    Scope,
+    UpdateResult,
+)
+
+
+@runtime_checkable
+class MemorySystemAdapter(Protocol):
+    #: Short stable id used in result manifests / tables (e.g. "S0", "S0-U", "S2").
+    name: str
+
+    def capabilities(self) -> set[Capability]:
+        """The operations this system genuinely supports. An operation whose
+        capability is absent must return ``OpStatus.unsupported`` (reconciled by the
+        contract tests) — it is a reported finding, not a failure."""
+        ...
+
+    def reset(self) -> None:
+        """Return the system to a clean, empty state so cases do not leak into one
+        another. Must be idempotent."""
+        ...
+
+    def ingest(self, scope: Scope, message: str) -> IngestResult:
+        """Offer a message to the system's memory pipeline for the given scope."""
+        ...
+
+    def query(self, scope: Scope, question: str) -> QueryResult:
+        """Answer a question for the scope using whatever memory the system holds."""
+        ...
+
+    def forget(self, scope: Scope, memory_id: str) -> ForgetResult:
+        """Delete a specific memory. ``unsupported`` if the system cannot forget."""
+        ...
+
+    def update(self, scope: Scope, memory_id: str, content: str) -> UpdateResult:
+        """Replace a memory's content. ``unsupported`` if the system cannot update."""
+        ...
+
+    def export_evidence(self, scope: Scope) -> EvidenceResult:
+        """Return governance/audit evidence for the scope, or ``unsupported`` if the
+        system produces none."""
+        ...

--- a/paper/harness/reference.py
+++ b/paper/harness/reference.py
@@ -1,0 +1,79 @@
+"""A trivial in-process reference adapter — a harness *self-test fixture*, not a
+study baseline.
+
+It exercises the ``MemorySystemAdapter`` contract end to end without any real model
+or store: a per-scope dict of memories, naive substring recall, and **no** governance
+evidence (so it drives the ``unsupported`` path for ``export_evidence``). The real
+S0 / S0-U / S1–S4 adapters live elsewhere; this one only proves the contract and the
+outcome vocabulary are coherent.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+from .types import (
+    Capability,
+    EvidenceResult,
+    ForgetResult,
+    IngestResult,
+    MemoryRef,
+    OpStatus,
+    QueryResult,
+    Scope,
+    UpdateResult,
+)
+
+
+class ReferenceDictAdapter:
+    name = "reference"
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], dict[str, str]] = {}
+        self._ids = itertools.count(1)
+
+    def capabilities(self) -> set[Capability]:
+        # Deliberately no EXPORT_EVIDENCE — an ungoverned reference has no audit.
+        return {Capability.INGEST, Capability.QUERY, Capability.FORGET, Capability.UPDATE}
+
+    def reset(self) -> None:
+        self._store.clear()
+        self._ids = itertools.count(1)
+
+    def _scope(self, scope: Scope) -> dict[str, str]:
+        return self._store.setdefault((scope.tenant_id, scope.user_id), {})
+
+    def ingest(self, scope: Scope, message: str) -> IngestResult:
+        mem_id = f"m{next(self._ids)}"
+        self._scope(scope)[mem_id] = message
+        return IngestResult(status=OpStatus.OK, memory_ids=[mem_id])
+
+    def query(self, scope: Scope, question: str) -> QueryResult:
+        terms = {w for w in question.lower().split() if len(w) > 3}
+        hits = [
+            MemoryRef(memory_id=mid, content=text)
+            for mid, text in self._scope(scope).items()
+            if terms & set(text.lower().split())
+        ]
+        answer = hits[0].content if hits else ""
+        return QueryResult(
+            status=OpStatus.OK,
+            answer=answer or "",
+            used_memory_ids=[h.memory_id for h in hits[:1]],
+            retrieved=hits,
+        )
+
+    def forget(self, scope: Scope, memory_id: str) -> ForgetResult:
+        self._scope(scope).pop(memory_id, None)
+        return ForgetResult(status=OpStatus.OK)
+
+    def update(self, scope: Scope, memory_id: str, content: str) -> UpdateResult:
+        bucket = self._scope(scope)
+        if memory_id not in bucket:
+            return UpdateResult(status=OpStatus.ERROR, detail="unknown memory_id")
+        bucket[memory_id] = content
+        return UpdateResult(status=OpStatus.OK)
+
+    def export_evidence(self, scope: Scope) -> EvidenceResult:
+        # No governance layer → honestly unsupported (drives the separate-reporting path).
+        return EvidenceResult(status=OpStatus.UNSUPPORTED, detail="no audit/evidence")

--- a/paper/harness/tests/test_contract.py
+++ b/paper/harness/tests/test_contract.py
@@ -1,0 +1,95 @@
+"""Deterministic contract tests every ``MemorySystemAdapter`` must satisfy.
+
+These run against *any* adapter (parametrize new systems in as they are built). They
+check the neutral guarantees the protocol depends on — scope isolation, reset, and —
+critically — that ``capabilities()`` is *honest*: an operation whose capability is
+declared must not report ``unsupported``, and one whose capability is absent must
+report exactly ``unsupported`` (never a faked ok/error). This is what lets the study
+report unsupported capability separately from failure (protocol §5).
+
+Run: ``python -m pytest paper/harness/tests``
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from paper.harness.reference import ReferenceDictAdapter
+from paper.harness.types import Capability, OpStatus, Scope
+
+# Register each adapter under test here.
+ADAPTERS = [ReferenceDictAdapter]
+
+S = Scope("t1", "u1")
+OTHER = Scope("t2", "u2")
+
+
+@pytest.fixture(params=ADAPTERS, ids=lambda a: a.name)
+def adapter(request):
+    a = request.param()
+    a.reset()
+    yield a
+
+
+def _op(adapter, cap: Capability, scope: Scope):
+    """Invoke the operation for a capability and return its result object."""
+    if cap is Capability.INGEST:
+        return adapter.ingest(scope, "seed message about mango pickles")
+    if cap is Capability.QUERY:
+        return adapter.query(scope, "mango pickles")
+    if cap is Capability.FORGET:
+        return adapter.forget(scope, "m1")
+    if cap is Capability.UPDATE:
+        return adapter.update(scope, "m1", "updated content")
+    if cap is Capability.EXPORT_EVIDENCE:
+        return adapter.export_evidence(scope)
+    raise AssertionError(cap)
+
+
+def test_capabilities_is_a_capability_set(adapter):
+    caps = adapter.capabilities()
+    assert isinstance(caps, set)
+    assert caps <= set(Capability)
+    assert isinstance(adapter.name, str) and adapter.name
+
+
+def test_reset_is_idempotent_and_clears(adapter):
+    adapter.ingest(S, "remember the vault code is 4821")
+    adapter.reset()
+    adapter.reset()  # twice — must not raise
+    q = adapter.query(S, "vault code")
+    assert q.status is OpStatus.OK
+    assert q.answer == ""  # cleared
+
+
+@pytest.mark.parametrize("cap", list(Capability))
+def test_capabilities_are_honest(adapter, cap):
+    # Ensure m1 exists so forget/update address a real id where supported.
+    adapter.ingest(S, "mango pickles are stored in the pantry")
+    result = _op(adapter, cap, S)
+    if cap in adapter.capabilities():
+        # A declared capability must never answer 'unsupported'.
+        assert result.status is not OpStatus.UNSUPPORTED, f"{cap} declared but unsupported"
+    else:
+        # An undeclared capability must answer exactly 'unsupported' (not faked).
+        assert result.status is OpStatus.UNSUPPORTED, f"{cap} absent but status={result.status}"
+
+
+def test_ingest_then_query_recalls(adapter):
+    if Capability.INGEST not in adapter.capabilities():
+        pytest.skip("adapter cannot ingest")
+    ing = adapter.ingest(S, "the meeting is in the blue conference room")
+    assert ing.status is OpStatus.OK and ing.memory_ids
+    q = adapter.query(S, "which conference room is the meeting")
+    assert q.status is OpStatus.OK
+    assert "blue" in q.answer.lower()
+
+
+def test_scope_isolation(adapter):
+    if Capability.INGEST not in adapter.capabilities():
+        pytest.skip("adapter cannot ingest")
+    adapter.ingest(S, "my private diagnosis is condition X")
+    other = adapter.query(OTHER, "diagnosis")
+    # A different tenant/user must not recall S's memory (invariant #1).
+    assert "condition x" not in other.answer.lower()
+    assert other.used_memory_ids == []

--- a/paper/harness/types.py
+++ b/paper/harness/types.py
@@ -1,0 +1,133 @@
+"""Neutral result, capability, and manifest types for the benchmark harness.
+
+System-agnostic by design: every system under test (governed MemoryOps `S0`, its
+governance-disabled twin `S0-U`, and the external baselines `S1`–`S4`) is driven
+through the same adapter and its per-operation results are described with the same
+vocabulary, so scores are comparable and a *missing capability* is never silently
+counted as a failure. See `paper/protocol.md` §5.
+
+Two distinct enums, kept separate on purpose:
+
+* ``OpStatus`` — what an *adapter operation* reports (`ok` / `unsupported` / `error`).
+  The adapter never decides pass/fail; it reports whether the system could perform
+  the operation at all.
+* ``Outcome`` — the *case-level* classification a rubric produces
+  (`pass` / `fail` / `unsupported` / `error`). The case evaluator maps
+  ``OpStatus.unsupported`` → ``Outcome.unsupported`` and ``OpStatus.error`` →
+  ``Outcome.error``; only an ``ok`` operation is graded pass/fail against the rubric.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class OpStatus(str, Enum):
+    """Whether an adapter could perform an operation (not whether it was correct)."""
+
+    OK = "ok"
+    UNSUPPORTED = "unsupported"  # the system has no such capability — a finding, not a fail
+    ERROR = "error"  # crash / timeout / malformed output
+
+
+class Outcome(str, Enum):
+    """Case-level classification produced by a rubric (protocol §5)."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    UNSUPPORTED = "unsupported"
+    ERROR = "error"
+
+
+class Capability(str, Enum):
+    """Operations a system may support. Declared by ``adapter.capabilities()`` and
+    reconciled against actual op statuses by the contract tests."""
+
+    INGEST = "ingest"
+    QUERY = "query"
+    FORGET = "forget"
+    UPDATE = "update"
+    EXPORT_EVIDENCE = "export_evidence"
+
+
+@dataclass(frozen=True)
+class Scope:
+    """Tenant + user isolation boundary carried on every operation (invariant #1)."""
+
+    tenant_id: str
+    user_id: str
+
+
+@dataclass
+class MemoryRef:
+    memory_id: str
+    content: str | None = None
+    score: float | None = None
+
+
+@dataclass
+class IngestResult:
+    status: OpStatus
+    memory_ids: list[str] = field(default_factory=list)
+    detail: str = ""
+
+
+@dataclass
+class QueryResult:
+    status: OpStatus
+    answer: str = ""
+    used_memory_ids: list[str] = field(default_factory=list)
+    retrieved: list[MemoryRef] = field(default_factory=list)
+    detail: str = ""
+
+
+@dataclass
+class ForgetResult:
+    status: OpStatus
+    detail: str = ""
+
+
+@dataclass
+class UpdateResult:
+    status: OpStatus
+    detail: str = ""
+
+
+@dataclass
+class EvidenceResult:
+    status: OpStatus
+    available: bool = False
+    payload: dict[str, Any] = field(default_factory=dict)
+    detail: str = ""
+
+
+@dataclass
+class RunManifest:
+    """Per-run provenance stamped into every result file (protocol §6/§10). No result
+    number is trustworthy without the manifest that produced it. Fields are filled by
+    the runner; unknowns stay empty rather than being guessed."""
+
+    system: str  # e.g. "S0", "S0-U", "S2"
+    benchmark_version: str
+    git_sha: str
+    model_id: str = ""
+    provider: str = ""
+    prompt_version: str = ""
+    temperature: float | None = None
+    seed: int | None = None
+    storage_backend: str = ""
+    vector_backend: str = ""
+    timestamp: str = ""  # ISO-8601 UTC
+    input_tokens: int = 0
+    output_tokens: int = 0
+    estimated_cost_usd: float = 0.0
+    error_count: int = 0
+    fallback_count: int = 0
+    env: dict[str, str] = field(default_factory=dict)  # python/lib versions
+
+    def to_dict(self) -> dict[str, Any]:
+        from dataclasses import asdict
+
+        return asdict(self)


### PR DESCRIPTION
Phase 2 foundation for the governance-runtime study — the **system-neutral benchmark
harness** (protocol §3, §5, §10). Touches nothing under the frozen baseline
(`services/api/app`).

- `paper/harness/types.py` — `OpStatus` (ok/unsupported/error, adapter-level) kept
  distinct from `Outcome` (pass/fail/unsupported/error, case-level); `Capability`;
  `Scope`; per-op result dataclasses; `RunManifest` (per-run provenance for §6/§10).
- `paper/harness/adapter.py` — the `MemorySystemAdapter` Protocol
  (`reset/ingest/query/forget/update/export_evidence` + `capabilities()`).
- `paper/harness/reference.py` — `ReferenceDictAdapter`, a harness **self-test
  fixture** (not a study baseline) that drives the `unsupported` path (no evidence).
- `paper/harness/tests/test_contract.py` — deterministic contract tests, incl.
  **capabilities() honesty** (declared ≠ unsupported; absent == unsupported), reset,
  scope isolation, recall. 9 passed (`python -m pytest paper/harness/tests`).

Next (gated on #88 landing): the S0 (governed) and S0-U (governance-disabled) MemoryOps
adapters on top of this contract, then S1–S4.
