### PR TITLE
fix(s0u): keep dedup + hygiene when policy enforcement is disabled

### DIFF
--- a/services/api/app/services/policy_broker.py
+++ b/services/api/app/services/policy_broker.py
@@ -40,30 +40,31 @@ class PolicyBroker:
         user_id: str,
         settings: StoredSettings,
     ) -> PolicyOutcome:
-        # Ablation / S0-U (paper study): with policy enforcement disabled the broker is
-        # permissive — no secret/injection block, no sensitivity elevation, no dedup or
-        # approval — the "no policy broker" ablation. Frozen default enforces as before.
-        if not get_app_settings().govern_policy_enforcement:
-            return PolicyOutcome(
-                Decision.SAVE, candidate, "policy enforcement disabled (ablation / S0-U)"
-            )
+        # Ablation / S0-U (paper study): "enforcement" = the governance *decisions*
+        # (secret/injection BLOCK, sensitive-content approval gating). With enforcement
+        # disabled those are skipped, but memory *hygiene* — sensitivity labelling,
+        # dedup/update-existing, and the low-utility floor — is KEPT, so S0-U stays a
+        # fair, mechanism-matched ungoverned twin (disabling dedup too would let S0-U
+        # accumulate duplicates and bias H2 utility toward the governed system). Frozen
+        # default (`govern_policy_enforcement=True`) enforces exactly as before.
+        enforce = get_app_settings().govern_policy_enforcement
         scan_result = scan(candidate.content)
 
-        # 1) Hard safety rules (deterministic, verifiable).
-        if scan_result.has_secret:
+        # 1) Hard safety rules (deterministic, verifiable) — governance enforcement.
+        if enforce and scan_result.has_secret:
             return PolicyOutcome(
                 Decision.BLOCK,
                 candidate,
                 f"blocked: secret-like content detected ({', '.join(scan_result.secret_labels)})",
             )
-        if scan_result.injection:
+        if enforce and scan_result.injection:
             return PolicyOutcome(
                 Decision.BLOCK,
                 candidate,
                 "blocked: prompt-injection / memory-poisoning pattern detected",
             )
 
-        # 2) Sensitivity (PII elevates; may require approval).
+        # 2) Sensitivity (PII elevates; may require approval). Labelling — kept.
         final_sensitivity = max(
             candidate.sensitivity,
             Sensitivity(scan_result.sensitivity),
@@ -89,9 +90,10 @@ class PolicyBroker:
                 f"dropped: importance {candidate.importance} below threshold {_MIN_IMPORTANCE}",
             )
 
-        # 5) Sensitive content gated behind approval.
+        # 5) Sensitive content gated behind approval — governance enforcement.
         if (
-            final_sensitivity in (Sensitivity.medium, Sensitivity.high)
+            enforce
+            and final_sensitivity in (Sensitivity.medium, Sensitivity.high)
             and settings.require_approval_for_sensitive
         ):
             return PolicyOutcome(

--- a/services/api/tests/test_governance_profile.py
+++ b/services/api/tests/test_governance_profile.py
@@ -85,6 +85,22 @@ def test_policy_broker_blocks_secret_when_full_but_saves_when_disabled(load_sett
     ).decision == Decision.SAVE
 
 
+def test_dedup_hygiene_preserved_when_enforcement_disabled(load_settings):
+    # S0-U disables governance *enforcement* but keeps memory hygiene: a duplicate
+    # still updates the existing memory rather than accumulating (otherwise S0-U would
+    # look artificially worse on utility — biasing H2 toward the governed system).
+    repo = InMemoryRepository()
+    broker = PolicyBroker(repo)
+    stored = repo.get_settings("t1", "u1")
+    seed_memory(repo, tenant_id="t1", user_id="u1", content="I love hiking in the alps")
+
+    load_settings(MEMORYOPS_GOVERNANCE_PROFILE="disabled")
+    dup = CandidateMemory(content="I love hiking in the alps")
+    out = broker.evaluate(dup, tenant_id="t1", user_id="u1", settings=stored)
+    assert out.decision == Decision.UPDATE_EXISTING  # dedup kept
+    assert out.existing_id is not None
+
+
 # ── behavioral: transactional evidence off → no rollback ─────────────────────
 def _ctx() -> WorkerContext:
     return WorkerContext(tenant_id="t1", user_id="u1", now=NOW)


### PR DESCRIPTION
Refines the governance-disabled path from #88 so **S0-U is a fair ungoverned twin**.

**Problem:** #88's disabled profile made the policy broker return a permissive SAVE at the top, which also skipped **dedup**. An S0-U that accumulates duplicates would look artificially worse on utility — biasing H2 *toward* the governed system.

**Fix:** `govern_policy_enforcement=False` now skips only the governance **decisions** (secret/injection BLOCK, sensitive-content approval gating) and **keeps memory hygiene** (sensitivity labelling, dedup/update-existing, low-utility floor). Frozen default (`True`) enforces exactly as before.

**Tests:** duplicate under `disabled` → `UPDATE_EXISTING` (dedup kept); secret still BLOCK under `full` vs SAVE under `disabled`. Full suite **437, rc=0** under default `full` (equivalence preserved). `ruff check app` clean.