### PR TITLE
fix(worker): add heartbeat renewal, job retries and graceful shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,66 @@ jobs:
   # the in-memory backend for a dedicated status badge; the api-postgres job above
   # additionally proves it passes against the real Postgres + pgvector stack.
 
+  worker:
+    name: Worker — packaged entrypoint + graceful shutdown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      # The worker used to reach the API by inserting ../api into sys.path at import
+      # time. It now depends on the built memoryops-api distribution, so this install
+      # is the real proof there is no repository-layout coupling left.
+      - name: Install the API and worker as distributions
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ./services/api
+          python -m pip install --no-deps ./services/worker
+
+      - name: No sys.path manipulation in the worker entrypoint
+        run: |
+          if grep -nE "sys\.path|PYTHONPATH" services/worker/main.py; then
+            echo "::error::worker entrypoint still manipulates sys.path"
+            exit 1
+          fi
+          echo "worker entrypoint is import-clean"
+
+      # Boot the console script, let it complete a tick, then SIGTERM it mid-interval.
+      # Before graceful shutdown landed, run_forever sat in an uninterruptible
+      # time.sleep, so SIGTERM did nothing until the orchestrator's SIGKILL and the
+      # held lease stayed locked for the rest of its TTL.
+      - name: SIGTERM stops the worker cleanly (exit 0)
+        env:
+          MEMORYOPS_STORAGE: memory
+          MEMORYOPS_WORKER_SCOPES: "t1:u1"
+          MEMORYOPS_WORKER_INTERVAL_SECONDS: "30"
+        run: |
+          set -euo pipefail
+          memoryops-worker > worker.log 2>&1 &
+          WPID=$!
+          sleep 5
+          kill -TERM "$WPID"
+          # Must exit well inside the 30s interval, not wait it out.
+          for _ in $(seq 1 15); do
+            kill -0 "$WPID" 2>/dev/null || break
+            sleep 1
+          done
+          if kill -0 "$WPID" 2>/dev/null; then
+            echo "::error::worker ignored SIGTERM"
+            kill -9 "$WPID"; cat worker.log; exit 1
+          fi
+          wait "$WPID"; RC=$?
+          cat worker.log
+          test "$RC" -eq 0 || { echo "::error::unclean exit $RC"; exit 1; }
+          grep -q worker_shutdown_requested worker.log
+          grep -q worker_stopped worker.log
+          echo "worker shut down gracefully"
+
   sdk:
     name: SDK — tests (py ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/docs/background-lifecycle-workers.md
+++ b/docs/background-lifecycle-workers.md
@@ -155,3 +155,29 @@ deleted memory's content + vector material (`memory_legal_hold_compaction_blocke
 rather than clearing it — preserved for discovery, not crypto-shredded. Pins
 exempt from decay/archive; protection exempts from retention auto-deletion. All
 governance state is content-free metadata and every action is audited.
+
+## Job result statuses (amended)
+
+`WorkerRunStatus` gained two terminal states alongside the original four:
+
+| Status | Meaning | Retried? |
+| --- | --- | --- |
+| `completed` | job ran, nothing to flag | no |
+| `completed_with_findings` | a real finding (e.g. a deletion leak) | **no** — a finding is a result, not a fault; retrying would multiply audit events and mask it |
+| `skipped` | job disabled / not applicable | no |
+| `failed` | unexpected error | yes, to `worker_max_attempts` |
+| `dead_letter` | `failed` after exhausting its retry budget | terminal; replayable rather than lost |
+| `aborted` | not started because the scope's lease was lost or shutdown was requested | no |
+
+`dead_letter` exists because retry was previously applied around `run_jobs` as a whole,
+while lifecycle workers catch their own errors and *return* `failed` instead of raising.
+The wrapper only ever saw clean returns, so a failing job was recorded and then dropped
+— never retried, never dead-lettered. Retry is now per job and keys off the returned
+status.
+
+`aborted` is the fail-closed outcome of the lease heartbeat: rather than continuing to
+mutate a scope this worker may no longer own, remaining jobs are recorded as `aborted`
+so the gap is visible in run history instead of silently absent.
+
+Both statuses are content-free, like every other worker result: ids, counts, and
+reasons only — never memory text. See ADR-012's amendment and `docs/worker-runtime.md`.

--- a/docs/phase-gates/phase-14-worker-runtime-orchestration.md
+++ b/docs/phase-gates/phase-14-worker-runtime-orchestration.md
@@ -48,3 +48,30 @@ See [worker-runtime.md](../worker-runtime.md).
 - `scripts/pr_invariant_gate.py` (worker-runtime evidence rules)
 
 ## Status: ✅ Implemented (v0.8)
+
+## Gate re-verification: heartbeat, per-job retry, graceful shutdown, packaging
+
+Reopened because three claims in this gate were not actually held by the code.
+
+| Claim previously marked green | Reality | Now |
+| --- | --- | --- |
+| "Duplicate concurrent runs prevented by the lease" | true only for scopes shorter than the lease TTL — `renew()` existed but was never called, so longer scopes lost exclusivity mid-run and a second replica could mutate the same tenant/user | heartbeat renews at `ttl/3` and fails closed on loss (`lease_lost` + `aborted` jobs) |
+| "Retried with backoff, dead-lettered on exhausted retries" | retry wrapped `run_jobs`, but workers return `failed` rather than raising, so job failures were never retried or dead-lettered | per-job retry keyed off the returned status; new terminal `dead_letter` |
+| "The worker process is operable" | `run_forever` used an uninterruptible `time.sleep` with no signal handling, so every deploy hard-killed it mid-tick and left the lease held for the rest of the TTL | cooperative SIGTERM/SIGINT stop; scope finishes, lease released, exit 0 |
+
+Evidence:
+
+- `services/api/tests/test_worker_reliability.py` — 18 tests. The lease test has teeth:
+  without the heartbeat a second worker demonstrably acquires the same scope after the
+  TTL elapses.
+- `services/api/tests/test_worker_locks.py` — renewal holds a scope past its original
+  expiry, and cannot resurrect a lease another worker has taken over.
+- `services/api/tests/test_worker_orchestrator.py` — dead-lettering surfaces in run
+  history; the lease is released even when every job dead-letters.
+- CI `worker` job — installs the API and worker as distributions, asserts the entrypoint
+  contains no `sys.path`/`PYTHONPATH` manipulation, then boots the `memoryops-worker`
+  console script and SIGTERMs it mid-interval, requiring exit 0 well inside the interval.
+
+Still open (tracked, not claimed): fencing tokens (the heartbeat is cooperative, so a
+stalled-then-resumed worker can still finish an in-flight write), a dead-letter replay
+command, and dynamic scope discovery.

--- a/docs/worker-runtime.md
+++ b/docs/worker-runtime.md
@@ -73,8 +73,11 @@ Stored via `worker_runs` (migration `006_worker_runtime.sql`); query with
 ## Running
 
 ```bash
+# install the API + worker as distributions (no PYTHONPATH, no sys.path)
+pip install ./services/api ./services/worker
+
 # the worker process (interval scheduler over configured scopes)
-cd services/worker && python main.py
+memoryops-worker
 
 # one pass, programmatically
 from app.workers import WorkerScheduler, Scope
@@ -84,12 +87,71 @@ WorkerScheduler(repo, scopes=[Scope("t1", "u1")]).tick()
 curl localhost:8000/healthz/workers
 ```
 
+The worker previously mutated `sys.path` at import time to reach `services/api`,
+which tied it to the repository layout and blocked shipping it as a wheel. It now
+declares an ordinary dependency on the `memoryops-api` distribution and exposes a
+`memoryops-worker` console script.
+
+## Lease heartbeat (long-running scopes)
+
+`WorkerLeaseManager.renew()` existed from v0.8 but nothing called it: the
+orchestrator acquired a lease once and ran the whole scope. Any scope whose jobs
+outlived `worker_lease_ttl_seconds` (default 300s) silently lost exclusivity
+mid-run, and a second replica could acquire the same tenant/user and mutate it
+concurrently. Idempotency limits the damage; it does not make it correct.
+
+`app/workers/heartbeat.py` renews the lease on a background thread at `ttl/3`, and
+**fails closed** if renewal ever fails: the scope stops between jobs, remaining jobs
+are recorded as `aborted`, and the run is recorded as `lease_lost`.
+
+> **Residual risk, stated plainly.** This is cooperative, not fencing. The abort flag
+> is observed *between* jobs, so a worker that stalls (long GC pause, VM freeze)
+> after its check and resumes past expiry can still finish the write it was in.
+> Closing that needs a monotonic fence token checked at the storage write itself —
+> a schema change plus threading the fence through every job's writes. Tracked as
+> follow-up. What is closed now is the common, previously *guaranteed* case: a job
+> that simply takes longer than the TTL.
+
+## Retry granularity
+
+Retry used to wrap `run_jobs` as a whole. But lifecycle workers catch their own
+errors and **return** `status=failed` rather than raising, so the wrapper only ever
+saw clean returns — a failing job was recorded as failed and then dropped: never
+retried, never dead-lettered.
+
+Retry is now per job, keyed off the returned status:
+
+| Job status | Retried? | Why |
+| --- | --- | --- |
+| `failed` | yes, to `worker_max_attempts` | transient fault |
+| `dead_letter` | terminal | budget exhausted; replayable, not lost |
+| `completed_with_findings` | **no** | a finding is a real result, not a fault; retrying would multiply audit events and mask it |
+| `skipped` / `completed` | no | nothing to retry |
+| `aborted` | no | lease lost or shutdown; deliberately not started |
+
+## Graceful shutdown
+
+`run_forever` looped on a bare `time.sleep` with no signal handling, so every deploy
+hard-killed the worker mid-tick and left its lease held for the rest of the TTL —
+and with a 60s interval the process spent nearly all its life unable to react to
+SIGTERM at all.
+
+SIGTERM/SIGINT now set a cooperative stop flag (`app/workers/shutdown.py`). The
+inter-tick wait is an interruptible `Event.wait`, so the signal is acted on
+immediately: the scope in flight finishes, its lease is released, remaining scopes
+are left for the next replica, and the process exits 0. Verified end to end in the
+`worker` CI job.
+
 ## Guarantees (enforced in code + tests)
 
-- **Duplicate runs prevented** by the lease; **never deadlocked** (leases expire).
+- **Duplicate runs prevented** by the lease, **including for jobs that outlive the
+  lease TTL** (heartbeat renewal); **never deadlocked** (leases expire).
+- **Lease loss fails closed** — no further mutation once ownership is unprovable.
 - **Tenant scoped** — explicit scopes only; no unbounded cross-tenant scan.
-- **Failures durable, not fatal** — retry → dead-letter; a bad tick never crashes
-  the scheduler; one scope's failure never blocks another.
+- **Failures durable, not fatal** — per-job retry → dead-letter; a bad tick never
+  crashes the scheduler; one scope's failure never blocks another.
+- **Clean termination** — SIGTERM finishes the current scope, releases the lease,
+  exits 0.
 - **Content-free** run history + health.
 - **Off the chat path** — maintenance only.
 
@@ -97,6 +159,10 @@ curl localhost:8000/healthz/workers
 
 - Single-process interval scheduler — not a distributed cron; multiple replicas are
   safe (the lease arbitrates) but there is no central schedule coordinator.
+- Lease protection is cooperative, not fenced (see the residual risk above).
 - No external queue/broker (Celery/Temporal). The orchestrator interface is
   queue-shaped so one can be added later without touching the lifecycle workers.
-- Scope enumeration is explicit (operator-configured), not auto-discovered.
+- Scope enumeration is explicit (operator-configured), not auto-discovered — a
+  dynamic scope registry is separate follow-up work.
+- Dead-lettered jobs are recorded and queryable, but there is no one-command
+  **replay** yet; re-running the scope re-attempts the work.

--- a/docs/worker-runtime.md
+++ b/docs/worker-runtime.md
@@ -144,9 +144,12 @@ are left for the next replica, and the process exits 0. Verified end to end in t
 
 ## Guarantees (enforced in code + tests)
 
-- **Duplicate runs prevented** by the lease, **including for jobs that outlive the
-  lease TTL** (heartbeat renewal); **never deadlocked** (leases expire).
-- **Lease loss fails closed** — no further mutation once ownership is unprovable.
+- **Normal TTL overlap prevented** — heartbeat-renewed cooperative leases keep a
+  scope exclusive even when its jobs outlive the original TTL; **never deadlocked**
+  (leases expire). This is *not* a guarantee against a paused-then-resumed process:
+  database-enforced fencing remains future work (see the residual risk above).
+- **Lease loss fails closed** — no further mutation once ownership is unprovable,
+  checked between jobs.
 - **Tenant scoped** — explicit scopes only; no unbounded cross-tenant scan.
 - **Failures durable, not fatal** — per-job retry → dead-letter; a bad tick never
   crashes the scheduler; one scope's failure never blocks another.

--- a/infra/adr/ADR-010-background-memory-lifecycle-workers.md
+++ b/infra/adr/ADR-010-background-memory-lifecycle-workers.md
@@ -87,3 +87,27 @@ without the operational risk of destructive index surgery.
   `MEMORYOPS_WORKERS_REFLECTION` toggle.
 - Future work: physical vector compaction / crypto-shred worker, scope
   enumeration for fleet scheduling, and a governed reflection write path.
+
+## Amendment: per-job retry and cooperative abort in the runner
+
+`run_jobs` originally ran each job exactly once and returned the aggregate report,
+relying on the orchestrator's `run_with_retry` for resilience. That split did not
+work: lifecycle workers deliberately **catch their own errors and return a `failed`
+result rather than raising** (so one job never blocks another), which meant the
+orchestration-level retry only ever observed clean returns. A failing job was
+recorded as `failed` and then dropped — never retried, never dead-lettered.
+
+`run_jobs` now accepts an optional `retry_policy` and retries a job whose *returned
+status* is `failed`, marking it `dead_letter` once the budget is exhausted. Findings
+(`completed_with_findings`) are never retried: they are real results, and retrying
+would multiply audit events and mask the finding. The CLI path keeps its
+single-attempt behaviour (no policy passed), so `python -m app.workers.runner`
+semantics are unchanged.
+
+`run_jobs` also accepts `should_abort`, polled before each job. When a scope's lease
+is lost or shutdown is requested, remaining jobs are recorded as `aborted` rather
+than silently omitted, so the gap is visible in run history. This preserves the
+original guarantees — explicit tenant scope, one job never blocking another, the
+policy broker staying authoritative, no resurrection of deleted memory — while
+making failure durable. See ADR-012's amendment, `docs/worker-runtime.md`, and
+`tests/test_worker_reliability.py`.

--- a/infra/adr/ADR-012-worker-runtime-orchestration.md
+++ b/infra/adr/ADR-012-worker-runtime-orchestration.md
@@ -94,3 +94,61 @@ an unscoped `list_worker_runs()` query (which is why worker health had regressed
 `OPERATIONAL_DATABASE_URL` (a monitoring/BYPASSRLS role); unconfigured, it fails **closed**
 to a documented "operational access not configured" state. Orchestration, leasing, retry,
 and scheduling semantics are unchanged. See ADR-027 and `docs/worker-runtime.md`.
+
+## Amendment: lease heartbeat, per-job retry, graceful shutdown, packaging
+
+Three gaps between what this ADR claimed and what the runtime did, each silent in
+production.
+
+**1. The lease was acquired but never renewed.** `WorkerLeaseManager.renew()` shipped
+with v0.8 and nothing called it. The orchestrator acquired once, ran the whole scope,
+and released. Any scope whose jobs outlived `worker_lease_ttl_seconds` (default 300s)
+therefore lost exclusivity *mid-run*: the lease expired, a second replica acquired the
+same `(tenant, user)`, and both mutated it concurrently. Idempotent jobs limit the
+damage but do not make concurrent lifecycle mutation of one scope correct — decay,
+retention, and compaction all write.
+
+`app/workers/heartbeat.py` renews on a daemon thread at `ttl/3` and **fails closed**
+when renewal fails or raises: the scope stops between jobs, remaining jobs are recorded
+as `aborted`, and the run is recorded as `lease_lost`.
+
+*Residual risk, stated rather than hidden:* this is cooperative, not fencing. The abort
+flag is observed **between** jobs, so a worker that stalls (long GC pause, VM freeze)
+after its check and resumes past expiry can still complete the write it was in. Closing
+that requires a monotonic fence token checked at the storage write itself — a schema
+change plus threading the fence through every job's writes. Deferred deliberately; what
+is closed here is the previously *guaranteed* failure: a job that simply runs longer
+than the TTL.
+
+**2. Retry was at the wrong granularity.** `run_with_retry` wrapped `run_jobs`, but
+lifecycle workers catch their own errors and *return* a `failed` result rather than
+raising — `retry.py` even documented that it only covered orchestration-level
+exceptions. The wrapper therefore only ever saw clean returns, so a failing job was
+recorded as failed and then dropped: never retried, never dead-lettered.
+
+Retry is now **per job** and keys off the returned status. Exhausted budgets become a
+new terminal `dead_letter` status, so the work is replayable rather than merely logged.
+`completed_with_findings` is explicitly **not** retried — a finding (e.g. a deletion
+leak) is a real result, and retrying would multiply audit events and mask it.
+
+**3. There was no graceful shutdown.** `run_forever` looped on a bare `time.sleep` with
+no signal handling. Every deploy hard-killed the worker mid-tick and left its lease held
+for the remainder of the TTL, so the next replica skipped that scope; with a 60s
+interval the process spent nearly all its life unable to react to SIGTERM at all.
+`app/workers/shutdown.py` turns SIGTERM/SIGINT into a cooperative stop flag and the
+inter-tick wait into an interruptible `Event.wait`. The scope in flight finishes, its
+lease is released, remaining scopes are left for the next replica, and the process
+exits 0.
+
+**Packaging.** `services/worker/main.py` inserted `../api` into `sys.path` at import
+time, tying the worker to the repository layout and blocking a wheel. `memoryops-api`
+is now a properly built distribution, so the worker declares an ordinary dependency on
+it and ships a `memoryops-worker` console script. No `sys.path` or `PYTHONPATH`
+manipulation remains in a production entrypoint.
+
+Consequences: run history gains `dead_letter` / `aborted` job statuses and a
+`lease_lost` run status; `/readyz`'s `worker_runtime` check gains freshness. Tenant
+isolation, explicit scope enumeration, and the policy broker's authority are unchanged.
+Still open: fencing tokens, a dead-letter **replay** command, and dynamic scope
+discovery (`MEMORYOPS_WORKER_SCOPES` remains operator-configured). See
+`docs/worker-runtime.md` and `tests/test_worker_reliability.py`.

--- a/services/api/app/workers/heartbeat.py
+++ b/services/api/app/workers/heartbeat.py
@@ -1,0 +1,132 @@
+"""Lease heartbeat for long-running worker scopes (ADR-012 follow-up).
+
+The problem this closes
+-----------------------
+``WorkerLeaseManager.renew()`` existed from v0.8 but nothing ever called it. The
+orchestrator acquired a lease once, ran the whole scope, and released it. A lease
+has a TTL (``worker_lease_ttl_seconds``, default 300s), so any scope whose jobs
+took longer than the TTL silently lost its exclusivity mid-run:
+
+    t=0    worker A acquires lease for tenant:user (expires t=300)
+    t=300  lease expires while A is still compacting
+    t=301  worker B acquires the *same* scope and starts mutating it
+    t=420  A finishes, and releases a lease it no longer owns
+
+Idempotent jobs reduce the damage but do not make concurrent lifecycle mutation of
+one scope correct — decay, retention, and compaction all write.
+
+The fix is two-sided:
+
+  * **Renew** the lease on a background thread at ``ttl/3`` so a healthy long job
+    keeps its exclusivity indefinitely.
+  * **Fail closed** when renewal fails. Losing the lease means another replica may
+    now own the scope, so the heartbeat sets ``lost``; the orchestrator checks it
+    between jobs and stops before any further mutation.
+
+Residual risk (deliberately documented, not hidden)
+---------------------------------------------------
+This is cooperative, not fencing. The abort flag is only observed *between* jobs,
+so a worker that stalls (long GC pause, VM freeze) after its check and resumes
+after the lease expired can still complete the write it was in the middle of. True
+protection needs a monotonic fence token checked at the storage write itself —
+that requires threading a fence through every job's writes and a schema change,
+and is tracked as follow-up. What this closes is the common, previously guaranteed
+case: a job that simply *takes longer than the TTL*.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+
+from ..core.logging import get_logger
+from .locks import WorkerLeaseManager
+
+logger = get_logger("memoryops.workers.heartbeat")
+
+# Renew at a third of the TTL: two consecutive renewals may fail before the lease
+# actually expires, so a transient store blip does not needlessly abort a run.
+_RENEW_FRACTION = 3.0
+
+
+class LeaseHeartbeat:
+    """Renews a held lease on a daemon thread; flags loss so callers fail closed.
+
+    Used as a context manager around a scope's work::
+
+        with LeaseHeartbeat(leases, key, ttl_seconds=300) as hb:
+            run_jobs(..., should_abort=hb.lost.is_set)
+            if hb.lost.is_set():
+                ...  # fail closed
+    """
+
+    def __init__(
+        self,
+        leases: WorkerLeaseManager,
+        key: str,
+        *,
+        ttl_seconds: int,
+        interval_seconds: float | None = None,
+        renew: Callable[[], bool] | None = None,
+    ) -> None:
+        self._leases = leases
+        self._key = key
+        self._interval = interval_seconds or max(ttl_seconds / _RENEW_FRACTION, 1.0)
+        self._renew = renew or (lambda: self._leases.renew(self._key))
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        # Set when the lease could no longer be renewed — the scope is no longer ours.
+        self.lost = threading.Event()
+        self.renewals = 0
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+    def start(self) -> LeaseHeartbeat:
+        self._thread = threading.Thread(
+            target=self._loop, name=f"lease-heartbeat:{self._key}", daemon=True
+        )
+        self._thread.start()
+        return self
+
+    def stop(self, *, timeout: float = 5.0) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None
+
+    def __enter__(self) -> LeaseHeartbeat:
+        return self.start()
+
+    def __exit__(self, *exc_info) -> None:
+        self.stop()
+
+    # ── internals ────────────────────────────────────────────────────────────
+    def _loop(self) -> None:
+        # `wait` returns True when stopped — an interruptible sleep, so shutdown is
+        # immediate rather than waiting out a full interval.
+        while not self._stop.wait(self._interval):
+            try:
+                renewed = self._renew()
+            except Exception as exc:  # noqa: BLE001 — a raising store means we can't prove ownership
+                renewed = False
+                logger.warning(
+                    "lease renewal raised; treating the lease as lost",
+                    extra={
+                        "event": "worker_lease_renew_error",
+                        "status": "failed",
+                        "error": type(exc).__name__,
+                    },
+                )
+            if renewed:
+                self.renewals += 1
+                continue
+            # Fail closed: we can no longer prove we own this scope.
+            self.lost.set()
+            logger.warning(
+                "worker lease lost; aborting scope before further mutation",
+                extra={
+                    "event": "worker_lease_lost",
+                    "status": "failed",
+                    "renewals": self.renewals,
+                },
+            )
+            return

--- a/services/api/app/workers/orchestrator.py
+++ b/services/api/app/workers/orchestrator.py
@@ -30,10 +30,12 @@ from ..core.logging import get_logger
 from ..db.entities import WorkerRunRecord
 from ..db.repository import Repository
 from ..services.audit import AuditService
+from .heartbeat import LeaseHeartbeat
 from .locks import WorkerLeaseManager, scope_key
 from .retry import RetryPolicy, run_with_retry
 from .runner import run_jobs
 from .schemas import WorkerRunReport, WorkerRunStatus
+from .shutdown import ShutdownSignal
 
 logger = get_logger("memoryops.workers.orchestrator")
 
@@ -43,6 +45,9 @@ RUN_WITH_FINDINGS = WorkerRunStatus.completed_with_findings.value
 RUN_FAILED = WorkerRunStatus.failed.value
 RUN_LOCKED_SKIP = "locked_skip"
 RUN_DEAD_LETTER = "dead_letter"
+# The lease was held at acquire time but could not be renewed while the scope ran,
+# so another replica may now own it. Fail closed and make it observable.
+RUN_LEASE_LOST = "lease_lost"
 
 
 @dataclass(frozen=True)
@@ -72,8 +77,15 @@ def default_owner() -> str:
 
 def _report_status(report: WorkerRunReport) -> str:
     statuses = {r.status for r in report.results}
+    # Most severe first. A job that exhausted its retries outranks a plain failure:
+    # it is replayable work that was given up on, and must not be summarised as a
+    # transient `failed` that something else might pick up.
+    if WorkerRunStatus.dead_letter.value in statuses:
+        return RUN_DEAD_LETTER
     if RUN_FAILED in statuses:
         return RUN_FAILED
+    if WorkerRunStatus.aborted.value in statuses:
+        return RUN_LEASE_LOST
     if RUN_WITH_FINDINGS in statuses:
         return RUN_WITH_FINDINGS
     return RUN_COMPLETED
@@ -87,12 +99,16 @@ class WorkerOrchestrator:
     retry_policy: RetryPolicy | None = None
     audit: AuditService | None = None
     sleep: Callable[[float], None] | None = None
+    # Optional cooperative stop flag (ShutdownSignal). When set, the orchestrator
+    # stops between jobs so a SIGTERM finishes cleanly and releases its lease.
+    shutdown: ShutdownSignal | None = None
 
     def __post_init__(self) -> None:
         s = get_settings()
+        self._lease_ttl_seconds = self.lease_ttl_seconds or s.worker_lease_ttl_seconds
         self._leases = WorkerLeaseManager(
             self.repo,
-            ttl_seconds=self.lease_ttl_seconds or s.worker_lease_ttl_seconds,
+            ttl_seconds=self._lease_ttl_seconds,
             owner=self.owner,
         )
         self._policy = self.retry_policy or RetryPolicy(
@@ -118,27 +134,54 @@ class WorkerOrchestrator:
                 trace_id=trace_id, details={"reason": "lease_held_by_other"},
             )
 
-        try:
-            outcome = run_with_retry(
-                lambda: run_jobs(
-                    self.repo,
-                    tenant_id=scope.tenant_id,
-                    user_id=scope.user_id,
-                    jobs=jobs,
-                    trace_id=trace_id,
-                    now=now,
-                    audit=self._audit,
-                ),
-                self._policy,
-                sleep=self.sleep or time.sleep,
+        # Renew the lease for as long as the scope runs, and fail closed if we ever
+        # cannot prove we still own it. Without this, any scope whose jobs outlived
+        # `worker_lease_ttl_seconds` silently lost exclusivity mid-run and a second
+        # replica could start mutating the same tenant/user (see heartbeat.py).
+        heartbeat = LeaseHeartbeat(
+            self._leases, key, ttl_seconds=self._lease_ttl_seconds
+        )
+        # Stop between jobs on a lost lease OR an operator shutdown request.
+        def _should_abort() -> bool:
+            return heartbeat.lost.is_set() or (
+                self.shutdown is not None and self.shutdown.is_set()
             )
+
+        try:
+            with heartbeat:
+                outcome = run_with_retry(
+                    lambda: run_jobs(
+                        self.repo,
+                        tenant_id=scope.tenant_id,
+                        user_id=scope.user_id,
+                        jobs=jobs,
+                        trace_id=trace_id,
+                        now=now,
+                        audit=self._audit,
+                        # Per-job retry + dead-letter. The outer run_with_retry only
+                        # ever caught orchestration-level raises; lifecycle workers
+                        # return failed results instead of raising, so without this a
+                        # failed job was recorded and then dropped.
+                        retry_policy=self._policy,
+                        sleep=self.sleep or time.sleep,
+                        should_abort=_should_abort,
+                    ),
+                    self._policy,
+                    sleep=self.sleep or time.sleep,
+                )
             if outcome.ok and outcome.value is not None:
                 report = outcome.value
+                status = _report_status(report)
+                details: dict = {"jobs": {r.job: r.status for r in report.results}}
+                if heartbeat.lost.is_set():
+                    status = RUN_LEASE_LOST
+                    details["reason"] = "lease_lost_mid_run"
+                details["lease_renewals"] = heartbeat.renewals
                 return self._record(
-                    scope, jobs, status=_report_status(report),
+                    scope, jobs, status=status,
                     attempts=outcome.attempts, now=now, trace_id=trace_id,
                     report=report,
-                    details={"jobs": {r.job: r.status for r in report.results}},
+                    details=details,
                 )
             # Retries exhausted on a transient fault → dead-letter, never lost.
             logger.warning(
@@ -161,9 +204,25 @@ class WorkerOrchestrator:
         now: datetime | None = None,
         trace_id: str | None = None,
     ) -> list[WorkerRunRecord]:
-        """One scheduling pass over all scopes. Scopes are independent."""
+        """One scheduling pass over all scopes. Scopes are independent.
+
+        A shutdown request stops the pass at a scope boundary: the scope in flight
+        finishes and releases its lease, and the remaining scopes are simply left
+        for the next replica rather than being started and hard-killed mid-write.
+        """
         records: list[WorkerRunRecord] = []
         for scope in scopes:
+            if self.shutdown is not None and self.shutdown.is_set():
+                logger.info(
+                    "shutdown requested; stopping pass at scope boundary",
+                    extra={
+                        "event": "worker_pass_interrupted",
+                        "status": "ok",
+                        "completed_scopes": len(records),
+                        "remaining_scopes": len(scopes) - len(records),
+                    },
+                )
+                break
             records.append(self.run_scope(scope, now=now, trace_id=trace_id))
         return records
 

--- a/services/api/app/workers/runner.py
+++ b/services/api/app/workers/runner.py
@@ -18,8 +18,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import time
+from collections.abc import Callable
 from datetime import UTC, datetime
 
+from ..core.logging import get_logger
 from ..db.factory import get_repository
 from ..db.repository import Repository
 from ..services.audit import AuditService
@@ -31,7 +34,16 @@ from .deletion_verification import DeletionVerificationWorker
 from .lifecycle import LifecycleWorker, WorkerContext
 from .reflection import ReflectionWorker
 from .retention import RetentionWorker
-from .schemas import DEFAULT_JOB_ORDER, WorkerJob, WorkerRunReport
+from .retry import RetryPolicy
+from .schemas import (
+    DEFAULT_JOB_ORDER,
+    WorkerJob,
+    WorkerJobResult,
+    WorkerRunReport,
+    WorkerRunStatus,
+)
+
+logger = get_logger("memoryops.workers.runner")
 
 # Job → worker class. Single source of truth for the runner and the CLI.
 _WORKERS: dict[WorkerJob, type[LifecycleWorker]] = {
@@ -56,6 +68,77 @@ def _resolve_jobs(jobs: list[str]) -> list[WorkerJob]:
     return resolved
 
 
+def _run_one_job(
+    job: WorkerJob,
+    repo: Repository,
+    audit: AuditService,
+    ctx: WorkerContext,
+    *,
+    policy: RetryPolicy | None,
+    sleep: Callable[[float], None],
+) -> WorkerJobResult:
+    """Run a single job, retrying a *failed* result up to the policy's budget.
+
+    Retrying on the returned status (not just on a raised exception) is the point.
+    Lifecycle workers catch their own errors and return
+    ``status=failed`` rather than raising, so the orchestration-level
+    ``run_with_retry`` around ``run_jobs`` only ever saw clean returns: a failing
+    job was recorded as failed and then simply dropped — never retried, never
+    dead-lettered. Findings (``completed_with_findings``) are real results, not
+    faults, so they are never retried.
+    """
+    attempts = 0
+    max_attempts = policy.max_attempts if policy else 1
+    result: WorkerJobResult | None = None
+
+    while attempts < max_attempts:
+        attempts += 1
+        worker = _WORKERS[job](repo, audit)
+        try:
+            result = worker.run(ctx)
+        except Exception as exc:  # noqa: BLE001 — a raising worker is still retryable
+            result = WorkerJobResult(
+                job=job.value,
+                tenant_id=ctx.tenant_id,
+                user_id=ctx.user_id,
+                started_at=ctx.now,
+                completed_at=datetime.now(UTC),
+                status=WorkerRunStatus.failed.value,
+                error=type(exc).__name__,
+            )
+        if result.status != WorkerRunStatus.failed.value:
+            break
+        if attempts < max_attempts and policy is not None:
+            logger.warning(
+                "worker job failed; retrying",
+                extra={
+                    "event": "worker_job_retry",
+                    "status": "failed",
+                    "job": job.value,
+                    "attempt": attempts,
+                    "error": result.error,
+                },
+            )
+            sleep(policy.delay_for(attempts))
+
+    assert result is not None  # loop runs at least once
+    result.details = {**result.details, "attempts": attempts}
+    if result.status == WorkerRunStatus.failed.value and attempts >= max_attempts > 1:
+        # Budget exhausted → dead-letter so the work is replayable, not just logged.
+        result.status = WorkerRunStatus.dead_letter.value
+        logger.warning(
+            "worker job dead-lettered after exhausting retries",
+            extra={
+                "event": "worker_job_dead_letter",
+                "status": "failed",
+                "job": job.value,
+                "attempts": attempts,
+                "error": result.error,
+            },
+        )
+    return result
+
+
 def run_jobs(
     repo: Repository,
     *,
@@ -66,11 +149,20 @@ def run_jobs(
     now: datetime | None = None,
     dry_run: bool = False,
     audit: AuditService | None = None,
+    retry_policy: RetryPolicy | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+    should_abort: Callable[[], bool] | None = None,
 ) -> WorkerRunReport:
     """Run the selected lifecycle jobs for one tenant/user scope.
 
     Each job runs independently; one job failing is recorded in its result and
     never prevents the others from running (workers never block the pipeline).
+
+    ``retry_policy`` enables per-job retry + dead-lettering (the orchestrator passes
+    one; the CLI defaults to a single attempt). ``should_abort`` is polled before
+    each job so a lost lease or a shutdown request stops the scope *between* jobs
+    rather than mutating a scope this worker may no longer own — remaining jobs are
+    recorded as ``aborted`` instead of silently vanishing from the report.
     """
     from ..observability import new_correlation_id, set_correlation_id, span
 
@@ -86,10 +178,26 @@ def run_jobs(
     # span so a run is one correlated trace end to end (ADR-022).
     set_correlation_id(trace_id) if trace_id else new_correlation_id("worker")
     report = WorkerRunReport(started_at=ctx.now)
+    aborted = False
     for job in _resolve_jobs(jobs or ["all"]):
+        if aborted or (should_abort is not None and should_abort()):
+            aborted = True
+            report.add(
+                WorkerJobResult(
+                    job=job.value,
+                    tenant_id=tenant_id,
+                    user_id=user_id,
+                    started_at=ctx.now,
+                    completed_at=datetime.now(UTC),
+                    status=WorkerRunStatus.aborted.value,
+                    details={"reason": "lease_lost_or_shutdown"},
+                )
+            )
+            continue
         with span("worker.job", job=job.value, dry_run=dry_run):
-            worker = _WORKERS[job](repo, audit)
-            report.add(worker.run(ctx))
+            report.add(
+                _run_one_job(job, repo, audit, ctx, policy=retry_policy, sleep=sleep)
+            )
     report.completed_at = datetime.now(UTC)
     return report
 

--- a/services/api/app/workers/scheduler.py
+++ b/services/api/app/workers/scheduler.py
@@ -19,6 +19,7 @@ from ..core.logging import get_logger
 from ..db.entities import WorkerRunRecord
 from ..db.repository import Repository
 from .orchestrator import Scope, WorkerOrchestrator, parse_scopes
+from .shutdown import ShutdownSignal
 
 logger = get_logger("memoryops.workers.scheduler")
 
@@ -32,12 +33,16 @@ class WorkerScheduler:
         interval_seconds: int | None = None,
         orchestrator: WorkerOrchestrator | None = None,
         sleep: Callable[[float], None] = time.sleep,
+        shutdown: ShutdownSignal | None = None,
     ) -> None:
         s = get_settings()
         self._repo = repo
         self._scopes = scopes if scopes is not None else parse_scopes(s.worker_scopes)
         self._interval = interval_seconds or s.worker_interval_seconds
-        self._orchestrator = orchestrator or WorkerOrchestrator(repo)
+        # The orchestrator needs the same stop flag so it can break between scopes
+        # and between jobs, not just between ticks.
+        self._shutdown = shutdown
+        self._orchestrator = orchestrator or WorkerOrchestrator(repo, shutdown=shutdown)
         self._sleep = sleep
 
     @property
@@ -64,9 +69,17 @@ class WorkerScheduler:
         A tick never raises into the loop: the orchestrator records per-scope
         failures, and any unexpected error is caught here so the scheduler keeps
         running (the worker process must not crash on a single bad pass).
+
+        Shutdown is cooperative. When a ``ShutdownSignal`` is supplied the
+        between-tick wait is an interruptible ``Event.wait`` rather than
+        ``time.sleep``, so a SIGTERM arriving mid-interval is acted on immediately
+        instead of after the full interval (with a 60s default, the process
+        previously spent nearly all its life ignoring SIGTERM until the SIGKILL).
         """
         ticks = 0
         while max_ticks is None or ticks < max_ticks:
+            if self._stop_requested():
+                break
             try:
                 self.tick()
             except Exception as exc:  # noqa: BLE001 — scheduler must survive a bad tick
@@ -76,6 +89,24 @@ class WorkerScheduler:
                            "error": type(exc).__name__},
                 )
             ticks += 1
+            if self._stop_requested():
+                break
             if max_ticks is None or ticks < max_ticks:
-                self._sleep(self._interval)
+                self._wait(self._interval)
+        if self._stop_requested():
+            logger.info(
+                "worker scheduler stopped cleanly",
+                extra={"event": "worker_stopped", "status": "ok", "ticks": ticks},
+            )
         return ticks
+
+    # ── shutdown plumbing ─────────────────────────────────────────────────────
+    def _stop_requested(self) -> bool:
+        return self._shutdown is not None and self._shutdown.is_set()
+
+    def _wait(self, seconds: float) -> None:
+        """Interruptible inter-tick wait; falls back to the injected sleep."""
+        if self._shutdown is not None:
+            self._shutdown.wait(seconds)
+        else:
+            self._sleep(seconds)

--- a/services/api/app/workers/schemas.py
+++ b/services/api/app/workers/schemas.py
@@ -60,6 +60,16 @@ class WorkerRunStatus(str, Enum):
     completed_with_findings = "completed_with_findings"  # e.g. deletion leak found
     skipped = "skipped"  # job disabled / not applicable
     failed = "failed"  # unexpected error; never blocks chat
+    # A `failed` job that exhausted its retry budget. Distinct from `failed` so
+    # exhausted work is replayable instead of merely recorded: lifecycle workers
+    # catch their own errors and return a failed *result* rather than raising, so
+    # the orchestration-level retry never saw them and nothing was ever retried or
+    # dead-lettered at the job level.
+    dead_letter = "dead_letter"
+    # The scope's lease was lost (or shutdown was requested) before this job ran, so
+    # it was deliberately not started — fail closed rather than mutate a scope
+    # another replica may now own.
+    aborted = "aborted"
 
 
 # ── Audit / structured event actions (invariant #7) ───────────────────────────

--- a/services/api/app/workers/shutdown.py
+++ b/services/api/app/workers/shutdown.py
@@ -1,0 +1,101 @@
+"""Graceful shutdown for the worker process (ADR-012 follow-up).
+
+Before this, ``WorkerScheduler.run_forever`` looped on a bare ``time.sleep`` with no
+signal handling at all. On Railway (or any orchestrator) a deploy sends SIGTERM and
+then SIGKILLs after a grace period, so the worker was always hard-killed:
+
+  * mid-tick work was cut off wherever it happened to be;
+  * the held lease was never released, so that scope stayed locked for the rest of
+    its TTL and the next replica skipped it;
+  * the sleep was uninterruptible, so a worker with a 60s interval spent most of
+    its life in a state where SIGTERM did nothing until the kill landed.
+
+``ShutdownSignal`` makes the stop cooperative: signals set an event, the scheduler
+waits on that event instead of sleeping (so it wakes immediately), finishes the tick
+it is in, releases its lease, and exits 0.
+"""
+
+from __future__ import annotations
+
+import signal
+import threading
+from types import FrameType
+
+from ..core.logging import get_logger
+
+logger = get_logger("memoryops.workers.shutdown")
+
+# The signals an orchestrator uses to ask a process to stop.
+_STOP_SIGNALS = (signal.SIGTERM, signal.SIGINT)
+
+
+class ShutdownSignal:
+    """A stop flag fed by SIGTERM/SIGINT, usable as an interruptible sleep.
+
+    Signal handlers can only be installed from the main thread of the main
+    interpreter; ``install()`` degrades to a no-op elsewhere (tests, embedded use)
+    rather than raising, and the event can still be set programmatically.
+    """
+
+    def __init__(self) -> None:
+        self._event = threading.Event()
+        self._previous: dict[int, object] = {}
+        self.signal_name: str | None = None
+
+    # ── flag ─────────────────────────────────────────────────────────────────
+    def is_set(self) -> bool:
+        return self._event.is_set()
+
+    def set(self) -> None:
+        self._event.set()
+
+    def wait(self, timeout: float | None = None) -> bool:
+        """Sleep up to ``timeout``, returning True as soon as a stop is requested.
+
+        This replaces ``time.sleep`` in the scheduler loop so a SIGTERM arriving
+        mid-interval is acted on immediately instead of after the full interval.
+        """
+        return self._event.wait(timeout)
+
+    # ── installation ─────────────────────────────────────────────────────────
+    def install(self) -> ShutdownSignal:
+        for sig in _STOP_SIGNALS:
+            try:
+                self._previous[sig] = signal.getsignal(sig)
+                signal.signal(sig, self._handle)
+            except (ValueError, OSError):  # not the main thread / unsupported
+                logger.debug(
+                    "could not install signal handler",
+                    extra={"event": "worker_signal_install_skipped", "signal": sig},
+                )
+        return self
+
+    def restore(self) -> None:
+        for sig, handler in self._previous.items():
+            try:
+                signal.signal(sig, handler)  # type: ignore[arg-type]
+            except (ValueError, OSError, TypeError):
+                pass
+        self._previous.clear()
+
+    def __enter__(self) -> ShutdownSignal:
+        return self.install()
+
+    def __exit__(self, *exc_info) -> None:
+        self.restore()
+
+    # ── handler ──────────────────────────────────────────────────────────────
+    def _handle(self, signum: int, _frame: FrameType | None) -> None:
+        self.signal_name = signal.Signals(signum).name
+        # Deliberately not exiting here: the scheduler must finish its current tick
+        # and release its lease. A second signal still hard-kills via the default
+        # handler only if the operator sends one after we restore handlers.
+        logger.info(
+            "shutdown requested; finishing current tick",
+            extra={
+                "event": "worker_shutdown_requested",
+                "status": "ok",
+                "signal": self.signal_name,
+            },
+        )
+        self._event.set()

--- a/services/api/tests/test_worker_locks.py
+++ b/services/api/tests/test_worker_locks.py
@@ -78,3 +78,37 @@ def test_renew_only_by_owner(repo) -> None:
     assert b.renew("t1:u1", now=NOW) is False
     assert a.renew("t1:u1", now=NOW + timedelta(seconds=30)) is True
     assert repo.get_lease("t1:u1").expires_at == NOW + timedelta(seconds=90)
+
+
+# ── heartbeat renewal (lease held across long work) ──────────────────────────
+# `renew()` existed from v0.8 but nothing ever called it, so a scope whose jobs
+# outlived the TTL silently lost exclusivity mid-run and a second replica could
+# acquire it and mutate the same tenant/user concurrently. Full behavioural
+# coverage in tests/test_worker_reliability.py.
+def test_renewal_keeps_a_scope_locked_past_its_original_ttl(repo) -> None:
+    a = _mgr(repo, "worker-a", ttl=60)
+    b = _mgr(repo, "worker-b", ttl=60)
+    assert a.acquire("t1:u1", now=NOW)
+
+    # Without renewal the lease would be reclaimable at NOW+60.
+    later = NOW + timedelta(seconds=59)
+    assert a.renew("t1:u1", now=later) is True
+
+    # At NOW+90 — past the original expiry — the renewed lease still excludes b.
+    assert b.acquire("t1:u1", now=NOW + timedelta(seconds=90)) is False
+    assert repo.get_lease("t1:u1").owner == "worker-a"
+
+
+def test_renewal_fails_once_another_worker_has_taken_over(repo) -> None:
+    """The signal the heartbeat fails closed on: renew() must not resurrect a lease."""
+    a = _mgr(repo, "worker-a", ttl=30)
+    b = _mgr(repo, "worker-b", ttl=30)
+    a.acquire("t1:u1", now=NOW)
+
+    # a stalls past its TTL; b legitimately reclaims the expired lease.
+    expired = NOW + timedelta(seconds=31)
+    assert b.acquire("t1:u1", now=expired) is True
+
+    # a must now be unable to renew — it no longer owns the scope.
+    assert a.renew("t1:u1", now=expired) is False
+    assert repo.get_lease("t1:u1").owner == "worker-b"

--- a/services/api/tests/test_worker_orchestrator.py
+++ b/services/api/tests/test_worker_orchestrator.py
@@ -128,3 +128,71 @@ def test_scheduler_run_forever_bounded_by_max_ticks(repo) -> None:
     # Sleeps only between ticks, not after the last one.
     assert slept == [5, 5]
     assert len(repo.list_worker_runs(tenant_id="t1", user_id="u1")) == 3
+
+
+# ── per-job retry, dead-letter, and cooperative shutdown ─────────────────────
+# Retry used to wrap `run_jobs` as a whole, but lifecycle workers catch their own
+# errors and *return* status=failed rather than raising — so the wrapper only saw
+# clean returns and a failing job was recorded then dropped: never retried, never
+# dead-lettered. Full coverage in tests/test_worker_reliability.py.
+def test_orchestrator_dead_letters_a_persistently_failing_job(repo, monkeypatch) -> None:
+    from app.workers import runner as runner_module
+    from app.workers.schemas import WorkerJob, WorkerJobResult, WorkerRunStatus
+
+    calls = {"n": 0}
+
+    class _AlwaysFails:
+        def __init__(self, repo, audit) -> None:
+            pass
+
+        def run(self, ctx) -> WorkerJobResult:
+            calls["n"] += 1
+            return WorkerJobResult(
+                job=WorkerJob.decay.value,
+                tenant_id=ctx.tenant_id,
+                user_id=ctx.user_id,
+                started_at=ctx.now,
+                completed_at=ctx.now,
+                status=WorkerRunStatus.failed.value,
+                error="Boom",
+            )
+
+    monkeypatch.setitem(runner_module._WORKERS, WorkerJob.decay, _AlwaysFails)
+
+    record = _orch(repo).run_scope(Scope("t1", "u1", jobs=("decay",)), now=NOW)
+
+    assert calls["n"] == 2, "the failing job must be retried, not recorded once and dropped"
+    assert record.status == RUN_DEAD_LETTER
+    assert record.details["jobs"]["decay"] == WorkerRunStatus.dead_letter.value
+
+
+def test_orchestrator_stops_between_scopes_when_shutdown_is_requested(repo) -> None:
+    """SIGTERM must stop the pass at a scope boundary, releasing the lease cleanly."""
+    from app.workers.shutdown import ShutdownSignal
+
+    seed_memory(repo, status=Status.active)
+    shutdown = ShutdownSignal()
+    orch = _orch(repo, shutdown=shutdown)
+
+    shutdown.set()
+    records = orch.run_once([Scope("t1", "u1"), Scope("t2", "u2")], now=NOW)
+
+    assert records == []
+    assert repo.get_lease(scope_key("t1", "u1")) is None
+
+
+def test_lease_is_released_even_when_every_job_dead_letters(repo, monkeypatch) -> None:
+    from app.workers import runner as runner_module
+    from app.workers.schemas import WorkerJob
+
+    class _Explodes:
+        def __init__(self, repo, audit) -> None:
+            pass
+
+        def run(self, ctx):
+            raise RuntimeError("worker exploded")
+
+    monkeypatch.setitem(runner_module._WORKERS, WorkerJob.decay, _Explodes)
+    _orch(repo).run_scope(Scope("t1", "u1", jobs=("decay",)), now=NOW)
+    # A stuck lease would make the next replica skip this scope for a full TTL.
+    assert repo.get_lease(scope_key("t1", "u1")) is None

--- a/services/api/tests/test_worker_reliability.py
+++ b/services/api/tests/test_worker_reliability.py
@@ -1,0 +1,392 @@
+"""Worker reliability: lease heartbeat, per-job retry, and graceful shutdown.
+
+Three gaps in the v0.8 runtime that this locks down:
+
+1. **The lease was never renewed.** `WorkerLeaseManager.renew()` existed but
+   nothing called it. A scope whose jobs outlived `worker_lease_ttl_seconds`
+   (default 300s) silently lost exclusivity mid-run, so a second replica could
+   acquire the same tenant/user and mutate it concurrently.
+
+2. **Job failures were never retried.** `run_with_retry` wrapped `run_jobs`, but
+   lifecycle workers catch their own errors and *return* `status=failed` instead of
+   raising — so the retry wrapper only ever saw clean returns. A failing job was
+   recorded as failed and then dropped: not retried, not dead-lettered.
+
+3. **No graceful shutdown.** `run_forever` looped on a bare `time.sleep` with no
+   signal handling, so every deploy hard-killed the worker mid-tick and left its
+   lease held for the remainder of the TTL.
+"""
+
+from __future__ import annotations
+
+import signal
+import threading
+from datetime import UTC, datetime, timedelta
+
+from app.workers.heartbeat import LeaseHeartbeat
+from app.workers.locks import WorkerLeaseManager, scope_key
+from app.workers.orchestrator import (
+    RUN_COMPLETED,
+    RUN_DEAD_LETTER,
+    RUN_LEASE_LOST,
+    Scope,
+    WorkerOrchestrator,
+)
+from app.workers.retry import RetryPolicy
+from app.workers.runner import run_jobs
+from app.workers.scheduler import WorkerScheduler
+from app.workers.schemas import WorkerJob, WorkerJobResult, WorkerRunStatus
+from app.workers.shutdown import ShutdownSignal
+
+from ._worker_helpers import seed_memory
+
+NOW = datetime(2026, 6, 22, tzinfo=UTC)
+
+
+def _fast_policy(attempts: int = 3) -> RetryPolicy:
+    return RetryPolicy(max_attempts=attempts, base_delay_seconds=0.0)
+
+
+# ── 1. lease heartbeat ───────────────────────────────────────────────────────
+def test_heartbeat_renews_the_lease_while_work_runs(repo) -> None:
+    leases = WorkerLeaseManager(repo, ttl_seconds=60, owner="w1")
+    key = scope_key("t1", "u1")
+    assert leases.acquire(key, now=NOW)
+
+    renewed = threading.Event()
+
+    def _renew() -> bool:
+        renewed.set()
+        return True
+
+    hb = LeaseHeartbeat(leases, key, ttl_seconds=60, interval_seconds=0.01, renew=_renew)
+    with hb:
+        assert renewed.wait(timeout=2.0), "heartbeat never renewed the lease"
+    assert not hb.lost.is_set()
+
+
+def test_heartbeat_flags_loss_when_renewal_fails(repo) -> None:
+    """Losing the lease must be observable, not silent — another replica may own us."""
+    leases = WorkerLeaseManager(repo, ttl_seconds=60, owner="w1")
+    hb = LeaseHeartbeat(
+        leases, scope_key("t1", "u1"), ttl_seconds=60,
+        interval_seconds=0.01, renew=lambda: False,
+    )
+    with hb:
+        assert hb.lost.wait(timeout=2.0), "lease loss was not flagged"
+
+
+def test_heartbeat_treats_a_raising_store_as_lease_loss(repo) -> None:
+    """If we cannot prove ownership, fail closed rather than assume we still hold it."""
+    leases = WorkerLeaseManager(repo, ttl_seconds=60, owner="w1")
+
+    def _boom() -> bool:
+        raise RuntimeError("store unreachable")
+
+    hb = LeaseHeartbeat(
+        leases, scope_key("t1", "u1"), ttl_seconds=60,
+        interval_seconds=0.01, renew=_boom,
+    )
+    with hb:
+        assert hb.lost.wait(timeout=2.0)
+
+
+def test_a_job_outliving_the_lease_ttl_does_not_lose_exclusivity(repo) -> None:
+    """The regression: work longer than the TTL must keep its lease.
+
+    Simulates a slow scope with a 1s TTL. Without renewal the lease expires and a
+    second worker can acquire the same scope; with the heartbeat it cannot.
+    """
+    key = scope_key("t1", "u1")
+    leases = WorkerLeaseManager(repo, ttl_seconds=1, owner="worker-a")
+    assert leases.acquire(key, now=datetime.now(UTC))
+
+    other = WorkerLeaseManager(repo, ttl_seconds=1, owner="worker-b")
+
+    with LeaseHeartbeat(leases, key, ttl_seconds=1, interval_seconds=0.05):
+        # Work for longer than the TTL while the heartbeat renews underneath us.
+        threading.Event().wait(1.6)
+        acquired_by_other = other.acquire(key, now=datetime.now(UTC))
+
+    assert not acquired_by_other, (
+        "a second worker acquired a scope whose lease should have been renewed — "
+        "the same tenant/user would be mutated concurrently"
+    )
+
+
+def test_orchestrator_records_lease_lost_and_aborts_remaining_jobs(repo, monkeypatch) -> None:
+    """A lost lease stops the scope between jobs instead of mutating on."""
+    seed_memory(repo, content="dark mode")
+
+    # Force every renewal to fail so the heartbeat flags loss almost immediately.
+    monkeypatch.setattr(
+        "app.workers.heartbeat.LeaseHeartbeat._renew", lambda self: False, raising=False
+    )
+    monkeypatch.setattr(WorkerLeaseManager, "renew", lambda self, key, now=None: False)
+
+    orch = WorkerOrchestrator(
+        repo, owner="w1", lease_ttl_seconds=1,
+        retry_policy=_fast_policy(1), sleep=lambda _s: None,
+    )
+    # Heartbeat interval is ttl/3 ≈ 0.33s; give the scope work that spans it.
+    record = orch.run_scope(Scope("t1", "u1"), now=NOW, trace_id="t")
+
+    # Either the run completed before the first renewal tick, or it was caught and
+    # failed closed. It must never be silently "completed" *after* a detected loss.
+    if record.details.get("reason") == "lease_lost_mid_run":
+        assert record.status == RUN_LEASE_LOST
+    else:
+        assert record.status in (RUN_COMPLETED, RUN_DEAD_LETTER)
+    # The lease is always released, whatever happened.
+    assert repo.get_lease(scope_key("t1", "u1")) is None
+
+
+# ── 2. per-job retry + dead-letter ───────────────────────────────────────────
+class _FlakyWorker:
+    """Fails `fail_times` times (by returning a failed result), then succeeds."""
+
+    calls = 0
+    fail_times = 1
+
+    def __init__(self, repo, audit) -> None:
+        pass
+
+    def run(self, ctx) -> WorkerJobResult:
+        type(self).calls += 1
+        failed = type(self).calls <= type(self).fail_times
+        return WorkerJobResult(
+            job=WorkerJob.decay.value,
+            tenant_id=ctx.tenant_id,
+            user_id=ctx.user_id,
+            started_at=ctx.now,
+            completed_at=ctx.now,
+            status=(
+                WorkerRunStatus.failed.value if failed else WorkerRunStatus.completed.value
+            ),
+            error="Boom" if failed else None,
+        )
+
+
+def _patch_decay(monkeypatch, worker_cls) -> None:
+    from app.workers import runner as runner_module
+
+    monkeypatch.setitem(runner_module._WORKERS, WorkerJob.decay, worker_cls)
+
+
+def test_a_failed_job_result_is_retried(repo, monkeypatch) -> None:
+    """The core gap: workers *return* failure rather than raising, so retry must
+    key off the result status, not just exceptions."""
+    _FlakyWorker.calls = 0
+    _FlakyWorker.fail_times = 1
+    _patch_decay(monkeypatch, _FlakyWorker)
+
+    report = run_jobs(
+        repo, tenant_id="t1", user_id="u1", jobs=["decay"], now=NOW,
+        retry_policy=_fast_policy(3), sleep=lambda _s: None,
+    )
+    assert _FlakyWorker.calls == 2, "failed job was not retried"
+    assert report.results[0].status == WorkerRunStatus.completed.value
+    assert report.results[0].details["attempts"] == 2
+
+
+def test_exhausted_retries_dead_letter_the_job(repo, monkeypatch) -> None:
+    _FlakyWorker.calls = 0
+    _FlakyWorker.fail_times = 99  # never succeeds
+    _patch_decay(monkeypatch, _FlakyWorker)
+
+    report = run_jobs(
+        repo, tenant_id="t1", user_id="u1", jobs=["decay"], now=NOW,
+        retry_policy=_fast_policy(3), sleep=lambda _s: None,
+    )
+    assert _FlakyWorker.calls == 3
+    result = report.results[0]
+    assert result.status == WorkerRunStatus.dead_letter.value, (
+        "an exhausted job must be dead-lettered so the work is replayable, "
+        "not merely recorded as failed and dropped"
+    )
+    assert result.details["attempts"] == 3
+    assert not report.ok
+
+
+def test_orchestrator_surfaces_a_dead_lettered_job_in_run_history(repo, monkeypatch) -> None:
+    _FlakyWorker.calls = 0
+    _FlakyWorker.fail_times = 99
+    _patch_decay(monkeypatch, _FlakyWorker)
+
+    orch = WorkerOrchestrator(
+        repo, owner="w1", retry_policy=_fast_policy(2), sleep=lambda _s: None
+    )
+    record = orch.run_scope(Scope("t1", "u1", jobs=("decay",)), now=NOW)
+
+    assert record.status == RUN_DEAD_LETTER
+    assert record.details["jobs"]["decay"] == WorkerRunStatus.dead_letter.value
+
+
+class _RaisingWorker:
+    def __init__(self, repo, audit) -> None:
+        pass
+
+    def run(self, ctx):
+        raise RuntimeError("worker exploded")
+
+
+def test_a_raising_job_is_also_retried_and_dead_lettered(repo, monkeypatch) -> None:
+    _patch_decay(monkeypatch, _RaisingWorker)
+    report = run_jobs(
+        repo, tenant_id="t1", user_id="u1", jobs=["decay"], now=NOW,
+        retry_policy=_fast_policy(2), sleep=lambda _s: None,
+    )
+    result = report.results[0]
+    assert result.status == WorkerRunStatus.dead_letter.value
+    assert result.error == "RuntimeError"
+    assert result.details["attempts"] == 2
+
+
+class _FindingWorker:
+    calls = 0
+
+    def __init__(self, repo, audit) -> None:
+        pass
+
+    def run(self, ctx) -> WorkerJobResult:
+        type(self).calls += 1
+        return WorkerJobResult(
+            job=WorkerJob.decay.value,
+            tenant_id=ctx.tenant_id,
+            user_id=ctx.user_id,
+            started_at=ctx.now,
+            completed_at=ctx.now,
+            status=WorkerRunStatus.completed_with_findings.value,
+        )
+
+
+def test_findings_are_never_retried(repo, monkeypatch) -> None:
+    """A finding (e.g. a deletion leak) is a real result, not a transient fault.
+
+    Retrying it would multiply audit events and mask the finding.
+    """
+    _FindingWorker.calls = 0
+    _patch_decay(monkeypatch, _FindingWorker)
+    run_jobs(
+        repo, tenant_id="t1", user_id="u1", jobs=["decay"], now=NOW,
+        retry_policy=_fast_policy(3), sleep=lambda _s: None,
+    )
+    assert _FindingWorker.calls == 1
+
+
+def test_abort_marks_remaining_jobs_aborted_not_missing(repo) -> None:
+    """Remaining jobs must be recorded as aborted, not silently absent from the report."""
+    report = run_jobs(
+        repo, tenant_id="t1", user_id="u1", jobs=["decay", "archive"], now=NOW,
+        should_abort=lambda: True,
+    )
+    assert [r.status for r in report.results] == [
+        WorkerRunStatus.aborted.value,
+        WorkerRunStatus.aborted.value,
+    ]
+    assert not report.ok
+
+
+def test_default_run_jobs_still_runs_once(repo) -> None:
+    """Without a policy the CLI path keeps its single-attempt behaviour."""
+    _FlakyWorker.calls = 0
+    _FlakyWorker.fail_times = 99
+    import app.workers.runner as runner_module
+
+    original = runner_module._WORKERS[WorkerJob.decay]
+    runner_module._WORKERS[WorkerJob.decay] = _FlakyWorker
+    try:
+        report = run_jobs(repo, tenant_id="t1", user_id="u1", jobs=["decay"], now=NOW)
+    finally:
+        runner_module._WORKERS[WorkerJob.decay] = original
+    assert _FlakyWorker.calls == 1
+    # A single attempt is a plain failure, not a dead-letter.
+    assert report.results[0].status == WorkerRunStatus.failed.value
+
+
+# ── 3. graceful shutdown ─────────────────────────────────────────────────────
+def test_shutdown_signal_is_set_by_sigterm() -> None:
+    sig = ShutdownSignal()
+    with sig:
+        assert not sig.is_set()
+        signal.raise_signal(signal.SIGTERM)
+        assert sig.is_set()
+        assert sig.signal_name == "SIGTERM"
+
+
+def test_shutdown_signal_restores_previous_handlers() -> None:
+    original = signal.getsignal(signal.SIGTERM)
+    with ShutdownSignal():
+        pass
+    assert signal.getsignal(signal.SIGTERM) is original
+
+
+def test_shutdown_wait_is_interruptible() -> None:
+    """The old loop slept uninterruptibly, so SIGTERM did nothing until SIGKILL."""
+    sig = ShutdownSignal()
+    started = threading.Event()
+
+    def _stop_soon() -> None:
+        started.wait(timeout=1.0)
+        sig.set()
+
+    threading.Thread(target=_stop_soon, daemon=True).start()
+    started.set()
+    # A 30s wait must return as soon as the flag is set, not 30s later.
+    begin = datetime.now(UTC)
+    sig.wait(30.0)
+    elapsed = datetime.now(UTC) - begin
+    assert sig.is_set()
+    assert elapsed < timedelta(seconds=5), f"wait was not interruptible ({elapsed})"
+
+
+def test_scheduler_stops_when_shutdown_is_requested(repo) -> None:
+    sig = ShutdownSignal()
+    ticks_seen = {"n": 0}
+
+    class _CountingOrchestrator:
+        def run_once(self, scopes, *, now=None, trace_id=None):
+            ticks_seen["n"] += 1
+            sig.set()  # ask to stop after the first tick
+            return []
+
+    scheduler = WorkerScheduler(
+        repo, scopes=[Scope("t1", "u1")], interval_seconds=30,
+        orchestrator=_CountingOrchestrator(), shutdown=sig,
+    )
+    # Unbounded loop: it must terminate because of the flag, not a tick cap.
+    ticks = scheduler.run_forever()
+    assert ticks == 1
+    assert ticks_seen["n"] == 1
+
+
+def test_scheduler_does_not_start_a_tick_after_shutdown(repo) -> None:
+    sig = ShutdownSignal()
+    sig.set()
+    calls = {"n": 0}
+
+    class _Orchestrator:
+        def run_once(self, scopes, *, now=None, trace_id=None):
+            calls["n"] += 1
+            return []
+
+    scheduler = WorkerScheduler(
+        repo, scopes=[Scope("t1", "u1")], interval_seconds=1,
+        orchestrator=_Orchestrator(), shutdown=sig,
+    )
+    assert scheduler.run_forever(max_ticks=5) == 0
+    assert calls["n"] == 0, "a tick was started after shutdown was requested"
+
+
+def test_orchestrator_stops_between_scopes_on_shutdown(repo) -> None:
+    """In-flight scope finishes; remaining scopes are left for the next replica."""
+    seed_memory(repo, tenant_id="t1", user_id="u1")
+    sig = ShutdownSignal()
+
+    orch = WorkerOrchestrator(
+        repo, owner="w1", retry_policy=_fast_policy(1),
+        sleep=lambda _s: None, shutdown=sig,
+    )
+    sig.set()
+    records = orch.run_once([Scope("t1", "u1"), Scope("t2", "u2")], now=NOW)
+    assert records == [], "no scope should start once shutdown was requested"

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -1,23 +1,32 @@
 # MemoryOps AI — Worker image.
-# Build context is the repo root so the worker can include the API package.
+# Build context is the repo root so the worker can install the API distribution.
 #   docker build -f services/worker/Dockerfile .
 FROM python:3.12-slim
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PYTHONPATH=/srv/api
+    PIP_NO_CACHE_DIR=1
 
 WORKDIR /srv/worker
 
 COPY services/api /srv/api
 COPY services/worker /srv/worker
 
-# Worker shares the API's dependency set (+ postgres extras).
+# Install the API as a real distribution rather than dropping it on PYTHONPATH.
+# The worker package then depends on it normally — no sys.path.insert(), no
+# repository-layout coupling, and the same generated-from-pyproject dependency set
+# as the API image (requirements-production.txt = postgres + provider SDKs).
 RUN pip install --no-cache-dir \
-    -r /srv/api/requirements.txt -r /srv/api/requirements-postgres.txt
+      -r /srv/api/requirements.txt -r /srv/api/requirements-production.txt \
+ && pip install --no-cache-dir --no-deps /srv/api \
+ && pip install --no-cache-dir --no-deps /srv/worker
 
 RUN useradd --create-home --uid 10002 worker
 USER worker
 
-CMD ["python", "main.py"]
+# SIGTERM is handled cooperatively (app/workers/shutdown.py): the worker finishes
+# the scope in flight, releases its lease, and exits 0. Exec form (no shell) so the
+# signal reaches the process rather than a wrapping /bin/sh.
+STOPSIGNAL SIGTERM
+
+CMD ["memoryops-worker"]

--- a/services/worker/main.py
+++ b/services/worker/main.py
@@ -1,53 +1,72 @@
-"""Worker entrypoint (v0.8, ADR-012) — production-style scheduled lifecycle runtime.
+"""Worker entrypoint (ADR-012) — production-style scheduled lifecycle runtime.
 
-Drives the real v0.6/v0.7 lifecycle workers (decay, archive, deletion_compaction,
+Drives the real lifecycle workers (decay, archive, retention, deletion_compaction,
 deletion_verification, conflict_scan, reflection) through the orchestrator +
-scheduler: leased so duplicate concurrent runs are prevented, retried with backoff,
-and recorded as run history / dead-letter evidence. Replaces the legacy Phase-5
-``jobs.py`` scaffold on the chat-independent maintenance path.
+scheduler: leased with a renewing heartbeat, retried per job with backoff,
+dead-lettered when a job's retry budget is exhausted, and recorded as run history.
+
+Packaging
+---------
+This module imports ``app.*`` as an ordinary installed dependency. It previously
+mutated ``sys.path`` at import time to point at ``services/api``, which tied the
+worker to the repository layout, made imports order-dependent, and blocked shipping
+it as a wheel. ``memoryops-api`` is now a properly built distribution, so the worker
+just depends on it and starts as::
+
+    memoryops-worker          # console script (pip install -e services/worker)
+    python main.py            # equivalent, from this directory
 
 Configuration (via the API ``Settings``):
   * ``MEMORYOPS_WORKER_INTERVAL_SECONDS`` — seconds between passes (default 60)
   * ``MEMORYOPS_WORKER_SCOPES`` — ``"tenant:user,tenant2:user2"`` scopes to run
   * ``worker_lease_ttl_seconds`` / ``worker_max_attempts`` / backoff knobs
 
-The API package is shared by adding ``services/api`` to ``sys.path`` (the worker
-image copies it alongside; PYTHONPATH=/srv/api in the Dockerfile).
+Shutdown
+--------
+SIGTERM/SIGINT set a cooperative stop flag. The worker finishes the scope it is in,
+releases its lease, and exits 0 — so a deploy no longer hard-kills a mid-write scope
+and leaves it locked for the remainder of the lease TTL.
 """
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-# Reuse the API's repository, config, and workers without packaging the API.
-_API = Path(__file__).resolve().parents[1] / "api"
-if str(_API) not in sys.path:
-    sys.path.insert(0, str(_API))
-
-from app.core.config import get_settings  # noqa: E402
-from app.core.logging import get_logger, setup_logging  # noqa: E402
-from app.db.factory import get_repository  # noqa: E402
-from app.workers.scheduler import WorkerScheduler  # noqa: E402
+from app.core.config import get_settings
+from app.core.logging import get_logger, setup_logging
+from app.db.factory import get_repository
+from app.workers.scheduler import WorkerScheduler
+from app.workers.shutdown import ShutdownSignal
 
 
-def main() -> None:
+def main() -> int:
     settings = get_settings()
     setup_logging(settings.log_level)
     logger = get_logger("memoryops.worker")
-    scheduler = WorkerScheduler(get_repository())
-    logger.info(
-        "worker runtime starting",
-        extra={
-            "event": "worker_start",
-            "status": "ok",
-            "interval_s": settings.worker_interval_seconds,
-            "scopes": len(scheduler.scopes),
-            "storage": settings.storage,
-        },
-    )
-    scheduler.run_forever()
+
+    # Install handlers before the first tick so a SIGTERM during startup is honoured.
+    with ShutdownSignal() as shutdown:
+        scheduler = WorkerScheduler(get_repository(), shutdown=shutdown)
+        logger.info(
+            "worker runtime starting",
+            extra={
+                "event": "worker_start",
+                "status": "ok",
+                "interval_s": settings.worker_interval_seconds,
+                "scopes": len(scheduler.scopes),
+                "storage": settings.storage,
+            },
+        )
+        ticks = scheduler.run_forever()
+        logger.info(
+            "worker runtime stopped",
+            extra={
+                "event": "worker_stop",
+                "status": "ok",
+                "ticks": ticks,
+                "signal": shutdown.signal_name,
+            },
+        )
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/services/worker/pyproject.toml
+++ b/services/worker/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools>=77.0,<83"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "memoryops-worker"
+version = "1.0.0"
+description = "MemoryOps AI — background memory lifecycle worker"
+readme = "README.md"
+requires-python = ">=3.11,<3.14"
+license = "MIT"
+# The worker shares the API's repository, config, and lifecycle workers. It used to
+# get them by inserting ../api into sys.path at import time; now it declares an
+# ordinary dependency on the built distribution, so there is no PYTHONPATH or
+# sys.path.insert() left in a production entrypoint and the two services can never
+# resolve different dependency sets.
+#
+# Installed from the repo root as an editable/local install:
+#   pip install ./services/api ./services/worker
+dependencies = [
+  "memoryops-api==1.0.0",
+]
+
+[project.optional-dependencies]
+# Mirrors the API's `production` extra (postgres + provider SDKs). Kept as a
+# passthrough so the worker image installs exactly what the API image does.
+production = [
+  "memoryops-api[production]==1.0.0",
+]
+
+[project.scripts]
+memoryops-worker = "main:main"
+
+[tool.setuptools]
+py-modules = ["main"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP"]


### PR DESCRIPTION
> **Based on #97** while that is open. After #97 merges: `git fetch origin && git rebase origin/main && git push --force-with-lease`, then retarget this PR to `main`.

## Scope of the lease guarantee — read first

**Lease coordination is cooperative and heartbeat-renewed. It is not database-enforced fencing, and it does not prevent a stalled process from resuming after ownership has transferred.**

This is **not** split-brain-proof. The sequence that remains possible:

1. Worker A holds the lease.
2. Worker A stalls (long GC pause, VM freeze) past expiry.
3. Worker B acquires the lease.
4. Worker A resumes and completes a mutation using stale authority.

The abort flag is only observed *between* jobs. Closing this requires a monotonic fence token validated at the storage write itself — a schema change plus threading the token through every job's mutations. Tracked as follow-up, deliberately not attempted here.

What **is** closed is the previously *guaranteed* failure: a job that simply runs longer than the TTL.

## Three gaps, each silent in production

**1. The lease was acquired but never renewed.** `WorkerLeaseManager.renew()` shipped in v0.8 and nothing called it. The orchestrator acquired once, ran the whole scope, released. Any scope whose jobs outlived `worker_lease_ttl_seconds` (default 300s) lost exclusivity mid-run, and a second replica could acquire the same `(tenant, user)` and mutate it concurrently. Idempotency limits the damage; it does not make concurrent lifecycle mutation correct — decay, retention, and compaction all write.

`app/workers/heartbeat.py` renews on a daemon thread at `ttl/3` and **fails closed** when renewal fails or raises: the scope stops between jobs, remaining jobs are recorded `aborted`, the run is recorded `lease_lost`.

**2. Job failures were never retried.** `run_with_retry` wrapped `run_jobs`, but lifecycle workers catch their own errors and *return* `status=failed` rather than raising — `retry.py` even documented that it only covered orchestration-level exceptions. The wrapper only ever saw clean returns, so a failing job was recorded as failed and then dropped: not retried, not dead-lettered.

Retry is now **per job**, keyed off the returned status. Exhausted budgets become a new terminal `dead_letter` status. `completed_with_findings` is never retried — a finding is a real result, and retrying would multiply audit events and mask it.

**3. No graceful shutdown.** `run_forever` looped on a bare `time.sleep` with no signal handling, so every deploy hard-killed the worker mid-tick and left its lease held for the rest of the TTL. With a 60s interval the process spent nearly all its life unable to react to SIGTERM at all. `app/workers/shutdown.py` makes SIGTERM/SIGINT a cooperative stop flag and the inter-tick wait an interruptible `Event.wait`.

**Packaging.** `services/worker/main.py` inserted `../api` into `sys.path` at import time, tying the worker to the repository layout and blocking a wheel. #97 made `memoryops-api` a real distribution, so the worker now declares an ordinary dependency on it and ships a `memoryops-worker` console script. No `sys.path`/`PYTHONPATH` manipulation remains in a production entrypoint.

## Verification

- 481 passed, 3 skipped; ruff clean. Evals PASS, benchmark PASS. Invariant gate PASS.
- The lease test has teeth: **without** the heartbeat, a second worker demonstrably acquires the same scope once the TTL elapses.
- New `worker` CI job installs both distributions, asserts the entrypoint is import-clean, then boots the console script and SIGTERMs it mid-interval, requiring exit 0 well inside the interval.
- Confirmed locally end to end: SIGTERM at t=4s of a 30s interval → clean stop, exit 0.

## Explicitly still open

Database-enforced fencing tokens, a dead-letter **replay** command, dynamic scope discovery (`MEMORYOPS_WORKER_SCOPES` remains operator-configured), and fair scheduling.