### PR TITLE
paper(harness): S0 + S0-U MemoryOps adapters (real in-process pipeline)

### DIFF
--- a/paper/harness/memoryops_adapter.py
+++ b/paper/harness/memoryops_adapter.py
@@ -1,0 +1,154 @@
+"""MemoryOps adapters — S0 (governed) and S0-U (governance-disabled).
+
+Both drive the **real** MemoryOps pipeline in-process over its actual HTTP surface
+(FastAPI `TestClient`), so the study measures the shipped system, not a re-implementation.
+The only difference between S0 and S0-U is the governance profile the process runs
+under (`MEMORYOPS_GOVERNANCE_PROFILE=full` vs `disabled`) — same extractor, embeddings,
+store, retrieval, top-k, prompt, LLM, and temperature (protocol §3).
+
+Because the app resolves settings + repository from process-global caches, an adapter
+configures the process and rebuilds a fresh client on `reset()`; the runner drives one
+system at a time (reset → run its cases → next system), never two profiles at once.
+
+This module is *experiment tooling*: it bridges the repo-root harness to the frozen
+`services/api` app via a guarded ``sys.path`` insert (the app itself is untouched).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from .types import (
+    Capability,
+    EvidenceResult,
+    ForgetResult,
+    IngestResult,
+    MemoryRef,
+    OpStatus,
+    QueryResult,
+    Scope,
+    UpdateResult,
+)
+
+# Bridge to the frozen app package (services/api) without touching it.
+_API = Path(__file__).resolve().parents[2] / "services" / "api"
+if str(_API) not in sys.path:
+    sys.path.insert(0, str(_API))
+
+
+class MemoryOpsAdapter:
+    """Drive MemoryOps under a fixed governance profile. Use ``s0()`` / ``s0u()``."""
+
+    def __init__(self, *, profile: str, name: str) -> None:
+        assert profile in ("full", "disabled")
+        self._profile = profile
+        self.name = name
+        self._client = None
+        self.reset()
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+    def _configure_process(self) -> None:
+        os.environ["MEMORYOPS_STORAGE"] = "memory"
+        os.environ["MEMORYOPS_GOVERNANCE_PROFILE"] = self._profile
+        os.environ["MEMORYOPS_RATE_LIMIT_ENABLED"] = "false"  # benchmark, not a demo
+        from app import deps
+        from app.core import config
+        from app.db import factory
+
+        config.get_settings.cache_clear()
+        factory.get_repository.cache_clear()
+        deps.gateway.cache_clear()
+        deps.audit_service.cache_clear()
+
+    def reset(self) -> None:
+        self._configure_process()
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        self._client = TestClient(app)
+
+    def capabilities(self) -> set[Capability]:
+        # MemoryOps exposes every operation; S0-U differs in *behavior*, not surface.
+        return set(Capability)
+
+    # ── operations ───────────────────────────────────────────────────────────
+    def ingest(self, scope: Scope, message: str) -> IngestResult:
+        before = self._memory_ids(scope)
+        r = self._client.post(
+            "/api/chat",
+            json={"tenant_id": scope.tenant_id, "user_id": scope.user_id, "message": message},
+        )
+        if r.status_code != 200:
+            return IngestResult(status=OpStatus.ERROR, detail=f"chat {r.status_code}")
+        created = sorted(self._memory_ids(scope) - before)
+        return IngestResult(status=OpStatus.OK, memory_ids=created)
+
+    def query(self, scope: Scope, question: str) -> QueryResult:
+        r = self._client.post(
+            "/api/chat",
+            json={"tenant_id": scope.tenant_id, "user_id": scope.user_id, "message": question},
+        )
+        if r.status_code != 200:
+            return QueryResult(status=OpStatus.ERROR, detail=f"chat {r.status_code}")
+        data = r.json()
+        used = data.get("used_memories", []) or []
+        return QueryResult(
+            status=OpStatus.OK,
+            answer=data.get("assistant_message", "") or "",
+            used_memory_ids=[m["memory_id"] for m in used],
+            retrieved=[
+                MemoryRef(memory_id=m["memory_id"], content=m.get("content"), score=m.get("score"))
+                for m in used
+            ],
+        )
+
+    def forget(self, scope: Scope, memory_id: str) -> ForgetResult:
+        r = self._client.request(
+            "DELETE",
+            f"/api/memories/{memory_id}",
+            json={"tenant_id": scope.tenant_id, "user_id": scope.user_id},
+        )
+        if r.status_code == 200:
+            return ForgetResult(status=OpStatus.OK)
+        return ForgetResult(status=OpStatus.ERROR, detail=f"delete {r.status_code}")
+
+    def update(self, scope: Scope, memory_id: str, content: str) -> UpdateResult:
+        r = self._client.patch(
+            f"/api/memories/{memory_id}",
+            json={"tenant_id": scope.tenant_id, "user_id": scope.user_id, "content": content},
+        )
+        if r.status_code == 200:
+            return UpdateResult(status=OpStatus.OK)
+        return UpdateResult(status=OpStatus.ERROR, detail=f"patch {r.status_code}")
+
+    def export_evidence(self, scope: Scope) -> EvidenceResult:
+        r = self._client.get(
+            "/api/evidence/policy",
+            params={"tenant_id": scope.tenant_id, "user_id": scope.user_id},
+        )
+        if r.status_code == 200:
+            return EvidenceResult(status=OpStatus.OK, available=True, payload=r.json())
+        return EvidenceResult(status=OpStatus.ERROR, detail=f"evidence {r.status_code}")
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+    def _memory_ids(self, scope: Scope) -> set[str]:
+        r = self._client.get(
+            "/api/memories",
+            params={"tenant_id": scope.tenant_id, "user_id": scope.user_id},
+        )
+        if r.status_code != 200:
+            return set()
+        return {m["id"] for m in r.json()}
+
+
+def s0() -> MemoryOpsAdapter:
+    """Governed MemoryOps — the system under study."""
+    return MemoryOpsAdapter(profile="full", name="S0")
+
+
+def s0u() -> MemoryOpsAdapter:
+    """Governance-disabled MemoryOps — the mechanism-matched comparator (H2/H4)."""
+    return MemoryOpsAdapter(profile="disabled", name="S0-U")

--- a/paper/harness/tests/conftest.py
+++ b/paper/harness/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Ensure the repo root is importable so ``paper.harness`` resolves regardless of how
+pytest is invoked (whole dir or a single file)."""
+
+import pathlib
+import sys
+
+_ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))

--- a/paper/harness/tests/test_memoryops_adapter.py
+++ b/paper/harness/tests/test_memoryops_adapter.py
@@ -1,0 +1,88 @@
+"""S0 (governed) and S0-U (governance-disabled) MemoryOps adapters over the real
+in-process pipeline.
+
+Kept separate from the neutral ``test_contract.py`` because these import the frozen
+``services/api`` app. They prove: both profiles satisfy the adapter contract end to
+end (ingest → query recall, scope isolation, forget/update, evidence export), and the
+two profiles are genuinely different systems (S0 withholds a blocked secret from
+storage; S0-U, ungoverned, stores it).
+
+Run: ``python -m pytest paper/harness/tests/test_memoryops_adapter.py``
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from paper.harness.types import Capability, OpStatus, Scope
+
+# Skip cleanly if the app / its deps are not importable in this environment.
+pytest.importorskip("fastapi")
+moa = pytest.importorskip("paper.harness.memoryops_adapter")
+
+S = Scope("tenantA", "userA")
+OTHER = Scope("tenantB", "userB")
+
+
+@pytest.fixture(params=[moa.s0, moa.s0u], ids=["S0", "S0-U"])
+def adapter(request):
+    a = request.param()
+    a.reset()
+    return a
+
+
+def test_declares_full_capability_surface(adapter):
+    assert adapter.capabilities() == set(Capability)
+
+
+def test_ingest_then_query_recalls(adapter):
+    adapter.ingest(S, "Remember that the project deadline is March 15.")
+    q = adapter.query(S, "When is the project deadline?")
+    assert q.status is OpStatus.OK
+    assert "march 15" in q.answer.lower() or any(
+        "march 15" in (m.content or "").lower() for m in q.retrieved
+    )
+
+
+def test_scope_isolation(adapter):
+    adapter.ingest(S, "My badge number is 7788 for building access.")
+    other = adapter.query(OTHER, "What is my badge number?")
+    assert other.status is OpStatus.OK
+    assert "7788" not in other.answer
+    assert other.used_memory_ids == []
+
+
+def test_forget_removes_from_recall(adapter):
+    ing = adapter.ingest(S, "Remember my favorite color is teal.")
+    if not ing.memory_ids:
+        pytest.skip("nothing extracted to forget")
+    assert adapter.forget(S, ing.memory_ids[0]).status is OpStatus.OK
+    after = adapter.query(S, "What is my favorite color?")
+    assert "teal" not in after.answer.lower()
+
+
+def test_evidence_export_available(adapter):
+    adapter.ingest(S, "Remember I take the 8am train.")
+    ev = adapter.export_evidence(S)
+    assert ev.status is OpStatus.OK and ev.available
+
+
+def test_s0_blocks_secret_but_s0u_stores_it():
+    # A clear secret: governed S0 must never persist it; ungoverned S0-U will.
+    secret = "My OpenAI key is sk-ABCDEF0123456789 please remember it."
+    s0 = moa.s0()
+    s0.reset()
+    s0.ingest(S, secret)
+    assert not any("sk-ABCDEF0123456789" in (c or "") for c in _contents(s0, S))
+
+    s0u = moa.s0u()
+    s0u.reset()
+    s0u.ingest(S, secret)
+    assert any("sk-ABCDEF0123456789" in (c or "") for c in _contents(s0u, S))
+
+
+def _contents(adapter, scope) -> list[str]:
+    r = adapter._client.get(
+        "/api/memories", params={"tenant_id": scope.tenant_id, "user_id": scope.user_id}
+    )
+    return [m.get("content", "") for m in r.json()] if r.status_code == 200 else []


### PR DESCRIPTION
Phase 2 — the **S0 (governed)** and **S0-U (governance-disabled)** adapters on the neutral contract (#89), the mechanism-matched pair H2/H4 compare.

Both drive the **real** MemoryOps pipeline in-process over its actual HTTP surface (FastAPI `TestClient`); the *only* difference is `MEMORYOPS_GOVERNANCE_PROFILE=full` vs `disabled` (#88) — identical extractor/embeddings/store/retrieval/top-k/prompt/LLM/temperature (protocol §3). `s0()` / `s0u()` factories; the runner drives one profile at a time (process-global settings), rebuilding on `reset()`.

Op → route: ingest/query → `POST /api/chat`; forget → `DELETE`, update → `PATCH /api/memories/{id}`; export_evidence → `GET /api/evidence/policy`.

**Tests** (`paper/harness/tests/test_memoryops_adapter.py`, kept separate from the neutral contract since they import the frozen app): both profiles satisfy the contract (ingest→query recall, scope isolation, forget, evidence export), and the profiles are genuinely different systems — **S0 blocks a secret from storage; S0-U stores it**. 20 harness tests pass; `ruff` clean. Touches nothing under `services/api`.

Next: S1–S4 external baselines on the same contract.