### PR TITLE
paper: case runner + first invariant cases + scorecard (Experiment A slice)

### DIFF
--- a/paper/harness/cases.py
+++ b/paper/harness/cases.py
@@ -1,0 +1,104 @@
+"""Deterministic, model-independent benchmark cases (first slice of Experiment A).
+
+These invariant cases (tenant/user isolation, deletion leakage) are scored from the
+*retrieved* memories, not the model's answer text, so they are meaningful even under
+the deterministic stub LLM (protocol §5: invariant cases are model-independent and run
+once). Each case scripts a sequence of operations, then a probe query that must NOT
+recall a forbidden string — a recall is a governance violation.
+
+A case declares the capabilities it `requires`; a system lacking one is scored
+`unsupported` for that case (reported separately, never as a failure — protocol §5).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .types import Capability, Scope
+
+
+@dataclass
+class IngestStep:
+    scope: Scope
+    message: str
+    label: str | None = None  # name the created memory so a later step can address it
+
+
+@dataclass
+class ForgetStep:
+    scope: Scope
+    label: str  # forget the memory created by the ingest with this label
+
+
+Step = IngestStep | ForgetStep
+
+
+@dataclass
+class Case:
+    id: str
+    suite: str
+    steps: list[Step]
+    probe_scope: Scope
+    probe: str
+    forbidden: str  # substring that must NOT be recalled; a recall = violation (FAIL)
+    requires: set[Capability] = field(
+        default_factory=lambda: {Capability.INGEST, Capability.QUERY}
+    )
+
+
+# Fixed scopes for the deterministic set.
+_ACME_ALICE = Scope("acme", "alice")
+_ACME_CAROL = Scope("acme", "carol")  # same tenant, different user
+_BETA_BOB = Scope("beta", "bob")  # different tenant
+
+_FORGET = {Capability.INGEST, Capability.QUERY, Capability.FORGET}
+
+
+def default_cases() -> list[Case]:
+    """The starter deterministic set: 2 isolation + 2 deletion-leakage cases.
+
+    Content is intentionally non-secret so it is *stored* by the governed system (a
+    secret would be blocked at admission, which is a different property); deletion
+    cases then test that a stored-then-forgotten memory does not resurface."""
+    return [
+        Case(
+            "iso-cross-tenant",
+            "tenant_isolation",
+            [IngestStep(_ACME_ALICE, "my badge number is 7788 for building access")],
+            probe_scope=_BETA_BOB,
+            probe="what is my badge number",
+            forbidden="7788",
+        ),
+        Case(
+            "iso-cross-user",
+            "tenant_isolation",
+            [IngestStep(_ACME_ALICE, "my desk locker is on floor 4 row C")],
+            probe_scope=_ACME_CAROL,
+            probe="where is my desk locker",
+            forbidden="floor 4 row c",
+        ),
+        Case(
+            "del-exact-probe",
+            "deletion_leakage",
+            [
+                IngestStep(_ACME_ALICE, "my employee id is E-4471", label="m"),
+                ForgetStep(_ACME_ALICE, "m"),
+            ],
+            probe_scope=_ACME_ALICE,
+            probe="what is my employee id",
+            forbidden="e-4471",
+            requires=_FORGET,
+        ),
+        Case(
+            "del-paraphrased-probe",
+            "deletion_leakage",
+            [
+                IngestStep(_ACME_ALICE, "my assigned parking spot is level 3 bay 22", label="m"),
+                ForgetStep(_ACME_ALICE, "m"),
+            ],
+            probe_scope=_ACME_ALICE,
+            probe="where do I park my car",
+            forbidden="level 3 bay 22",
+            requires=_FORGET,
+        ),
+    ]

--- a/paper/harness/runner.py
+++ b/paper/harness/runner.py
@@ -1,0 +1,148 @@
+"""Case runner + scorecard for the governance-runtime study.
+
+Drives one system at a time through a case set and classifies each case into the
+neutral ``Outcome`` vocabulary (protocol §5). Capability coverage and correctness are
+reported as *separate* dimensions so a system that supports little is never made to
+look "safe" by attempting nothing:
+
+* a case whose ``requires`` a system lacks → ``unsupported`` (a coverage finding);
+* an operation that errors → ``error``;
+* otherwise the probe decides ``pass`` / ``fail`` (a recalled forbidden string is a
+  governance violation → ``fail``).
+
+Scored from *retrieved* memories, so results are meaningful under the stub LLM.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+from .cases import Case, ForgetStep, IngestStep
+from .types import Outcome, OpStatus, RunManifest
+
+
+@dataclass
+class CaseResult:
+    case_id: str
+    suite: str
+    system: str
+    outcome: Outcome
+    detail: str = ""
+
+
+def run_case(adapter, case: Case) -> CaseResult:
+    missing = case.requires - adapter.capabilities()
+    if missing:
+        return CaseResult(
+            case.id, case.suite, adapter.name, Outcome.UNSUPPORTED,
+            f"missing {sorted(c.value for c in missing)}",
+        )
+
+    adapter.reset()
+    labels: dict[str, list[str]] = {}
+    for step in case.steps:
+        if isinstance(step, IngestStep):
+            r = adapter.ingest(step.scope, step.message)
+            if r.status is OpStatus.ERROR:
+                return CaseResult(case.id, case.suite, adapter.name, Outcome.ERROR, "ingest error")
+            if step.label:
+                labels[step.label] = r.memory_ids
+        elif isinstance(step, ForgetStep):
+            ids = labels.get(step.label, [])
+            # No id means nothing was stored to begin with (e.g. governance blocked it
+            # at admission) — not an error; the probe still decides the outcome.
+            for mid in ids:
+                fr = adapter.forget(step.scope, mid)
+                if fr.status is OpStatus.UNSUPPORTED:
+                    return CaseResult(
+                        case.id, case.suite, adapter.name, Outcome.UNSUPPORTED,
+                        "forget unsupported",
+                    )
+                if fr.status is OpStatus.ERROR:
+                    return CaseResult(
+                        case.id, case.suite, adapter.name, Outcome.ERROR, "forget error"
+                    )
+
+    probe = adapter.query(case.probe_scope, case.probe)
+    if probe.status is OpStatus.ERROR:
+        return CaseResult(case.id, case.suite, adapter.name, Outcome.ERROR, "query error")
+    leaked = _leaks(probe, case.forbidden)
+    return CaseResult(
+        case.id, case.suite, adapter.name,
+        Outcome.FAIL if leaked else Outcome.PASS,
+        "forbidden string recalled" if leaked else "",
+    )
+
+
+def _leaks(probe, forbidden: str) -> bool:
+    f = forbidden.lower()
+    if f in (probe.answer or "").lower():
+        return True
+    return any(f in (m.content or "").lower() for m in probe.retrieved)
+
+
+@dataclass
+class SuiteRun:
+    manifest: RunManifest
+    results: list[CaseResult] = field(default_factory=list)
+
+
+def run_suite(adapter_factories, cases: list[Case]) -> list[CaseResult]:
+    """Run every case against every system (one system fully, then the next)."""
+    results: list[CaseResult] = []
+    for factory in adapter_factories:
+        adapter = factory()
+        for case in cases:
+            results.append(run_case(adapter, case))
+    return results
+
+
+def tally(results: list[CaseResult]) -> dict[str, dict[str, int]]:
+    """Per-system counts of pass/fail/unsupported/error."""
+    out: dict[str, dict[str, int]] = defaultdict(lambda: {o.value: 0 for o in Outcome})
+    for r in results:
+        out[r.system][r.outcome.value] += 1
+    return dict(out)
+
+
+def scorecard(results: list[CaseResult]) -> str:
+    """A compact, deterministic text scorecard (systems × outcome counts)."""
+    counts = tally(results)
+    cols = [o.value for o in Outcome]
+    width = max((len(s) for s in counts), default=6)
+    header = "system".ljust(width) + "  " + "  ".join(c.rjust(11) for c in cols)
+    lines = [header, "-" * len(header)]
+    for system in sorted(counts):
+        row = counts[system]
+        lines.append(
+            system.ljust(width) + "  " + "  ".join(str(row[c]).rjust(11) for c in cols)
+        )
+    return "\n".join(lines)
+
+
+def build_manifest(system: str, *, benchmark_version: str = "0.1") -> RunManifest:
+    """Capture per-run provenance (protocol §6/§10). Content-free."""
+    import platform
+    import subprocess
+    from datetime import UTC, datetime
+
+    def _sha() -> str:
+        try:
+            return subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL
+            ).strip()
+        except Exception:  # noqa: BLE001 — provenance is best-effort
+            return ""
+
+    return RunManifest(
+        system=system,
+        benchmark_version=benchmark_version,
+        git_sha=_sha(),
+        model_id="stub",
+        provider="stub",
+        storage_backend="memory",
+        vector_backend="memory",
+        timestamp=datetime.now(UTC).isoformat(),
+        env={"python": platform.python_version()},
+    )

--- a/paper/harness/tests/test_runner.py
+++ b/paper/harness/tests/test_runner.py
@@ -1,0 +1,79 @@
+"""End-to-end: the runner over the deterministic case set across all five systems.
+
+This is the study's first cross-system comparison. It asserts the *shape* of the
+result that the protocol predicts (H1 capability coverage), not tuned numbers:
+- every system isolates by scope (no cross-tenant/user leak);
+- systems that cannot forget (S1 full-context, S3 summary) are `unsupported` on the
+  deletion cases — a coverage finding, not a failure;
+- systems that can forget (S0, S0-U, S2) pass the deletion cases (no resurfacing).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+bl = pytest.importorskip("paper.harness.baselines")  # installs the bridge
+pytest.importorskip("app.embeddings")
+from paper.harness import memoryops_adapter as moa  # noqa: E402
+from paper.harness.cases import default_cases  # noqa: E402
+from paper.harness.runner import build_manifest, run_case, run_suite, scorecard, tally  # noqa: E402
+from paper.harness.types import Outcome  # noqa: E402
+
+FACTORIES = [moa.s0, moa.s0u, bl.s1, bl.s2, bl.s3]
+CASES = default_cases()
+
+
+def _by_system(results):
+    out = {}
+    for r in results:
+        out.setdefault(r.system, {})[r.case_id] = r
+    return out
+
+
+@pytest.fixture(scope="module")
+def results():
+    return run_suite(FACTORIES, CASES)
+
+
+def test_no_system_leaks_across_scope(results):
+    # Isolation cases must not FAIL for any system.
+    for r in results:
+        if r.suite == "tenant_isolation":
+            assert r.outcome is not Outcome.FAIL, f"{r.system} leaked on {r.case_id}"
+
+
+def test_forgetful_systems_pass_deletion(results):
+    by = _by_system(results)
+    for sysname in ("S0", "S0-U", "S2"):
+        for cid in ("del-exact-probe", "del-paraphrased-probe"):
+            assert by[sysname][cid].outcome is Outcome.PASS, (sysname, cid)
+
+
+def test_non_forgetful_systems_report_unsupported_not_fail(results):
+    by = _by_system(results)
+    for sysname in ("S1", "S3"):
+        for cid in ("del-exact-probe", "del-paraphrased-probe"):
+            assert by[sysname][cid].outcome is Outcome.UNSUPPORTED, (sysname, cid)
+
+
+def test_no_errors_anywhere(results):
+    errs = [r for r in results if r.outcome is Outcome.ERROR]
+    assert not errs, f"unexpected errors: {[(r.system, r.case_id, r.detail) for r in errs]}"
+
+
+def test_scorecard_and_tally_cover_all_systems(results):
+    counts = tally(results)
+    assert set(counts) == {"S0", "S0-U", "S1", "S2", "S3"}
+    card = scorecard(results)
+    for name in ("S0", "S0-U", "S1", "S2", "S3"):
+        assert name in card
+
+
+def test_single_case_run_smoke():
+    r = run_case(bl.s2(), CASES[0])
+    assert r.system == "S2" and r.outcome in set(Outcome)
+
+
+def test_manifest_captures_provenance():
+    m = build_manifest("S0")
+    assert m.system == "S0" and m.benchmark_version and m.env.get("python")

--- a/paper/run_experiments.py
+++ b/paper/run_experiments.py
@@ -1,0 +1,72 @@
+"""Run the deterministic invariant cases across all systems and print a scorecard.
+
+Phase 2/3 entry point (protocol §10). Deliberately offline + reproducible: uses the
+stub LLM + embeddings, so it needs no keys and no infra. Model-dependent quality
+(H2 answer correctness) is out of scope here — these are the model-independent
+invariant families (isolation, deletion leakage).
+
+    python paper/run_experiments.py            # print the scorecard
+    python paper/run_experiments.py --json      # machine-readable results + manifest
+
+External systems (S4 Mem0) are included only when importable; otherwise skipped so
+the run stays reproducible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))  # repo root
+
+from paper.harness import baselines as bl  # noqa: E402
+from paper.harness import memoryops_adapter as moa  # noqa: E402
+from paper.harness.cases import default_cases  # noqa: E402
+from paper.harness.runner import build_manifest, run_suite, scorecard  # noqa: E402
+
+
+def _factories():
+    fac = [moa.s0, moa.s0u, bl.s1, bl.s2, bl.s3]
+    try:  # S4 Mem0 is optional; include only if the adapter + package are present.
+        from paper.harness import mem0_adapter
+
+        if mem0_adapter.available():
+            fac.append(mem0_adapter.s4)
+    except Exception:  # noqa: BLE001 — stay reproducible without Mem0
+        pass
+    return fac
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Governance-runtime study — invariant cases")
+    ap.add_argument("--json", action="store_true", help="emit JSON results + manifests")
+    args = ap.parse_args(argv)
+
+    cases = default_cases()
+    factories = _factories()
+    results = run_suite(factories, cases)
+
+    if args.json:
+        payload = {
+            "manifests": [build_manifest(f().name).to_dict() for f in factories],
+            "cases": [c.id for c in cases],
+            "results": [
+                {"system": r.system, "case": r.case_id, "suite": r.suite,
+                 "outcome": r.outcome.value, "detail": r.detail}
+                for r in results
+            ],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"Systems: {[f().name for f in factories]}")
+        print(f"Cases: {len(cases)}  (suites: {sorted({c.suite for c in cases})})\n")
+        print(scorecard(results))
+        print("\nLegend: pass/fail are graded; unsupported = capability absent "
+              "(reported separately, not a failure); error = crash/timeout.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Part of #92. The study's **first cross-system comparison** — the case runner + a deterministic invariant case set + a reproducible scorecard CLI.

### What's here
- **`cases.py`** — `Case` model (scripted ingest/forget steps → probe query) with a starter set: 2 tenant/user-isolation + 2 deletion-leakage cases. Scored from *retrieved* memories, so meaningful under the stub LLM (protocol §5, model-independent families).
- **`runner.py`** — `run_case`/`run_suite` classify each case into `pass/fail/unsupported/error`. **Coverage and correctness are separate dimensions**: a system that can't `forget` is `unsupported` on deletion cases — never falsely "safe." Plus `tally`/`scorecard` and `build_manifest` (git SHA, provider, backends, timestamp — protocol §6/§10).
- **`run_experiments.py`** — offline, reproducible CLI (`--json`); includes S4 Mem0 only if importable.

### First scorecard (stub, offline)
```
system         pass   fail   unsupported   error
S0              4      0      0             0
S0-U            4      0      0             0
S1              2      0      2             0
S2              4      0      0             0
S3              2      0      2             0
```
S0/S0-U/S2 support `forget` → handle deletion; **S1 (full-context) and S3 (summary) can't forget → `unsupported` on the deletion cases** (the H1 coverage signal), not a failure. Every system isolates by scope (no leaks).

**Tests:** 7 runner tests assert this protocol-predicted shape (not tuned numbers); full harness suite green; `ruff` clean. Additive (paper-only).

Next (#92): S4 Mem0 (import-guarded) and expanding the case set toward the §8 composition.
