### PR TITLE
fix(platform): unify dependencies and enforce provider integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,81 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  packaging:
+    name: Packaging — dependency source of truth + installable wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      # services/api/pyproject.toml is authoritative; every requirements*.txt is
+      # generated from it. Before this gate the two had silently diverged (pyproject
+      # pinned fastapi 0.139.2 / uvicorn 0.37.0 / pydantic-settings 2.6.1 while
+      # requirements.txt pinned 0.140.0 / 0.51.0 / 2.14.2), so Docker+CI and the
+      # published wheel resolved different dependency sets and a green run proved
+      # nothing about either.
+      - name: Dependency files match pyproject.toml
+        run: python scripts/sync_dependencies.py --check
+
+      # A wheel that imports only because the repo is on sys.path is not a wheel.
+      # Build it, install into a clean venv with no source checkout on the path, and
+      # boot the real app from site-packages.
+      - name: Build the API wheel
+        working-directory: services/api
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+
+      - name: Install the wheel into a clean environment and boot it
+        working-directory: services/api
+        run: |
+          python -m venv /tmp/wheel-env
+          /tmp/wheel-env/bin/pip install --upgrade pip
+          /tmp/wheel-env/bin/pip install dist/*.whl
+          # cd out of the source tree so a missing packaged file cannot be masked by
+          # the local checkout — which is exactly how the missing prompt assets went
+          # unnoticed: app/llm/prompts/*.md are read from disk at runtime and were
+          # absent from the wheel, so every structured-intelligence call raised
+          # PromptNotFoundError in a wheel deployment while passing from a checkout.
+          cd /tmp
+          MEMORYOPS_STORAGE=memory /tmp/wheel-env/bin/python - <<'PY'
+          import app.main  # noqa: F401
+          from app.llm.prompt_registry import available_tasks, get_prompt
+
+          for task in available_tasks():
+              assert get_prompt(task).strip(), f"empty prompt asset: {task}"
+          print("wheel import ok; prompt assets loaded:", available_tasks())
+          PY
+
+      # The provider adapters import their SDKs lazily, so a missing SDK shows up only
+      # at call time (as a silent stub degradation). Prove each advertised extra
+      # actually resolves and exposes the module its adapter imports.
+      - name: Optional extras resolve to the modules the adapters import
+        working-directory: services/api
+        run: |
+          set -euo pipefail
+          # extra:module — module names must match the adapter imports exactly.
+          for pair in "openai:openai" \
+                      "anthropic:anthropic" \
+                      "gemini:google.generativeai" \
+                      "qdrant:qdrant_client" \
+                      "lancedb:lancedb" \
+                      "weaviate:weaviate"; do
+            extra="${pair%%:*}"; module="${pair##*:}"
+            echo "::group::extra '$extra' -> module '$module'"
+            python -m venv "/tmp/extra-$extra"
+            "/tmp/extra-$extra/bin/pip" install --quiet --upgrade pip
+            "/tmp/extra-$extra/bin/pip" install --quiet ".[$extra]"
+            "/tmp/extra-$extra/bin/python" -c "import importlib; importlib.import_module('$module'); print('$extra ok')"
+            rm -rf "/tmp/extra-$extra"
+            echo "::endgroup::"
+          done
+
   api:
     name: API — tests + lint + evals
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-live.yml
+++ b/.github/workflows/nightly-live.yml
@@ -44,7 +44,35 @@ jobs:
         working-directory: services/api
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+          # requirements-providers.txt is REQUIRED here: the OpenAI adapter imports the
+          # `openai` SDK lazily and degrades to the deterministic stub when it is absent.
+          # This job previously installed only requirements.txt (no provider SDKs) while
+          # setting MEMORYOPS_LLM_PROVIDER=openai, so the "live provider" recall gate was
+          # silently scoring stub output rather than OpenAI.
+          python -m pip install -r requirements.txt -r requirements-providers.txt
+
+      # Fail loudly rather than re-run a stub smoke test dressed up as a live one.
+      - name: Assert the OpenAI provider is genuinely selected
+        if: steps.check.outputs.has_key == 'true'
+        working-directory: services/api
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MEMORYOPS_LLM_PROVIDER: openai
+        run: |
+          python - <<'PY'
+          from importlib.util import find_spec
+
+          from app.core.config import get_settings
+          from app.llm.registry import build_llm_provider
+
+          assert find_spec("openai") is not None, "openai SDK not installed"
+          provider = build_llm_provider(get_settings())
+          assert provider.name == "openai", (
+              f"expected the openai provider, got {provider.name!r} — this run would "
+              "have scored the stub, not a live model"
+          )
+          print("live provider confirmed:", provider.name)
+          PY
 
       - name: Extraction quality vs OpenAI (recall gate)
         if: steps.check.outputs.has_key == 'true'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -28,6 +28,13 @@ jobs:
             req: services/api/requirements.txt
           - label: api-postgres
             req: services/api/requirements-postgres.txt
+          # The provider SDKs and the full production set are what the API and worker
+          # images actually install, so they must be audited too — auditing only the
+          # base set would leave the deployed dependency tree unscanned.
+          - label: api-providers
+            req: services/api/requirements-providers.txt
+          - label: api-production
+            req: services/api/requirements-production.txt
           - label: sdk
             # No `req`: the SDK declares deps in pyproject, so we audit the package
             # directory instead of a requirements file (empty `req` selects that path).

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ venv/
 .pytest_cache/
 .mypy_cache/
 *.egg-info/
+# setuptools/`python -m build` artifacts (the packaging CI job builds a wheel).
+build/
+dist/
 
 # Node
 node_modules/

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,8 +1,13 @@
 # MemoryOps AI — Web image (Next.js).
 FROM node:20-slim AS deps
 WORKDIR /app
-COPY package.json package-lock.json* ./
-RUN npm ci || npm install
+# package-lock.json is required (not `package-lock.json*`): a missing lockfile must
+# fail the build, not silently resolve fresh transitives at image-build time.
+COPY package.json package-lock.json ./
+# `npm ci` only — never `|| npm install`. The fallback defeated the lockfile: a stale
+# or absent lock silently regenerated the tree, so the image could ship dependency
+# versions no one reviewed and CI never saw.
+RUN npm ci
 
 FROM node:20-slim AS build
 WORKDIR /app

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -1,0 +1,126 @@
+# Dependency management & provider packaging
+
+`services/api/pyproject.toml` is the **single source of truth** for API and worker
+dependencies. Every `services/api/requirements*.txt` is generated from it and
+verified in CI.
+
+## Why
+
+The API had two independent dependency sources that had silently diverged:
+
+| Package | `pyproject.toml` | `requirements.txt` |
+| --- | --- | --- |
+| fastapi | 0.139.2 | 0.140.0 |
+| uvicorn | 0.37.0 | 0.51.0 |
+| pydantic-settings | 2.6.1 | 2.14.2 |
+| pytest-recording | *(absent)* | 0.13.2 |
+
+Docker images and CI install the requirements files; `pip install .` and the
+published wheel resolve the pyproject set. A green CI run therefore proved nothing
+about the package metadata, and nothing about the image once the two drifted.
+
+## Workflow
+
+```bash
+# 1. Edit dependencies in services/api/pyproject.toml (never a requirements file)
+# 2. Regenerate
+python scripts/sync_dependencies.py
+# 3. Commit both pyproject.toml and the regenerated requirements files
+```
+
+CI (`packaging` job) runs `python scripts/sync_dependencies.py --check` and fails on
+drift. `tests/test_packaging.py` runs the same check locally.
+
+Generated files (all carry a DO-NOT-EDIT banner):
+
+| File | Contents | Used by |
+| --- | --- | --- |
+| `requirements.txt` | `[project].dependencies` | base install, SDK CI |
+| `requirements-postgres.txt` | `postgres` extra | Postgres CI |
+| `requirements-providers.txt` | `providers` extra | nightly live-provider smoke |
+| `requirements-production.txt` | `production` extra | API + worker images |
+| `requirements-dev.txt` | `dev` extra + `-r requirements.txt` | tests, lint |
+
+## Optional extras
+
+```bash
+pip install 'memoryops-api[openai]'      # LLM + embeddings via OpenAI
+pip install 'memoryops-api[anthropic]'
+pip install 'memoryops-api[gemini]'
+pip install 'memoryops-api[providers]'   # all three
+pip install 'memoryops-api[qdrant]'      # or [lancedb] / [weaviate]
+pip install 'memoryops-api[production]'  # postgres + all providers (what the images install)
+```
+
+Every provider adapter imports its SDK **lazily**, so the package stays importable
+and the test suite stays fully offline without any of these. That laziness is also
+how the SDKs went missing from every runtime image: selecting
+`MEMORYOPS_LLM_PROVIDER=openai` in an image without `openai` installed silently
+degraded to the deterministic stub, with only a log line to show for it.
+
+> The `gemini` extra pins **`google-generativeai`** (module `google.generativeai`),
+> the legacy SDK that `app/llm/gemini_provider.py` actually imports — *not* the newer
+> `google-genai` (module `google.genai`). Migrating the adapter is tracked follow-up
+> work and needs a live-key test to land safely. `test_provider_extras_pin_the_module_each_adapter_imports`
+> pins this correspondence so an extra can never install an SDK its adapter cannot use.
+
+### Fail-closed under `MEMORYOPS_PROFILE=production`
+
+`Settings.production_readiness_errors()` now refuses to start when a networked
+provider is selected but cannot actually be used:
+
+- `llm_provider` set to `openai`/`anthropic`/`gemini` with no API key, or with the
+  SDK missing.
+- `embeddings_provider='openai'` with no key or SDK.
+- `vector_index` set to an external backend whose client is not installed.
+
+Dev keeps degrading silently — offline tests and the demo depend on it.
+
+## Embedding-space integrity
+
+The OpenAI embedding adapter used to catch provider errors and return
+`StubEmbeddingProvider` output in their place. That reads like graceful degradation
+(invariant #4) but is a silent correctness bug: the stub vector lives in a
+**different embedding space** from the model's, yet is indistinguishable from a real
+one once persisted. A transient outage permanently poisoned the index with vectors
+whose distances are meaningless — no signal, and no way to identify affected rows.
+
+Invariant #4 requires that a failure never *blocks the response*. It does not
+license fabricating data. The adapter now raises `EmbeddingUnavailable`, and the
+existing call sites degrade correctly:
+
+- `write_service` wraps it in `safe_call(..., default=[])` → the memory is stored
+  with **no vector** and ranks by keyword only; it can be re-embedded later.
+- `retriever` catches it and returns `mode="fallback"` (keyword-only retrieval).
+
+Covered by `tests/test_embedding_integrity.py`.
+
+> Not yet implemented: an async re-embedding worker, and per-vector
+> `provider`/`model`/`dimension`/`embedding_version` columns to make un-embedded and
+> stale-space rows queryable. Both are follow-up work — the change above stops new
+> contamination, it does not backfill or label existing vectors.
+
+## Packaging
+
+The wheel must carry everything the app reads at runtime. `app/llm/prompts/*.md` are
+loaded from disk by `app/llm/prompt_registry.py`; with no `package-data` declared
+they were **omitted from the wheel**, so every structured-intelligence call raised
+`PromptNotFoundError` in a wheel-installed deployment while passing in dev and CI
+(where the source checkout supplies the files).
+
+`[tool.setuptools.package-data]` now declares them, and two guards keep it that way:
+
+- `tests/test_packaging.py::test_every_runtime_asset_dir_is_declared_as_package_data`
+  fails when any new non-`.py` file appears under `app/` without a matching
+  `package-data` entry.
+- The `packaging` CI job builds the wheel, installs it into a clean venv, `cd`s out
+  of the source tree, and boots it — so a missing packaged file cannot be masked by
+  the checkout.
+
+## Node
+
+`apps/web/Dockerfile` uses `npm ci` only. The previous `npm ci || npm install`
+fallback defeated the lockfile: a stale or absent `package-lock.json` silently
+regenerated the dependency tree, so the image could ship versions no one reviewed
+and CI never saw. The lockfile is also now copied non-optionally
+(`package-lock.json`, not `package-lock.json*`), so a missing lock fails the build.

--- a/scripts/sync_dependencies.py
+++ b/scripts/sync_dependencies.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Generate (and drift-check) services/api/requirements*.txt from pyproject.toml.
+
+Why this exists
+---------------
+The API had two independent dependency sources that had silently diverged:
+``pyproject.toml`` pinned fastapi 0.139.2 / uvicorn 0.37.0 / pydantic-settings 2.6.1
+while ``requirements.txt`` pinned 0.140.0 / 0.51.0 / 2.14.2. Docker and CI install
+the requirements files; ``pip install .`` and the published wheel resolve the
+pyproject set. A green CI run therefore proved nothing about the package metadata,
+and nothing about the image if the two drifted again.
+
+``pyproject.toml`` is now authoritative. This script materialises every
+requirements file listed under ``[tool.memoryops.requirements]`` from it.
+
+Usage
+-----
+    python scripts/sync_dependencies.py            # rewrite the generated files
+    python scripts/sync_dependencies.py --check    # exit 1 on drift (CI gate)
+
+Deliberately dependency-free: stdlib ``tomllib`` only, so it runs in any clean
+environment (including the CI job that runs before deps are installed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+API_DIR = REPO_ROOT / "services" / "api"
+PYPROJECT = API_DIR / "pyproject.toml"
+
+BANNER = (
+    "# ─────────────────────────────────────────────────────────────────────────\n"
+    "# GENERATED FILE — DO NOT EDIT BY HAND.\n"
+    "#\n"
+    "# Source of truth: services/api/pyproject.toml\n"
+    "# Regenerate:      python scripts/sync_dependencies.py\n"
+    "# Verify:          python scripts/sync_dependencies.py --check   (CI gate)\n"
+    "#\n"
+    "# Hand-edits are reverted by the next regeneration and fail the CI drift gate.\n"
+    "# ─────────────────────────────────────────────────────────────────────────\n"
+)
+
+
+def load_pyproject() -> dict:
+    with PYPROJECT.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def render(name: str, spec: dict, project: dict) -> str:
+    """Render one requirements file from its spec."""
+    base_deps: list[str] = project.get("dependencies", [])
+    extras_table: dict[str, list[str]] = project.get("optional-dependencies", {})
+
+    lines = [BANNER]
+
+    for required in spec.get("requires", []):
+        lines.append(f"-r {required}\n")
+    if spec.get("requires"):
+        lines.append("\n")
+
+    if spec.get("include_base", False):
+        lines.append("# [project].dependencies\n")
+        lines.extend(f"{dep}\n" for dep in base_deps)
+        lines.append("\n")
+
+    for extra in spec.get("extras", []):
+        if extra not in extras_table:
+            raise SystemExit(
+                f"{name}: unknown extra {extra!r}. "
+                f"Known extras: {', '.join(sorted(extras_table)) or '(none)'}"
+            )
+        lines.append(f"# [project.optional-dependencies].{extra}\n")
+        lines.extend(f"{dep}\n" for dep in extras_table[extra])
+        lines.append("\n")
+
+    # Collapse the trailing blank line so the file ends with exactly one newline.
+    text = "".join(lines)
+    return text.rstrip("\n") + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the generated files match pyproject.toml; exit 1 on drift",
+    )
+    args = parser.parse_args()
+
+    data = load_pyproject()
+    project = data["project"]
+    targets = data.get("tool", {}).get("memoryops", {}).get("requirements", {})
+    if not targets:
+        raise SystemExit(
+            "no [tool.memoryops.requirements] entries in pyproject.toml — nothing to generate"
+        )
+
+    drifted: list[str] = []
+    written: list[str] = []
+
+    for name, spec in targets.items():
+        path = API_DIR / name
+        expected = render(name, spec, project)
+        current = path.read_text() if path.exists() else None
+
+        if current == expected:
+            continue
+
+        if args.check:
+            drifted.append(name)
+            if current is None:
+                print(f"  ✗ {name}: missing (would be generated)")
+            else:
+                print(f"  ✗ {name}: differs from pyproject.toml")
+        else:
+            path.write_text(expected)
+            written.append(name)
+            print(f"  ✓ wrote services/api/{name}")
+
+    if args.check:
+        if drifted:
+            print(
+                "\nDependency drift detected: the generated requirements files no longer\n"
+                "match services/api/pyproject.toml. pyproject.toml is the source of truth.\n"
+                "\n    python scripts/sync_dependencies.py\n\n"
+                "then commit the regenerated files.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"✓ all {len(targets)} requirements files match pyproject.toml")
+        return 0
+
+    if not written:
+        print(f"✓ all {len(targets)} requirements files already up to date")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -7,9 +7,16 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /app
 
-# Install runtime + postgres deps first for layer caching.
-COPY requirements.txt requirements-postgres.txt ./
-RUN pip install --no-cache-dir -r requirements.txt -r requirements-postgres.txt
+# Install runtime + production deps first for layer caching. All requirements files
+# are generated from pyproject.toml (scripts/sync_dependencies.py) and drift-checked
+# in CI, so this image and `pip install .` resolve the same set.
+#
+# requirements-production.txt carries Postgres *and* the openai/anthropic/gemini SDKs:
+# the provider adapters import their SDK lazily, so an image without them silently
+# degraded MEMORYOPS_LLM_PROVIDER=openai to the stub. Under MEMORYOPS_PROFILE=production
+# that combination is now a startup error, so the image must be able to honour it.
+COPY requirements.txt requirements-production.txt ./
+RUN pip install --no-cache-dir -r requirements.txt -r requirements-production.txt
 
 COPY . .
 

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -302,6 +302,86 @@ class Settings(BaseSettings):
                 "public_evals=true: the eval trigger is a denial-of-wallet vector when "
                 "public — set MEMORYOPS_PUBLIC_EVALS=false."
             )
+        errors.extend(self._provider_readiness_errors())
+        return errors
+
+    def _provider_readiness_errors(self) -> list[str]:
+        """Fail-closed checks for provider selection (production profile only).
+
+        Every provider adapter imports its SDK lazily and degrades to a stub/no-op
+        when the SDK or key is missing, so the app always starts. That is right for
+        dev and for tests (which must run offline), but in production it means an
+        operator can set MEMORYOPS_LLM_PROVIDER=openai, see a healthy service, and
+        be served deterministic stub output indefinitely with only a log line. A
+        deployment that asked for a real provider must fail loudly instead.
+        """
+        from importlib.util import find_spec
+
+        errors: list[str] = []
+
+        def missing(module: str) -> bool:
+            # find_spec only resolves the module; it does not import the SDK, so this
+            # stays cheap and side-effect-free at startup.
+            try:
+                return find_spec(module) is None
+            except (ImportError, ValueError):  # namespace/partial install
+                return True
+
+        # ── LLM provider ────────────────────────────────────────────────────
+        llm_requirements = {
+            "openai": ("openai", "openai", self.openai_api_key, "OPENAI_API_KEY"),
+            "anthropic": ("anthropic", "anthropic", self.anthropic_api_key, "ANTHROPIC_API_KEY"),
+            # Legacy SDK module — matches app/llm/gemini_provider.py's actual import.
+            "gemini": ("google.generativeai", "gemini", self.gemini_api_key, "GEMINI_API_KEY"),
+        }
+        if self.llm_provider in llm_requirements:
+            module, extra, key, key_env = llm_requirements[self.llm_provider]
+            if not key:
+                errors.append(
+                    f"llm_provider={self.llm_provider!r} but {key_env} is unset: the provider "
+                    "would silently degrade to the deterministic stub — set the key or "
+                    "MEMORYOPS_LLM_PROVIDER=stub."
+                )
+            if missing(module):
+                errors.append(
+                    f"llm_provider={self.llm_provider!r} but the {module!r} SDK is not "
+                    f"installed: the provider would silently degrade to the deterministic "
+                    f"stub — install it (pip install 'memoryops-api[{extra}]')."
+                )
+
+        # ── Embedding provider ──────────────────────────────────────────────
+        # Stricter than the LLM path: a wrong embedding does not just degrade one
+        # answer, it persists a vector in the wrong space (see app/embeddings/providers.py).
+        if self.embeddings_provider == "openai":
+            if not self.openai_api_key:
+                errors.append(
+                    "embeddings_provider='openai' but OPENAI_API_KEY is unset: memories "
+                    "would be embedded with the stub and stored in a different vector "
+                    "space than the configured model — set the key or "
+                    "MEMORYOPS_EMBEDDING_PROVIDER=stub."
+                )
+            if missing("openai"):
+                errors.append(
+                    "embeddings_provider='openai' but the 'openai' SDK is not installed: "
+                    "memories would be embedded with the stub — install it "
+                    "(pip install 'memoryops-api[openai]')."
+                )
+
+        # ── External vector backend (ADR-021) ───────────────────────────────
+        vector_requirements = {
+            "qdrant": ("qdrant_client", "qdrant"),
+            "lancedb": ("lancedb", "lancedb"),
+            "weaviate": ("weaviate", "weaviate"),
+        }
+        if self.vector_index in vector_requirements:
+            module, extra = vector_requirements[self.vector_index]
+            if missing(module):
+                errors.append(
+                    f"vector_index={self.vector_index!r} but the {module!r} client is not "
+                    f"installed: the factory would fall back to the in-memory index, which "
+                    f"loses all vectors on restart — install it "
+                    f"(pip install 'memoryops-api[{extra}]')."
+                )
         return errors
 
 

--- a/services/api/app/embeddings/providers.py
+++ b/services/api/app/embeddings/providers.py
@@ -1,10 +1,26 @@
 """Optional network embedding providers + provider selection.
 
-Rules (v0.3):
+Rules:
   * Tests and offline runs never require a real key — selection falls back to the
-    deterministic stub whenever a provider is unconfigured or unavailable.
-  * A configured provider that raises at call time degrades to the stub per call
-    (invariant #4), so a flaky embeddings API never blocks the read path.
+    deterministic stub whenever a provider is unconfigured (dev profile only).
+  * A configured provider that raises at call time raises ``EmbeddingUnavailable``
+    rather than substituting a stub vector.
+
+Why a failed embedding must NOT become a stub vector
+----------------------------------------------------
+This module used to catch provider errors and return ``StubEmbeddingProvider``
+output in their place. That looks like graceful degradation (invariant #4) but it
+is a correctness bug: the stub vector is a *different embedding space* from the
+model's, yet it is indistinguishable from a real one once persisted. A transient
+OpenAI outage therefore permanently poisoned the index with vectors whose cosine
+distance to real ones is meaningless — silently degrading retrieval quality with
+no signal, and no way to find the affected rows afterwards.
+
+Invariant #4 says a retrieval failure must never *block the response*; it does not
+say a failure may fabricate data. The correct degradation is **no vector**: callers
+(`write_service`, `retriever`) already wrap embedding in `safe_call(..., default=[])`,
+and an empty embedding degrades that memory to keyword-only ranking — recoverable,
+observable, and re-embeddable later. See docs/embedding-integrity.md.
 """
 
 from __future__ import annotations
@@ -14,6 +30,15 @@ from ..core.logging import get_logger
 from .stub import StubEmbeddingProvider
 
 logger = get_logger("memoryops.embeddings")
+
+
+class EmbeddingUnavailable(RuntimeError):
+    """The configured embedding provider could not produce a vector.
+
+    Raised instead of returning a stub vector from a different embedding space.
+    Callers degrade to keyword-only ranking (empty embedding) rather than
+    persisting a fabricated vector.
+    """
 
 
 class OpenAIEmbeddingProvider:
@@ -30,7 +55,6 @@ class OpenAIEmbeddingProvider:
         self._api_key = api_key
         self._model = model
         self.dim = dim
-        self._fallback = StubEmbeddingProvider(dim)
 
     def _client(self):  # pragma: no cover - needs the openai package + key
         from openai import OpenAI
@@ -44,30 +68,45 @@ class OpenAIEmbeddingProvider:
             return vec[: self.dim]
         return vec + [0.0] * (self.dim - len(vec))
 
+    def _fail(self, exc: Exception, op: str) -> EmbeddingUnavailable:
+        # Content-free log: provider/model/op only, never the embedded text.
+        logger.warning(
+            "openai embedding failed; degrading to no vector (keyword-only)",
+            extra={
+                "event": "embed_unavailable",
+                "provider": self.name,
+                "model": self._model,
+                "op": op,
+                "error": type(exc).__name__,
+            },
+        )
+        return EmbeddingUnavailable(f"{self.name}/{self._model} {op} failed: {type(exc).__name__}")
+
     def embed_text(self, text: str) -> list[float]:
         try:  # pragma: no cover - exercised only with a real key
             resp = self._client().embeddings.create(model=self._model, input=text)
             return self._fit(list(resp.data[0].embedding))
-        except Exception:  # noqa: BLE001 — degrade to deterministic stub
-            logger.warning("openai embedding failed; using stub", extra={"event": "embed_fallback"})
-            return self._fallback.embed_text(text)
+        except Exception as exc:  # noqa: BLE001 — never fabricate a cross-space vector
+            raise self._fail(exc, "embed_text") from exc
 
     def embed_batch(self, texts: list[str]) -> list[list[float]]:
         try:  # pragma: no cover - exercised only with a real key
             resp = self._client().embeddings.create(model=self._model, input=texts)
             return [self._fit(list(d.embedding)) for d in resp.data]
-        except Exception:  # noqa: BLE001
-            logger.warning("openai batch embedding failed; using stub",
-                           extra={"event": "embed_fallback"})
-            return self._fallback.embed_batch(texts)
+        except Exception as exc:  # noqa: BLE001
+            raise self._fail(exc, "embed_batch") from exc
 
 
 def build_provider():
     """Select an embedding provider from settings, defaulting to the stub.
 
     ``MEMORYOPS_EMBEDDING_PROVIDER`` / ``embeddings_provider`` accepts
-    ``stub`` (alias ``heuristic``) or ``openai``. ``openai`` without a key
-    silently falls back to the stub so the app always starts.
+    ``stub`` (alias ``heuristic``) or ``openai``.
+
+    ``openai`` without a key falls back to the stub so the app always starts in the
+    dev profile. Under ``MEMORYOPS_PROFILE=production`` that combination is rejected
+    at startup by ``Settings.production_readiness_errors`` — a production deployment
+    that asked for real embeddings must not quietly serve stub ones.
     """
     settings = get_settings()
     dim = settings.embedding_dim
@@ -77,5 +116,10 @@ def build_provider():
             api_key=settings.openai_api_key,
             model=settings.openai_embedding_model,
             dim=dim,
+        )
+    if provider == "openai":
+        logger.warning(
+            "embedding provider 'openai' selected without an API key; using stub",
+            extra={"event": "embed_provider_fallback", "provider": "stub", "fallback": True},
         )
     return StubEmbeddingProvider(dim)

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -9,19 +9,32 @@ description = "MemoryOps AI — enterprise memory governance API (write path)"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
 license = "MIT"
+# ── Dependency source of truth ───────────────────────────────────────────────
+# This file is authoritative. Every `requirements*.txt` in this directory is
+# GENERATED from the tables below by `scripts/sync_dependencies.py`, and CI fails
+# if they drift (`--check`). Never hand-edit a requirements file — edit here and
+# regenerate. Otherwise a wheel install and a Docker build resolve to two
+# different dependency sets, and a green CI run proves nothing about the image.
+#
 # Exact pins (==X.Y.Z), no ranges. Rationale (per hermes-agent): a range lets
 # PyPI ship a fresh transitive at any time with no review on our side. Exact
 # pins mean a new version only reaches us via an intentional bump here. Smaller
 # dependency set = smaller blast radius for the next supply-chain attack.
 dependencies = [
-  "fastapi==0.139.2",
-  # Explicit patched pin — <1.0.1 carries the PYSEC-2026 Starlette advisories.
+  "fastapi==0.140.0",
+  # Explicit patched pin — <1.0.1 carries the PYSEC-2026-161/248/249/1942/2280/2281
+  # Starlette advisories. Pinned directly (not just transitively via fastapi) so a
+  # patched Starlette can't silently regress.
   "starlette==1.3.1",
-  "uvicorn[standard]==0.37.0",
+  "uvicorn[standard]==0.51.0",
   "pydantic==2.13.4",
-  "pydantic-settings==2.6.1",
+  "pydantic-settings==2.14.2",
   "tenacity==9.1.4",
   "python-dotenv==1.2.2",
+  # JWT verification (auth adapters, off by default). The [crypto] extra ships the
+  # 'cryptography' backend so RS*/ES*/JWKS (advertised in docs/auth-adapters.md) work
+  # out of the box, not just HS*. Pinned >=2.13.0: releases before 2.12.0 are affected
+  # by a high-severity JWT critical-header validation vulnerability.
   "PyJWT[crypto]==2.13.0",
 ]
 
@@ -31,11 +44,71 @@ postgres = [
   "psycopg[binary]==3.2.3",
   "pgvector==0.3.6",
 ]
+
+# ── LLM / embedding provider SDKs ────────────────────────────────────────────
+# The adapters in app/llm and app/embeddings import these lazily so the package
+# stays importable (and the test suite stays offline) without them. That laziness
+# is what let the SDKs go missing from every runtime image: selecting
+# MEMORYOPS_LLM_PROVIDER=openai in an image without `openai` installed silently
+# degraded to the stub. Under MEMORYOPS_PROFILE=production that is now a
+# fail-closed startup error (Settings.production_readiness_errors), so the
+# production extra below carries all three.
+openai = ["openai==2.52.0"]
+anthropic = ["anthropic==0.120.2"]
+# NOTE: this is the legacy `google-generativeai` SDK (module `google.generativeai`),
+# not the newer `google-genai` (module `google.genai`). It is pinned to match what
+# app/llm/gemini_provider.py actually imports — pinning the newer package here would
+# install an SDK the adapter cannot use, which is precisely the failure mode this
+# dependency unification exists to prevent. Migrating the adapter to `google-genai`
+# is tracked as follow-up work and needs a live-key test to land safely.
+gemini = ["google-generativeai==0.8.6"]
+providers = [
+  "openai==2.52.0",
+  "anthropic==0.120.2",
+  "google-generativeai==0.8.6",
+]
+
+# ── Optional vector backends (ADR-021) ───────────────────────────────────────
+# Import-guarded adapters; `memory` (the default) and Postgres/pgvector need none
+# of these. Selecting one in production without its client installed is likewise
+# a fail-closed startup error.
+qdrant = ["qdrant-client==1.18.0"]
+lancedb = ["lancedb==0.36.0"]
+weaviate = ["weaviate-client==4.22.0"]
+
+# The dependency set the production API/worker images install: Postgres + all
+# three provider SDKs. They are small, and shipping them means
+# MEMORYOPS_LLM_PROVIDER can be switched by env var without rebuilding a
+# provider-specific image.
+production = [
+  "sqlalchemy==2.0.36",
+  "psycopg[binary]==3.2.3",
+  "pgvector==0.3.6",
+  "openai==2.52.0",
+  "anthropic==0.120.2",
+  "google-generativeai==0.8.6",
+]
+
 dev = [
   "pytest==8.3.4",
   "httpx==0.28.1",
   "ruff==0.8.4",
+  # Records real LLM-provider responses once, replays them in CI without keys (P1.1).
+  "pytest-recording==0.13.2",
 ]
+
+# ── Packaging ────────────────────────────────────────────────────────────────
+# Explicit, so `tests` can never be auto-discovered into the distribution.
+[tool.setuptools.packages.find]
+include = ["app*"]
+
+# The task system prompts are Markdown files loaded from disk at runtime
+# (app/llm/prompt_registry.py resolves `Path(__file__).parent / "prompts"`). Without
+# this they are omitted from the wheel and every structured-intelligence call —
+# extraction, conflict detection, merge recommendation — raises PromptNotFoundError
+# in any wheel-installed deployment, while working fine from a source checkout.
+[tool.setuptools.package-data]
+"app.llm" = ["prompts/*.md"]
 
 [tool.ruff]
 line-length = 100
@@ -47,3 +120,29 @@ select = ["E", "F", "I", "B", "UP"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
+
+# ── Generated requirements files ─────────────────────────────────────────────
+# Maps each generated file to the extras it materialises. Consumed by
+# scripts/sync_dependencies.py; adding an entry here is enough to have the file
+# generated and drift-checked. `include_base` pulls [project].dependencies;
+# `requires` emits a `-r <file>` include line.
+[tool.memoryops.requirements."requirements.txt"]
+include_base = true
+extras = []
+
+[tool.memoryops.requirements."requirements-postgres.txt"]
+include_base = false
+extras = ["postgres"]
+
+[tool.memoryops.requirements."requirements-providers.txt"]
+include_base = false
+extras = ["providers"]
+
+[tool.memoryops.requirements."requirements-production.txt"]
+include_base = false
+extras = ["production"]
+
+[tool.memoryops.requirements."requirements-dev.txt"]
+include_base = false
+extras = ["dev"]
+requires = ["requirements.txt"]

--- a/services/api/requirements-postgres.txt
+++ b/services/api/requirements-postgres.txt
@@ -1,4 +1,13 @@
-# Postgres + pgvector backend (MEMORYOPS_STORAGE=postgres)
+# ─────────────────────────────────────────────────────────────────────────
+# GENERATED FILE — DO NOT EDIT BY HAND.
+#
+# Source of truth: services/api/pyproject.toml
+# Regenerate:      python scripts/sync_dependencies.py
+# Verify:          python scripts/sync_dependencies.py --check   (CI gate)
+#
+# Hand-edits are reverted by the next regeneration and fail the CI drift gate.
+# ─────────────────────────────────────────────────────────────────────────
+# [project.optional-dependencies].postgres
 sqlalchemy==2.0.36
 psycopg[binary]==3.2.3
 pgvector==0.3.6

--- a/services/api/requirements-production.txt
+++ b/services/api/requirements-production.txt
@@ -7,10 +7,10 @@
 #
 # Hand-edits are reverted by the next regeneration and fail the CI drift gate.
 # ─────────────────────────────────────────────────────────────────────────
--r requirements.txt
-
-# [project.optional-dependencies].dev
-pytest==8.3.4
-httpx==0.28.1
-ruff==0.8.4
-pytest-recording==0.13.2
+# [project.optional-dependencies].production
+sqlalchemy==2.0.36
+psycopg[binary]==3.2.3
+pgvector==0.3.6
+openai==2.52.0
+anthropic==0.120.2
+google-generativeai==0.8.6

--- a/services/api/requirements-providers.txt
+++ b/services/api/requirements-providers.txt
@@ -7,10 +7,7 @@
 #
 # Hand-edits are reverted by the next regeneration and fail the CI drift gate.
 # ─────────────────────────────────────────────────────────────────────────
--r requirements.txt
-
-# [project.optional-dependencies].dev
-pytest==8.3.4
-httpx==0.28.1
-ruff==0.8.4
-pytest-recording==0.13.2
+# [project.optional-dependencies].providers
+openai==2.52.0
+anthropic==0.120.2
+google-generativeai==0.8.6

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -1,16 +1,18 @@
-# Runtime deps — exact pins, mirror of pyproject [project].dependencies.
-# Postgres extras are optional; install with: pip install -r requirements.txt -r requirements-postgres.txt
+# ─────────────────────────────────────────────────────────────────────────
+# GENERATED FILE — DO NOT EDIT BY HAND.
+#
+# Source of truth: services/api/pyproject.toml
+# Regenerate:      python scripts/sync_dependencies.py
+# Verify:          python scripts/sync_dependencies.py --check   (CI gate)
+#
+# Hand-edits are reverted by the next regeneration and fail the CI drift gate.
+# ─────────────────────────────────────────────────────────────────────────
+# [project].dependencies
 fastapi==0.140.0
-# Pinned explicitly (not just transitively via fastapi) so a patched Starlette can't
-# silently regress: <1.0.1 carries the PYSEC-2026-161/248/249/1942/2280/2281 advisories.
 starlette==1.3.1
 uvicorn[standard]==0.51.0
 pydantic==2.13.4
 pydantic-settings==2.14.2
 tenacity==9.1.4
 python-dotenv==1.2.2
-# JWT verification (auth adapters, off by default). The [crypto] extra ships the
-# 'cryptography' backend so RS*/ES*/JWKS (advertised in docs/auth-adapters.md) work
-# out of the box, not just HS*. Pinned >=2.13.0: releases before 2.12.0 are affected
-# by a high-severity JWT critical-header validation vulnerability.
 PyJWT[crypto]==2.13.0

--- a/services/api/tests/test_embedding_integrity.py
+++ b/services/api/tests/test_embedding_integrity.py
@@ -1,0 +1,94 @@
+"""Embedding-space integrity: a failed provider must never fabricate a vector.
+
+The OpenAI embedding adapter used to catch provider errors and return
+``StubEmbeddingProvider`` output in their place. That reads like graceful
+degradation (invariant #4) but is a silent correctness bug: the stub vector lives
+in a *different embedding space* from the model's, yet is indistinguishable from a
+real one once persisted. A transient outage permanently poisoned the index with
+vectors whose distances are meaningless, with no signal and no way to identify the
+affected rows later.
+
+Invariant #4 requires that a failure never *blocks the response*; it does not
+license fabricating data. The correct degradation is no vector at all — callers
+already treat an empty embedding as keyword-only ranking.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.embeddings.providers import (
+    EmbeddingUnavailable,
+    OpenAIEmbeddingProvider,
+    build_provider,
+)
+from app.embeddings.stub import StubEmbeddingProvider
+
+
+class _BoomProvider(OpenAIEmbeddingProvider):
+    """OpenAI adapter whose underlying client always fails."""
+
+    def _client(self):
+        raise RuntimeError("provider unreachable")
+
+
+def test_failed_embedding_raises_instead_of_returning_a_stub_vector():
+    provider = _BoomProvider(api_key="sk-test", model="text-embedding-3-small", dim=64)
+    with pytest.raises(EmbeddingUnavailable):
+        provider.embed_text("I prefer dark mode dashboards")
+
+
+def test_failed_batch_embedding_raises_instead_of_returning_stub_vectors():
+    provider = _BoomProvider(api_key="sk-test", model="text-embedding-3-small", dim=64)
+    with pytest.raises(EmbeddingUnavailable):
+        provider.embed_batch(["alpha", "beta"])
+
+
+def test_failure_never_yields_a_vector_from_the_stub_space():
+    """The regression itself: no code path may return the stub's vector for this text.
+
+    Asserted on the value, not just the exception type, so a future "helpful"
+    fallback re-introduced anywhere in the adapter still fails this test.
+    """
+    text = "quarterly revenue was discussed in the board meeting"
+    provider = _BoomProvider(api_key="sk-test", model="text-embedding-3-small", dim=64)
+    stub_vector = StubEmbeddingProvider(64).embed_text(text)
+
+    try:
+        result = provider.embed_text(text)
+    except EmbeddingUnavailable:
+        return  # correct behaviour
+    assert result != stub_vector, (
+        "a failed OpenAI embedding returned a stub vector — cross-space contamination"
+    )
+
+
+def test_write_path_degrades_to_no_vector_not_a_fake_one(monkeypatch):
+    """`safe_call` in write_service turns the raise into an empty embedding.
+
+    Empty means keyword-only ranking for that memory: recoverable and re-embeddable,
+    unlike a persisted vector in the wrong space.
+    """
+    from app.core.reliability import safe_call
+
+    provider = _BoomProvider(api_key="sk-test", model="text-embedding-3-small", dim=64)
+    embedding = safe_call(lambda: provider.embed_text("hello"), default=[], label="embed")
+    assert embedding == []
+
+
+def test_retriever_degrades_to_keyword_only_when_embedding_fails(monkeypatch):
+    """Invariant #4 still holds: retrieval falls back rather than raising."""
+    from app.db.factory import get_repository
+    from app.services import retriever as retriever_module
+
+    def _boom(_text):
+        raise EmbeddingUnavailable("provider unreachable")
+
+    monkeypatch.setattr(retriever_module, "embed", _boom)
+    result = retriever_module.Retriever(get_repository()).retrieve("t1", "u1", "any query")
+    assert result.mode == "fallback"
+
+
+def test_offline_selection_still_returns_the_stub_provider():
+    """Removing the runtime fallback must not make the offline default networked."""
+    assert build_provider().name == "stub"

--- a/services/api/tests/test_embeddings.py
+++ b/services/api/tests/test_embeddings.py
@@ -40,3 +40,31 @@ def test_related_text_more_similar_than_unrelated():
     related = embed("dark mode dashboards are my preference")
     unrelated = embed("the capital of France is Paris")
     assert cosine(base, related) > cosine(base, unrelated)
+
+
+# ── embedding-space integrity ────────────────────────────────────────────────
+# A failed network provider must never substitute a stub vector. The stub lives in
+# a *different* embedding space but is indistinguishable from a real vector once
+# persisted, so a transient outage used to permanently poison the index with
+# meaningless distances. Full coverage in tests/test_embedding_integrity.py.
+def test_failed_provider_raises_rather_than_returning_a_stub_vector():
+    import pytest
+
+    from app.embeddings.providers import EmbeddingUnavailable, OpenAIEmbeddingProvider
+
+    class _Down(OpenAIEmbeddingProvider):
+        def _client(self):
+            raise RuntimeError("provider unreachable")
+
+    provider = _Down(api_key="sk-test", model="text-embedding-3-small", dim=64)
+    with pytest.raises(EmbeddingUnavailable):
+        provider.embed_text("dark mode dashboards")
+
+
+def test_openai_selection_without_a_key_still_degrades_to_stub_offline():
+    # Selection-time fallback is retained so the app always starts in dev; it is the
+    # *call-time* fallback that fabricated cross-space vectors. Production rejects
+    # this combination at startup (Settings.production_readiness_errors).
+    from app.embeddings.providers import build_provider
+
+    assert build_provider().name == "stub"

--- a/services/api/tests/test_packaging.py
+++ b/services/api/tests/test_packaging.py
@@ -1,0 +1,156 @@
+"""Packaging guards: the wheel must carry everything the app reads at runtime.
+
+Two failure modes this locks down, both of which shipped silently because a source
+checkout masks them (the files are simply there on disk):
+
+1. **Missing package data.** `app/llm/prompt_registry.py` resolves its system
+   prompts as `Path(__file__).parent / "prompts" / "<task>.md"` and reads them at
+   call time. The wheel declared no `package-data`, so those Markdown files were
+   omitted and every structured-intelligence call — extraction, conflict detection,
+   merge recommendation — raised `PromptNotFoundError` in a wheel-installed
+   deployment while passing in CI and in dev.
+
+2. **Dependency drift.** `pyproject.toml` is the source of truth; every
+   `requirements*.txt` is generated from it by `scripts/sync_dependencies.py`.
+   They had diverged (fastapi 0.139.2 vs 0.140.0, uvicorn 0.37.0 vs 0.51.0,
+   pydantic-settings 2.6.1 vs 2.14.2), so the image and the wheel resolved
+   different dependency sets.
+
+The full build-install-boot proof runs in the `packaging` CI job; these tests are
+the fast local guard.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+API_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = API_DIR.parents[1]
+PYPROJECT = API_DIR / "pyproject.toml"
+
+
+@pytest.fixture(scope="module")
+def pyproject() -> dict:
+    with PYPROJECT.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+# ── package data ─────────────────────────────────────────────────────────────
+def _runtime_asset_dirs() -> set[Path]:
+    """Directories under app/ holding non-Python files the app reads at runtime."""
+    found: set[Path] = set()
+    for path in (API_DIR / "app").rglob("*"):
+        if not path.is_file() or path.suffix == ".py":
+            continue
+        if "__pycache__" in path.parts:
+            continue
+        found.add(path.parent)
+    return found
+
+
+def test_every_runtime_asset_dir_is_declared_as_package_data(pyproject):
+    """A new non-.py asset under app/ must be added to [tool.setuptools.package-data].
+
+    Otherwise it works in dev and vanishes from the wheel.
+    """
+    declared = pyproject["tool"]["setuptools"]["package-data"]
+    # Expand "app.llm": ["prompts/*.md"] into the directories it covers.
+    covered: set[Path] = set()
+    for package, patterns in declared.items():
+        pkg_dir = API_DIR / Path(package.replace(".", "/"))
+        for pattern in patterns:
+            for match in pkg_dir.glob(pattern):
+                covered.add(match.parent)
+
+    undeclared = sorted(
+        str(d.relative_to(API_DIR)) for d in _runtime_asset_dirs() - covered
+    )
+    assert not undeclared, (
+        "runtime assets under app/ are not declared as setuptools package-data and "
+        f"would be missing from the wheel: {undeclared}"
+    )
+
+
+def test_prompt_assets_are_covered_by_package_data(pyproject):
+    """Explicit regression guard for the prompt files specifically."""
+    patterns = pyproject["tool"]["setuptools"]["package-data"].get("app.llm", [])
+    matched = {p.name for pattern in patterns for p in (API_DIR / "app/llm").glob(pattern)}
+    on_disk = {p.name for p in (API_DIR / "app/llm/prompts").glob("*.md")}
+    assert on_disk, "no prompt files on disk — did the registry layout change?"
+    assert on_disk <= matched, f"prompts missing from package-data: {sorted(on_disk - matched)}"
+
+
+def test_all_registered_prompts_exist_on_disk():
+    """The registry's task table must not reference a file that isn't shipped."""
+    from app.llm.prompt_registry import available_tasks, get_prompt
+
+    for task in available_tasks():
+        assert get_prompt(task).strip(), f"empty or missing prompt asset: {task}"
+
+
+def test_tests_are_not_packaged(pyproject):
+    include = pyproject["tool"]["setuptools"]["packages"]["find"]["include"]
+    assert include == ["app*"], "packages.find must stay explicit so tests aren't shipped"
+
+
+# ── dependency source of truth ───────────────────────────────────────────────
+def test_requirements_files_match_pyproject():
+    """`requirements*.txt` are generated; drift means the image and wheel differ."""
+    proc = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "sync_dependencies.py"), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"dependency drift between pyproject.toml and requirements*.txt:\n"
+        f"{proc.stdout}\n{proc.stderr}\n"
+        "Run: python scripts/sync_dependencies.py"
+    )
+
+
+def test_provider_extras_pin_the_module_each_adapter_imports(pyproject):
+    """An extra must install the SDK its adapter actually imports.
+
+    `app/llm/gemini_provider.py` imports `google.generativeai` (the legacy
+    `google-generativeai` distribution), not `google.genai` (`google-genai`).
+    Pinning the wrong one installs an SDK the adapter cannot use — a broken extra
+    that looks correct.
+    """
+    extras = pyproject["project"]["optional-dependencies"]
+    expected_distribution = {
+        "openai": "openai",
+        "anthropic": "anthropic",
+        "gemini": "google-generativeai",
+        "qdrant": "qdrant-client",
+        "lancedb": "lancedb",
+        "weaviate": "weaviate-client",
+    }
+    for extra, distribution in expected_distribution.items():
+        pins = extras[extra]
+        assert any(p.split("==")[0] == distribution for p in pins), (
+            f"extra '{extra}' must pin '{distribution}', got {pins}"
+        )
+        assert all("==" in p for p in pins), f"extra '{extra}' must use exact pins: {pins}"
+
+
+def test_production_extra_covers_postgres_and_all_providers(pyproject):
+    """The production images install this; it must be able to honour any
+    MEMORYOPS_LLM_PROVIDER / MEMORYOPS_STORAGE=postgres selection."""
+    pins = pyproject["project"]["optional-dependencies"]["production"]
+    production = {p.split("==")[0] for p in pins}
+    for required in (
+        "sqlalchemy",
+        "psycopg",
+        "pgvector",
+        "openai",
+        "anthropic",
+        "google-generativeai",
+    ):
+        assert any(name.startswith(required) for name in production), (
+            f"production extra is missing {required}: {sorted(production)}"
+        )

--- a/services/api/tests/test_production_profile.py
+++ b/services/api/tests/test_production_profile.py
@@ -57,6 +57,116 @@ def test_production_profile_passes_when_hardened():
     assert safe.production_readiness_errors() == []
 
 
+# ── provider packaging readiness (fail-closed) ───────────────────────────────
+# Every provider adapter imports its SDK lazily and degrades to a stub when the SDK
+# or key is missing, so the service starts and looks healthy while serving stub
+# output. In production that silent substitution is a hard error instead.
+def _hardened(**overrides) -> Settings:
+    """A settings object that is production-clean apart from `overrides`."""
+    base = dict(
+        profile="production",
+        storage="postgres",
+        auth_mode="jwt",
+        cors_allow_origins="https://app.example.com",
+        database_url="postgresql+psycopg://real:secret@db.internal:5432/memoryops",
+        public_evals=False,
+    )
+    return Settings(**{**base, **overrides})
+
+
+def _all_sdks_present(monkeypatch) -> None:
+    """Pretend every optional SDK is installed, isolating key/selection checks."""
+    import importlib.util
+
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+
+
+def _no_sdks_present(monkeypatch) -> None:
+    import importlib.util
+
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+
+
+def test_production_rejects_llm_provider_without_api_key(monkeypatch):
+    _all_sdks_present(monkeypatch)
+    errors = _hardened(llm_provider="openai", openai_api_key="").production_readiness_errors()
+    assert any("OPENAI_API_KEY is unset" in e for e in errors)
+
+
+def test_production_rejects_llm_provider_without_sdk(monkeypatch):
+    _no_sdks_present(monkeypatch)
+    errors = _hardened(
+        llm_provider="anthropic", anthropic_api_key="sk-real"
+    ).production_readiness_errors()
+    assert any("'anthropic' SDK is not installed" in e for e in errors)
+    assert any("memoryops-api[anthropic]" in e for e in errors)
+
+
+def test_production_gemini_checks_the_module_the_adapter_imports(monkeypatch):
+    """The adapter imports `google.generativeai` (legacy SDK), not `google.genai`.
+
+    Guards against the extras pinning a package whose module the adapter can't use.
+    """
+    seen: list[str] = []
+    import importlib.util
+
+    def fake(name):
+        seen.append(name)
+        return object()
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake)
+    _hardened(llm_provider="gemini", gemini_api_key="k").production_readiness_errors()
+    assert "google.generativeai" in seen
+
+
+def test_production_rejects_openai_embeddings_without_key_or_sdk(monkeypatch):
+    _all_sdks_present(monkeypatch)
+    errors = _hardened(
+        embeddings_provider="openai", openai_api_key=""
+    ).production_readiness_errors()
+    # Embeddings are stricter than the LLM path: a stub vector is *persisted* in the
+    # wrong space, so the message must say so.
+    assert any("different vector space" in e for e in errors)
+
+    _no_sdks_present(monkeypatch)
+    errors = _hardened(
+        embeddings_provider="openai", openai_api_key="sk-real"
+    ).production_readiness_errors()
+    assert any("'openai' SDK is not installed" in e for e in errors)
+
+
+def test_production_rejects_external_vector_backend_without_client(monkeypatch):
+    _no_sdks_present(monkeypatch)
+    errors = _hardened(vector_index="qdrant").production_readiness_errors()
+    assert any("qdrant_client" in e and "not installed" in e for e in errors)
+
+
+def test_production_allows_stub_providers_and_memory_index(monkeypatch):
+    """The offline default selection must stay clean — no SDKs required."""
+    _no_sdks_present(monkeypatch)
+    assert _hardened(
+        llm_provider="stub", embeddings_provider="stub", vector_index="memory"
+    ).production_readiness_errors() == []
+
+
+def test_production_allows_fully_configured_provider(monkeypatch):
+    _all_sdks_present(monkeypatch)
+    assert _hardened(
+        llm_provider="openai",
+        embeddings_provider="openai",
+        openai_api_key="sk-real",
+        vector_index="qdrant",
+    ).production_readiness_errors() == []
+
+
+def test_provider_checks_are_production_only(monkeypatch):
+    """Dev must keep booting with no keys and no SDKs (offline tests, demos)."""
+    _no_sdks_present(monkeypatch)
+    assert Settings(
+        profile="dev", llm_provider="openai", embeddings_provider="openai"
+    ).production_readiness_errors() == []
+
+
 def test_cors_origins_parsing():
     assert Settings(cors_allow_origins="*").cors_origins_list() == ["*"]
     assert Settings(cors_allow_origins="").cors_origins_list() == ["*"]


### PR DESCRIPTION
Establishes the packaging and provider foundation the later PRs build on. **Merge first.**

`services/api/pyproject.toml` becomes the single source of truth for API and worker dependencies; every `requirements*.txt` is generated from it and drift-checked in CI.

## Why

The two dependency sources had silently diverged:

| Package | `pyproject.toml` | `requirements.txt` |
| --- | --- | --- |
| fastapi | 0.139.2 | 0.140.0 |
| uvicorn | 0.37.0 | 0.51.0 |
| pydantic-settings | 2.6.1 | 2.14.2 |
| pytest-recording | *(absent)* | 0.13.2 |

Docker and CI install the requirements files; `pip install .` and the published wheel resolve the pyproject set. A green CI run proved nothing about the package metadata, and nothing about the image.

## What's included

**Dependency source of truth** — `scripts/sync_dependencies.py` generates and verifies (`--check`) every requirements file. Stdlib-only, so it runs before deps are installed. New `packaging` CI job: drift check → wheel build → clean-venv install → boot from site-packages → per-extra module resolution.

**Provider extras** — `openai`, `anthropic`, `gemini`, `providers`, `qdrant`, `lancedb`, `weaviate`, `production`. The API and worker images now install `requirements-production.txt` (postgres + all three provider SDKs), so `MEMORYOPS_LLM_PROVIDER` is switchable by env var without a new image.

**Correct Gemini SDK** — the extra pins `google-generativeai` (module `google.generativeai`), which `app/llm/gemini_provider.py` actually imports — *not* `google-genai`. Pinning the newer package would install an SDK the adapter cannot use, which is exactly the failure this PR exists to prevent. A test locks each extra to the module its adapter imports.

**Fail-closed production provider selection** — under `MEMORYOPS_PROFILE=production`, selecting a networked LLM/embedding provider or external vector backend without its key or SDK is now a startup error instead of a silent degradation to the stub. Dev still degrades (offline tests and the demo depend on it).

**Prompt package-data** — `app/llm/prompts/*.md` are read from disk at runtime but no `package-data` was declared, so they were **absent from the wheel**: every structured-intelligence call raised `PromptNotFoundError` in a wheel-installed deployment while passing from a source checkout. Found by the new packaging gate. `packages.find` is now explicit so `tests` is never shipped, and a guard fails on any new undeclared asset under `app/`.

**Wheel-installed runtime tests** — CI builds the wheel, installs it into a clean venv, `cd`s out of the source tree, and boots it. A missing packaged file can no longer be masked by the checkout.

**Embedding-space integrity** — the OpenAI embedding adapter caught provider errors and returned `StubEmbeddingProvider` output in their place. The stub is a *different embedding space* but indistinguishable from a real vector once persisted, so a transient outage permanently poisoned the index with meaningless distances — no signal, no way to find affected rows. It now raises `EmbeddingUnavailable`; `write_service` stores no vector (keyword-only, re-embeddable) and `retriever` reports `mode="fallback"`. Invariant #4 forbids blocking a response, not fabricating data.

**Nightly live-provider assertion** — `nightly-live.yml` set `MEMORYOPS_LLM_PROVIDER=openai` with a real key but installed no provider SDK, so the ≥0.7 recall gate had been scoring the deterministic **stub**. It now installs the providers extra and asserts the real provider is selected before running.

## Verification

- 458 passed, 3 skipped; ruff clean.
- Evals PASS, governance benchmark PASS.
- PR invariant evidence gate: PASS.
- Wheel verified installing and booting on Python 3.11 with prompts loading from site-packages.
- `pip-audit` now also covers the provider and production requirements the images ship.

## Follow-up (not in this PR)

Async re-embedding worker and per-vector `embedding_provider`/`model`/`dimension`/`version`/`status` columns. This PR stops new contamination; it does not backfill or label existing vectors.

Note for reviewers: on Postgres, `search_candidates` filters `embedding IS NOT NULL`, so a memory stored without a vector is currently excluded from dense search rather than merely keyword-degraded. Closing that is tracked as the hybrid-retrieval / embedding-lifecycle work.