### PR TITLE
paper(harness): S1/S2/S3 ungoverned baselines (full-context, vector, summary)

### DIFF
--- a/paper/harness/baselines.py
+++ b/paper/harness/baselines.py
@@ -1,0 +1,225 @@
+"""Ungoverned baseline adapters S1–S3 (protocol §3).
+
+Deliberately simple, self-contained, offline systems that share MemoryOps' **LLM**
+(`app.core.llm.get_llm().complete`) and **embeddings** (`app.embeddings.embed`) so the
+model is held constant across systems (protocol §4) — the difference under test is the
+memory + governance design, not the model.
+
+- **S1 full-context** — keeps raw history, passes all of it to the model. The utility
+  *ceiling* (no retrieval loss), not a persistent-memory governance baseline.
+- **S2 plain-vector** — embed each message, cosine top-k, compose. Standard RAG memory.
+- **S3 rolling-summary** — a single growing summary string. Compression baseline.
+
+None have governance: they honestly return ``unsupported`` for capabilities they lack
+(S1/S3 cannot forget/update a specific memory; none export governance evidence) — which
+is exactly the capability-coverage signal H1 measures, never silently a failure.
+
+Note: under the deterministic stub LLM the *answer text* is a fixed template, so utility
+here is read from the **retrieved** memories (retrieval precision/recall); answer
+correctness needs a real model (protocol §11). This module is experiment tooling; it
+bridges to the frozen ``services/api`` app via a guarded ``sys.path`` insert.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+import sys
+from pathlib import Path
+
+from .types import (
+    Capability,
+    EvidenceResult,
+    ForgetResult,
+    IngestResult,
+    MemoryRef,
+    OpStatus,
+    QueryResult,
+    Scope,
+    UpdateResult,
+)
+
+_API = Path(__file__).resolve().parents[2] / "services" / "api"
+if str(_API) not in sys.path:
+    sys.path.insert(0, str(_API))
+
+
+def _llm_answer(context: str, question: str) -> str:
+    from app.core.llm import get_llm
+
+    return get_llm().complete(system=context, user=question)
+
+
+def _embed(text: str) -> list[float]:
+    from app.embeddings import embed
+
+    return embed(text)
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    if not a or not b:
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+def _unsupported_forget() -> ForgetResult:
+    return ForgetResult(status=OpStatus.UNSUPPORTED, detail="no addressable memory")
+
+
+def _unsupported_update() -> UpdateResult:
+    return UpdateResult(status=OpStatus.UNSUPPORTED, detail="no addressable memory")
+
+
+def _no_evidence() -> EvidenceResult:
+    return EvidenceResult(status=OpStatus.UNSUPPORTED, detail="ungoverned: no evidence")
+
+
+class FullContextBaseline:
+    """S1 — pass all history to the model (utility ceiling)."""
+
+    name = "S1"
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], list[tuple[str, str]]] = {}
+        self._ids = itertools.count(1)
+
+    def capabilities(self) -> set[Capability]:
+        return {Capability.INGEST, Capability.QUERY}
+
+    def reset(self) -> None:
+        self._store.clear()
+        self._ids = itertools.count(1)
+
+    def _bucket(self, s: Scope) -> list[tuple[str, str]]:
+        return self._store.setdefault((s.tenant_id, s.user_id), [])
+
+    def ingest(self, scope: Scope, message: str) -> IngestResult:
+        mid = f"s1-{next(self._ids)}"
+        self._bucket(scope).append((mid, message))
+        return IngestResult(status=OpStatus.OK, memory_ids=[mid])
+
+    def query(self, scope: Scope, question: str) -> QueryResult:
+        items = self._bucket(scope)
+        context = "\n".join(text for _, text in items)
+        return QueryResult(
+            status=OpStatus.OK,
+            answer=_llm_answer(context, question),
+            used_memory_ids=[mid for mid, _ in items],
+            retrieved=[MemoryRef(memory_id=mid, content=text) for mid, text in items],
+        )
+
+    def forget(self, scope: Scope, memory_id: str) -> ForgetResult:
+        return _unsupported_forget()
+
+    def update(self, scope: Scope, memory_id: str, content: str) -> UpdateResult:
+        return _unsupported_update()
+
+    def export_evidence(self, scope: Scope) -> EvidenceResult:
+        return _no_evidence()
+
+
+class VectorBaseline:
+    """S2 — embed, cosine top-k, compose. Standard RAG memory."""
+
+    name = "S2"
+
+    def __init__(self, *, top_k: int = 5) -> None:
+        self._top_k = top_k
+        self._store: dict[tuple[str, str], dict[str, tuple[str, list[float]]]] = {}
+        self._ids = itertools.count(1)
+
+    def capabilities(self) -> set[Capability]:
+        return {Capability.INGEST, Capability.QUERY, Capability.FORGET, Capability.UPDATE}
+
+    def reset(self) -> None:
+        self._store.clear()
+        self._ids = itertools.count(1)
+
+    def _bucket(self, s: Scope) -> dict[str, tuple[str, list[float]]]:
+        return self._store.setdefault((s.tenant_id, s.user_id), {})
+
+    def ingest(self, scope: Scope, message: str) -> IngestResult:
+        mid = f"s2-{next(self._ids)}"
+        self._bucket(scope)[mid] = (message, _embed(message))
+        return IngestResult(status=OpStatus.OK, memory_ids=[mid])
+
+    def query(self, scope: Scope, question: str) -> QueryResult:
+        qv = _embed(question)
+        scored = [
+            (mid, text, _cosine(qv, vec)) for mid, (text, vec) in self._bucket(scope).items()
+        ]
+        scored.sort(key=lambda t: t[2], reverse=True)
+        top = scored[: self._top_k]
+        context = "\n".join(text for _, text, _ in top)
+        return QueryResult(
+            status=OpStatus.OK,
+            answer=_llm_answer(context, question),
+            used_memory_ids=[mid for mid, _, _ in top],
+            retrieved=[MemoryRef(memory_id=mid, content=text, score=sc) for mid, text, sc in top],
+        )
+
+    def forget(self, scope: Scope, memory_id: str) -> ForgetResult:
+        self._bucket(scope).pop(memory_id, None)
+        return ForgetResult(status=OpStatus.OK)
+
+    def update(self, scope: Scope, memory_id: str, content: str) -> UpdateResult:
+        bucket = self._bucket(scope)
+        if memory_id not in bucket:
+            return UpdateResult(status=OpStatus.ERROR, detail="unknown memory_id")
+        bucket[memory_id] = (content, _embed(content))
+        return UpdateResult(status=OpStatus.OK)
+
+    def export_evidence(self, scope: Scope) -> EvidenceResult:
+        return _no_evidence()
+
+
+class SummaryBaseline:
+    """S3 — a single rolling summary string. Compression baseline."""
+
+    name = "S3"
+
+    def __init__(self, *, max_chars: int = 4000) -> None:
+        self._max = max_chars
+        self._summary: dict[tuple[str, str], str] = {}
+
+    def capabilities(self) -> set[Capability]:
+        return {Capability.INGEST, Capability.QUERY}
+
+    def reset(self) -> None:
+        self._summary.clear()
+
+    def ingest(self, scope: Scope, message: str) -> IngestResult:
+        key = (scope.tenant_id, scope.user_id)
+        # Offline-deterministic "summary": append and keep the most recent tail. A
+        # real deployment would LLM-summarize; that is a real-model variant.
+        merged = (self._summary.get(key, "") + "\n" + message).strip()
+        self._summary[key] = merged[-self._max :]
+        return IngestResult(status=OpStatus.OK)  # no addressable id
+
+    def query(self, scope: Scope, question: str) -> QueryResult:
+        context = self._summary.get((scope.tenant_id, scope.user_id), "")
+        return QueryResult(status=OpStatus.OK, answer=_llm_answer(context, question))
+
+    def forget(self, scope: Scope, memory_id: str) -> ForgetResult:
+        return _unsupported_forget()
+
+    def update(self, scope: Scope, memory_id: str, content: str) -> UpdateResult:
+        return _unsupported_update()
+
+    def export_evidence(self, scope: Scope) -> EvidenceResult:
+        return _no_evidence()
+
+
+def s1() -> FullContextBaseline:
+    return FullContextBaseline()
+
+
+def s2() -> VectorBaseline:
+    return VectorBaseline()
+
+
+def s3() -> SummaryBaseline:
+    return SummaryBaseline()

--- a/paper/harness/tests/test_baselines.py
+++ b/paper/harness/tests/test_baselines.py
@@ -1,0 +1,108 @@
+"""Ungoverned baselines S1 (full-context), S2 (plain-vector), S3 (rolling-summary).
+
+Each is driven through the neutral contract; kept separate from ``test_contract.py``
+because they import the shared LLM/embeddings from the frozen app. Verifies the
+contract, retrieval where applicable, scope isolation, and — importantly —
+**capability honesty**: an operation a baseline genuinely lacks returns exactly
+``unsupported`` (never a faked ok/error), which is the H1 coverage signal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from paper.harness.types import Capability, OpStatus, Scope
+
+bl = pytest.importorskip("paper.harness.baselines")  # installs the services/api bridge
+pytest.importorskip("app.embeddings", reason="frozen app not importable here")
+
+S = Scope("tenantA", "userA")
+OTHER = Scope("tenantB", "userB")
+
+
+@pytest.fixture(params=[bl.s1, bl.s2, bl.s3], ids=["S1", "S2", "S3"])
+def adapter(request):
+    a = request.param()
+    a.reset()
+    return a
+
+
+def _op(adapter, cap: Capability, scope: Scope):
+    if cap is Capability.INGEST:
+        return adapter.ingest(scope, "seed about tangerines")
+    if cap is Capability.QUERY:
+        return adapter.query(scope, "tangerines")
+    if cap is Capability.FORGET:
+        return adapter.forget(scope, "x1")
+    if cap is Capability.UPDATE:
+        return adapter.update(scope, "x1", "new")
+    if cap is Capability.EXPORT_EVIDENCE:
+        return adapter.export_evidence(scope)
+    raise AssertionError(cap)
+
+
+@pytest.mark.parametrize("cap", list(Capability))
+def test_capabilities_are_honest(adapter, cap):
+    adapter.ingest(S, "tangerines are stored in the crate")
+    result = _op(adapter, cap, S)
+    if cap in adapter.capabilities():
+        assert result.status is not OpStatus.UNSUPPORTED
+    else:
+        assert result.status is OpStatus.UNSUPPORTED, f"{cap}: {result.status}"
+
+
+def test_reset_clears(adapter):
+    adapter.ingest(S, "the vault code is 4821")
+    adapter.reset()
+    q = adapter.query(S, "vault code")
+    assert q.status is OpStatus.OK
+    # S1/S2 expose retrieved memories; after reset there are none.
+    assert q.used_memory_ids == []
+
+
+def test_scope_isolation(adapter):
+    adapter.ingest(S, "my badge number is 7788 for building access")
+    other = adapter.query(OTHER, "what is my badge number")
+    assert other.status is OpStatus.OK
+    assert other.used_memory_ids == []
+    assert all("7788" not in (m.content or "") for m in other.retrieved)
+
+
+# ── retrieval (S1 full-context, S2 vector) ───────────────────────────────────
+def test_full_context_returns_all_history():
+    a = bl.s1()
+    a.reset()
+    a.ingest(S, "my badge number is 7788")
+    a.ingest(S, "i like pizza on fridays")
+    q = a.query(S, "what is my badge number")
+    # Full-context surfaces everything (the ceiling: no retrieval loss).
+    contents = " ".join(m.content or "" for m in q.retrieved)
+    assert "7788" in contents
+    assert len(q.used_memory_ids) == 2
+
+
+def test_vector_ranks_relevant_memory_first():
+    a = bl.s2()
+    a.reset()
+    a.ingest(S, "my badge number is 7788 for building access")
+    a.ingest(S, "i enjoy hiking in the mountains on weekends")
+    q = a.query(S, "what is my badge number")
+    assert q.status is OpStatus.OK
+    assert q.retrieved, "vector baseline retrieved nothing"
+    # The badge memory (shares 'badge'/'number') ranks above the hiking distractor.
+    assert "7788" in (q.retrieved[0].content or "")
+
+
+def test_vector_forget_removes_then_absent():
+    a = bl.s2()
+    a.reset()
+    ing = a.ingest(S, "my badge number is 7788")
+    a.ingest(S, "unrelated note about coffee")
+    assert a.forget(S, ing.memory_ids[0]).status is OpStatus.OK
+    q = a.query(S, "what is my badge number")
+    assert all("7788" not in (m.content or "") for m in q.retrieved)
+
+
+def test_baselines_have_no_governance_evidence(adapter):
+    adapter.ingest(S, "remember the launch is tuesday")
+    assert adapter.export_evidence(S).status is OpStatus.UNSUPPORTED


### PR DESCRIPTION
Part of #92. Adds the three self-contained, offline ungoverned baselines on the neutral contract (#89), sharing MemoryOps' **LLM + embeddings** so the model is held constant (protocol §4).

- **S1 full-context** — all history to the model (utility ceiling).
- **S2 plain-vector** — embed → cosine top-k → compose (standard RAG memory).
- **S3 rolling-summary** — a single growing summary (compression baseline).

Each honestly returns `unsupported` for capabilities it lacks (S1/S3 can't forget/update a specific memory; none export governance evidence) — the H1 **coverage** signal, never silently a failure.

Under the deterministic stub LLM the answer text is a fixed template, so utility is read from **retrieved** memories (retrieval precision/recall); answer correctness needs a real model (protocol §11).

**Tests:** 27 cases (capability honesty, reset, scope isolation, S1 full-history recall, S2 relevance ranking + forget). Full harness suite **47 passed**; `ruff` clean. Additive (paper-only). Remaining: **S4 Mem0** (import-guarded), manifest wiring, and the runner (#92).