### PR TITLE
fix(governance): prevent status transitions from bypassing deletion controls

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -149,9 +149,42 @@ per-memory `AuditEvent[]`, newest first.
 
 ## PATCH /api/memories/{id}
 Body: `{ tenant_id, user_id, content?, importance?, confidence?, status? }`.
-`status=active` approves a pending memory (or restores an archived one);
-`rejected` rejects; `archived` archives. `404` on a `deleted` memory — deletion is
-terminal. Returns the updated `MemoryRecord`. Emits an audit event.
+Returns the updated `MemoryRecord`. Emits an audit event.
+
+`status` is validated as a **transition**, not just a value — a target is legal only
+from specific current states:
+
+| Current | Requested | Result | Audit action |
+| --- | --- | --- | --- |
+| `pending` | `active` | approve | `memory_approved` |
+| `pending` | `rejected` | reject | `memory_rejected` |
+| `active` | `archived` | archive | `memory_archived` |
+| `archived` | `active` | restore | `memory_restored` |
+| *any* | `deleted` / `pending` / `blocked` | **422** | — |
+| `deleted` | *any* | **404** (deletion is terminal) | — |
+| any other combination | | **409** | — |
+
+`422` means the status is never settable through `PATCH`; `409` means the value is
+settable in general but not from the current state.
+
+**Why this is validated.** `status` previously accepted the whole `Status` enum and
+was assigned directly; the handler's branch chain only named active/rejected/archived,
+so anything else was written verbatim. `status="deleted"` produced a row hidden from
+retrieval (invariant #2) but with `deleted_at = None` — so retention and compaction,
+which key off `deleted_at`, never reclaimed it — with no tombstone, no lineage
+propagation, and only a generic `memory_updated` audit action. **It succeeded even
+under a legal hold**, which `DELETE` correctly refuses with `409`. The row landed in a
+limbo neither the deletion guarantee nor the preservation guarantee covered.
+
+Deletion is exclusive to `DELETE /api/memories/{id}` — the only path performing
+legal-hold verification, `deleted_at` assignment, tombstone creation, lineage
+propagation, deletion audit evidence, and compaction eligibility.
+
+The `status` field is **retained**; this is a behavioural correction for invalid
+transitions, not a field removal, so the `1.x` additive-compatibility promise holds.
+`archived → active` is now audited as `memory_restored` rather than `memory_approved`
+— the old code keyed the action off the target status alone, making a restore
+indistinguishable from an approval.
 
 ## DELETE /api/memories/{id}
 Body: `{ tenant_id, user_id }`. Soft delete: `status=deleted`, `deleted_at=now()`,

--- a/infra/adr/ADR-009-memory-control-plane.md
+++ b/infra/adr/ADR-009-memory-control-plane.md
@@ -86,3 +86,50 @@ browser (read views + action buttons)        ← apps/web (v0.5)
 - Provenance is metadata only — embeddings and raw secrets are never serialized.
 - Demo identity (`tenant_demo`/`user_demo`) still comes from `lib/api.ts`; real
   auth/session wiring remains the deployment's responsibility.
+
+## Amendment: status changes are validated as transitions
+
+The control plane exposed `status` on `PATCH /api/memories/{id}` as a free
+assignment over the whole `Status` enum. The handler's branch chain only named
+`active` / `rejected` / `archived`, so any other value was written verbatim.
+
+`status="deleted"` was the consequential case. It produced a row that satisfied the
+*retrieval* half of the deletion guarantee (invariant #2 excludes `deleted` rows)
+while violating everything the deletion workflow exists to provide:
+
+- `deleted_at` stayed null, so retention and compaction — which key off
+  `deleted_at` — never reclaimed the content;
+- no tombstone was stamped, so tombstone lineage (ADR-018) could not propagate the
+  deletion to derived memories;
+- the audit trail recorded a generic `memory_updated`, not `memory_deleted`;
+- and it succeeded **under a legal hold**, which `DELETE` correctly refuses with
+  `409`. A preservation control was defeated by a route that was not attempting to
+  delete.
+
+The record ended in a limbo neither the deletion guarantee nor the preservation
+guarantee covered: invisible to the user, un-compactable by the system, and still
+reported as held by `/api/retention/memory/{id}`.
+
+**Decision.** The control plane validates a *transition* — `(current, requested)` —
+rather than a value. `app/services/status_transitions.py` is the single source of
+truth; the route consults it before any mutation and additionally guards the
+unsupported set so a widened schema cannot reopen the hole. Deletion is exclusive to
+`DELETE /api/memories/{id}`, the only path performing legal-hold verification,
+`deleted_at` assignment, tombstone creation, lineage propagation, deletion audit
+evidence, and compaction eligibility.
+
+`422` marks a status that `PATCH` never supports (`deleted`, `pending`, `blocked`);
+`409` marks one that is legal in general but not from the current state.
+
+**Compatibility.** The `status` field is retained and every transition the UI
+actually issues (approve, reject, archive, restore) is unchanged, so the `1.x`
+additive promise holds. One audit correction: `archived → active` is now
+`memory_restored` rather than `memory_approved` — the previous code keyed the audit
+action off the target status alone, making a restore indistinguishable from an
+approval in the trail.
+
+**Still open.** This closes the illegal-transition breach only. Governed content
+editing (a `content` PATCH still bypasses the policy broker, secret scanning,
+sensitivity reclassification, and leaves the old embedding attached to new content),
+explicit transition endpoints, and API-level RBAC are follow-up work. The demo
+identity note above is superseded by the authenticated BFF control plane.

--- a/services/api/app/routes/memories.py
+++ b/services/api/app/routes/memories.py
@@ -20,6 +20,13 @@ from ..schemas.memory import (
     MemoryRecord,
     Status,
 )
+from ..services.status_transitions import (
+    TRANSITION_AUDIT,
+    UNSUPPORTED_PATCH_STATUSES,
+    InvalidTransition,
+    UnsupportedStatus,
+    validate_transition,
+)
 
 router = APIRouter(prefix="/api/memories", tags=["memories"])
 
@@ -233,6 +240,27 @@ def patch_memory(memory_id: str, patch: MemoryPatch, request: Request) -> Memory
     if not m or m.status == Status.deleted:
         raise HTTPException(status_code=404, detail="memory not found")
 
+    # ── status transition validation (before any mutation) ────────────────────
+    # Route-level defence in depth: even if the schema were widened again, an
+    # unsupported target is refused here. `status="deleted"` previously fell
+    # through the handler's elif chain and was assigned verbatim, producing a row
+    # that was hidden from retrieval but had no `deleted_at`, no tombstone, no
+    # lineage, and a generic `memory_updated` audit action — and it succeeded even
+    # under a legal hold that the real DELETE route refuses with 409.
+    transition: str | None = None
+    if patch.status is not None:
+        if patch.status in UNSUPPORTED_PATCH_STATUSES:
+            raise HTTPException(
+                status_code=422,
+                detail="status must be changed through its dedicated governance workflow",
+            )
+        try:
+            transition = validate_transition(m.status, patch.status)
+        except UnsupportedStatus as exc:  # pragma: no cover - guarded above
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        except InvalidTransition as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
     # Mutation + audit are one atomic unit of work (P0): a crash mid-way can no
     # longer persist the edit without its audit evidence, or vice versa. The
     # transaction must open *before* the in-place field mutations — the in-memory
@@ -248,14 +276,13 @@ def patch_memory(memory_id: str, patch: MemoryPatch, request: Request) -> Memory
             m.importance = patch.importance
         if patch.confidence is not None:
             m.confidence = patch.confidence
-        if patch.status is not None:
+        if patch.status is not None and transition is not None:
+            # `transition` was resolved from (current, requested) above, so the audit
+            # action reflects what actually happened. The old elif chain keyed off the
+            # target alone, so pending→active and archived→active were both recorded
+            # as "memory_approved" — a restore was indistinguishable from an approval.
             m.status = patch.status
-            if patch.status == Status.active:
-                action, reason = "memory_approved", "pending memory approved"
-            elif patch.status == Status.rejected:
-                action, reason = "memory_rejected", "pending memory rejected"
-            elif patch.status == Status.archived:
-                action, reason = "memory_archived", "memory archived"
+            action, reason = TRANSITION_AUDIT[transition]
 
         repo.update_memory(m)
         emit_loop_event_sync(

--- a/services/api/app/services/status_transitions.py
+++ b/services/api/app/services/status_transitions.py
@@ -1,0 +1,92 @@
+"""Legal status transitions for `PATCH /api/memories/{id}`.
+
+Why this exists
+---------------
+`MemoryPatch.status` accepted the **entire** `Status` enum and the handler assigned
+it directly, with an `elif` chain that only named `active` / `rejected` / `archived`.
+Any other value fell through and was written verbatim. `status="deleted"` therefore
+produced a row that was:
+
+  * hidden from retrieval (invariant #2 excludes `deleted`),
+  * but with ``deleted_at = None``, so retention and compaction — which key off
+    ``deleted_at`` — never reclaimed it,
+  * with no tombstone and no lineage propagation,
+  * audited only as a generic ``memory_updated``,
+  * **and it succeeded while the memory was under legal hold**, which the real
+    ``DELETE`` route correctly refuses with 409.
+
+That is worse than an ordinary bypass: the record ends up in a limbo that neither
+the deletion guarantee nor the preservation guarantee covers — invisible to the
+user, un-compactable by the system, and still reported as held.
+
+The fix is to validate the **transition**, not just the requested value: a target
+status is legal only from specific current states.
+
+Deletion stays exclusive to ``DELETE /api/memories/{memory_id}``, which is the only
+path that performs legal-hold verification, ``deleted_at`` assignment, tombstone
+creation, lineage propagation, deletion audit evidence, and compaction eligibility.
+
+Compatibility
+-------------
+The `status` field is **kept** — this is a behavioural correction for invalid
+transitions, not a removal. Every transition real clients use (approve, reject,
+archive, restore) still works unchanged, so the `1.x` additive-compatibility promise
+holds: no public request or response field is removed.
+"""
+
+from __future__ import annotations
+
+from ..schemas.memory import Status
+
+# Statuses `PATCH` never supports, whatever the current state.
+#   deleted — must go through the deletion workflow (legal hold, tombstone, lineage)
+#   pending — assigned by the policy broker at write time, never by a client
+#   blocked — a policy-broker verdict, never a client-assigned state
+UNSUPPORTED_PATCH_STATUSES: frozenset[Status] = frozenset(
+    {Status.deleted, Status.pending, Status.blocked}
+)
+
+# (current, requested) -> the governance action it represents.
+ALLOWED_TRANSITIONS: dict[tuple[Status, Status], str] = {
+    (Status.pending, Status.active): "approve",
+    (Status.pending, Status.rejected): "reject",
+    (Status.active, Status.archived): "archive",
+    (Status.archived, Status.active): "restore",
+}
+
+# Human-readable action -> (audit action, audit reason).
+TRANSITION_AUDIT: dict[str, tuple[str, str]] = {
+    "approve": ("memory_approved", "pending memory approved"),
+    "reject": ("memory_rejected", "pending memory rejected"),
+    "archive": ("memory_archived", "memory archived"),
+    "restore": ("memory_restored", "archived memory restored"),
+}
+
+
+class UnsupportedStatus(ValueError):
+    """The requested status is never settable via PATCH (→ 422)."""
+
+
+class InvalidTransition(ValueError):
+    """The requested status is settable, but not from the current state (→ 409)."""
+
+
+def validate_transition(current: Status, requested: Status) -> str:
+    """Return the governance action for a legal transition, else raise.
+
+    Raises:
+        UnsupportedStatus: the target is never valid on this route (422).
+        InvalidTransition: the target is valid in general, but not from
+            ``current`` (409).
+    """
+    if requested in UNSUPPORTED_PATCH_STATUSES:
+        raise UnsupportedStatus(
+            f"status '{requested.value}' must be changed through its dedicated "
+            "governance workflow, not PATCH"
+        )
+    action = ALLOWED_TRANSITIONS.get((current, requested))
+    if action is None:
+        raise InvalidTransition(
+            f"cannot change status from '{current.value}' to '{requested.value}'"
+        )
+    return action

--- a/services/api/tests/test_deletion.py
+++ b/services/api/tests/test_deletion.py
@@ -253,3 +253,76 @@ def test_loop_traces_do_not_resurrect_deleted_memory(gateway, repo):
     # ... but the deletion guarantee continues to hold.
     assert mem.id not in {m.id for m in repo.retrieve_active("t1", "u1")}
     assert mem.id not in {m.id for m in repo.list_memories("t1", "u1")}
+
+
+def test_patch_cannot_produce_a_deleted_row_outside_the_deletion_workflow(api_client):
+    """The deletion guarantee has exactly one entry point.
+
+    `PATCH {"status": "deleted"}` used to write `status=deleted` directly, producing
+    a row that satisfied the *retrieval* half of invariant #2 (hidden) while
+    violating everything the deletion workflow exists to provide: `deleted_at` was
+    null, so retention and compaction never reclaimed it; no tombstone was stamped,
+    so lineage could not propagate it to derived memories; and the audit trail
+    recorded a generic `memory_updated`. Full coverage in
+    tests/test_status_transition_bypass.py.
+    """
+    from app.db.entities import StoredMemory
+    from app.schemas.memory import MemoryType, Sensitivity, Source, Status
+
+    client, repo = api_client
+    mem = repo.create_memory(
+        StoredMemory(
+            tenant_id="t1",
+            user_id="u1",
+            memory_type=MemoryType.preference,
+            content="dark mode",
+            importance=7,
+            confidence=0.9,
+            sensitivity=Sensitivity.low,
+            status=Status.active,
+            source=Source(kind="chat", excerpt="dark mode"),
+        )
+    )
+
+    r = client.patch(
+        f"/api/memories/{mem.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "status": "deleted"},
+    )
+    assert r.status_code == 422
+
+    after = repo.get_memory("t1", "u1", mem.id)
+    assert after.status is Status.active
+    assert after.deleted_at is None
+    # Still retrievable: the row was never deleted, so it must not have been hidden.
+    assert mem.id in {m.id for m in repo.retrieve_active("t1", "u1")}
+
+
+def test_the_deletion_workflow_still_satisfies_the_invariant(api_client):
+    """Closing the PATCH bypass must not weaken real deletion."""
+    from app.db.entities import StoredMemory
+    from app.schemas.memory import MemoryType, Sensitivity, Source, Status
+
+    client, repo = api_client
+    mem = repo.create_memory(
+        StoredMemory(
+            tenant_id="t1",
+            user_id="u1",
+            memory_type=MemoryType.preference,
+            content="dark mode",
+            importance=7,
+            confidence=0.9,
+            sensitivity=Sensitivity.low,
+            status=Status.active,
+            source=Source(kind="chat", excerpt="dark mode"),
+        )
+    )
+
+    r = client.request(
+        "DELETE", f"/api/memories/{mem.id}", json={"tenant_id": "t1", "user_id": "u1"}
+    )
+    assert r.status_code == 200
+
+    after = repo.get_memory("t1", "u1", mem.id)
+    assert after.status is Status.deleted
+    assert after.deleted_at is not None, "the workflow stamps deleted_at; PATCH never did"
+    assert mem.id not in {m.id for m in repo.retrieve_active("t1", "u1")}

--- a/services/api/tests/test_governance_api.py
+++ b/services/api/tests/test_governance_api.py
@@ -289,16 +289,26 @@ def test_provenance_404_for_unknown(api_client):
 def test_memory_audit_timeline_is_scoped_to_that_memory(api_client):
     client, repo = api_client
     a = _seed(repo, content="memory A")
-    b = _seed(repo, content="memory B")
+    # B is seeded `pending` so its rejection is a *legal* transition and actually
+    # writes a `memory_rejected` event. Seeded active, the reject is refused (409)
+    # and this test would pass vacuously — proving isolation of an event that was
+    # never written.
+    b = _seed(repo, status=Status.pending, content="memory B")
 
-    client.patch(
+    archived = client.patch(
         f"/api/memories/{a.id}",
         json={"tenant_id": "t1", "user_id": "u1", "status": "archived"},
     )
-    client.patch(
+    assert archived.status_code == 200
+    rejected = client.patch(
         f"/api/memories/{b.id}",
         json={"tenant_id": "t1", "user_id": "u1", "status": "rejected"},
     )
+    assert rejected.status_code == 200
+
+    # The event exists on B, so its absence from A's timeline is meaningful.
+    b_actions = {e["action"] for e in client.get(f"/api/memories/{b.id}/audit{_q()}").json()}
+    assert "memory_rejected" in b_actions
 
     r = client.get(f"/api/memories/{a.id}/audit{_q()}")
     assert r.status_code == 200

--- a/services/api/tests/test_status_transition_bypass.py
+++ b/services/api/tests/test_status_transition_bypass.py
@@ -1,0 +1,238 @@
+"""`PATCH /api/memories/{id}` must not bypass the deletion workflow.
+
+The exploit
+-----------
+`MemoryPatch.status` accepted the entire `Status` enum and the handler assigned it
+directly; its `elif` chain only named active/rejected/archived, so anything else
+fell through and was written verbatim. `status="deleted"` produced a row that was:
+
+  * hidden from retrieval (invariant #2 excludes `deleted`),
+  * but with `deleted_at = None`, so retention and compaction — which key off
+    `deleted_at` — never reclaimed it,
+  * with no tombstone and no lineage propagation,
+  * audited only as a generic `memory_updated`,
+  * **and it succeeded under a legal hold** that the real `DELETE` route refuses
+    with 409.
+
+The record landed in a limbo neither guarantee covers: invisible to the user,
+un-compactable by the system, and still reported as held. A *preservation* control
+defeated by a route that was not even trying to delete.
+
+Deletion stays exclusive to `DELETE /api/memories/{memory_id}` — the only path that
+performs legal-hold verification, `deleted_at` assignment, tombstone creation,
+lineage propagation, deletion audit evidence, and compaction eligibility.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.db import lineage
+from app.db.entities import StoredMemory
+from app.schemas.memory import MemoryType, Sensitivity, Source, Status
+
+_Q = "?tenant_id=t1&user_id=u1"
+
+
+def _seed(repo, *, status: Status = Status.active, content: str = "dark mode") -> StoredMemory:
+    return repo.create_memory(
+        StoredMemory(
+            tenant_id="t1",
+            user_id="u1",
+            memory_type=MemoryType.preference,
+            content=content,
+            importance=7,
+            confidence=0.9,
+            sensitivity=Sensitivity.low,
+            status=status,
+            source=Source(kind="chat", excerpt=content),
+        )
+    )
+
+
+def _patch(client, memory_id: str, **fields):
+    return client.patch(
+        f"/api/memories/{memory_id}",
+        json={"tenant_id": "t1", "user_id": "u1", **fields},
+    )
+
+
+# ── the exploit, as a permanent regression test ──────────────────────────────
+def test_legal_hold_cannot_be_bypassed_by_patching_status_to_deleted(api_client):
+    client, repo = api_client
+
+    # 1. an active memory
+    m = _seed(repo, content="my account number is 12345")
+    assert repo.get_memory("t1", "u1", m.id).status is Status.active
+
+    # 2. under legal hold
+    hold = client.post(
+        "/api/retention/legal-hold",
+        json={
+            "tenant_id": "t1",
+            "user_id": "u1",
+            "memory_id": m.id,
+            "on": True,
+            "reason": "litigation",
+        },
+    )
+    assert hold.status_code == 200
+
+    # 3. the real deletion route correctly refuses
+    deleted = client.request(
+        "DELETE", f"/api/memories/{m.id}", json={"tenant_id": "t1", "user_id": "u1"}
+    )
+    assert deleted.status_code == 409, "legal hold must block the deletion workflow"
+
+    # 4. and PATCH must not be a way around it
+    bypass = _patch(client, m.id, status="deleted")
+    assert bypass.status_code == 422, (
+        "PATCH status=deleted must be refused; it previously succeeded with 200 and "
+        "produced a row hidden from retrieval but with no deleted_at, no tombstone, "
+        "and no deletion audit — while still under legal hold"
+    )
+
+    # 5. the memory is untouched and still active
+    after = repo.get_memory("t1", "u1", m.id)
+    assert after.status is Status.active
+
+    # 6. no deletion timestamp was stamped
+    assert after.deleted_at is None
+
+    # 7. no tombstone was created
+    #    `is_tombstoned` is true for an explicit marker OR a soft-deleted row, so
+    #    this covers both the marker and the status the bypass used to set.
+    assert not lineage.is_tombstoned(after)
+
+    # 8. governance still reports the hold
+    state = client.get(f"/api/retention/memory/{m.id}{_Q}").json()
+    assert state["governance"]["legal_hold"] is True
+    assert state["retention_decision"]["eligible_for_deletion"] is False
+
+    # 9. no deletion audit event exists
+    actions = {e["action"] for e in client.get(f"/api/memories/{m.id}/audit{_Q}").json()}
+    assert "memory_deleted" not in actions
+
+    # 10. and no generic update event falsely stands in for a deletion
+    assert "memory_updated" not in actions, (
+        "the refused transition must not be audited as an edit"
+    )
+
+
+def test_patch_status_deleted_is_refused_even_without_a_legal_hold(api_client):
+    """The bypass is invalid on its own terms, not only when a hold exists."""
+    client, repo = api_client
+    m = _seed(repo)
+
+    assert _patch(client, m.id, status="deleted").status_code == 422
+    after = repo.get_memory("t1", "u1", m.id)
+    assert after.status is Status.active
+    assert after.deleted_at is None
+
+
+def test_the_deletion_route_still_works_without_a_hold(api_client):
+    """Closing the bypass must not break legitimate deletion."""
+    client, repo = api_client
+    m = _seed(repo)
+
+    r = client.request(
+        "DELETE", f"/api/memories/{m.id}", json={"tenant_id": "t1", "user_id": "u1"}
+    )
+    assert r.status_code == 200
+    after = repo.get_memory("t1", "u1", m.id)
+    assert after.status is Status.deleted
+    assert after.deleted_at is not None, "the real workflow stamps deleted_at"
+
+
+# ── unsupported target statuses (422) ────────────────────────────────────────
+@pytest.mark.parametrize("target", ["deleted", "pending", "blocked"])
+def test_unsupported_statuses_are_rejected_with_422(api_client, target):
+    client, repo = api_client
+    m = _seed(repo)
+    r = _patch(client, m.id, status=target)
+    assert r.status_code == 422, f"PATCH status={target} must be unsupported"
+    assert repo.get_memory("t1", "u1", m.id).status is Status.active
+
+
+# ── invalid current-state transitions (409) ──────────────────────────────────
+@pytest.mark.parametrize(
+    ("current", "target"),
+    [
+        (Status.active, "rejected"),  # rejection is only for pending memory
+        (Status.active, "active"),  # no-op is not a governance transition
+        (Status.pending, "archived"),  # must be approved before it can be archived
+        (Status.archived, "rejected"),
+        (Status.rejected, "active"),
+        (Status.rejected, "archived"),
+    ],
+)
+def test_invalid_transitions_are_rejected_with_409(api_client, current, target):
+    client, repo = api_client
+    m = _seed(repo, status=current)
+    r = _patch(client, m.id, status=target)
+    assert r.status_code == 409, f"{current.value} -> {target} must be refused"
+    assert repo.get_memory("t1", "u1", m.id).status is current
+
+
+def test_deleted_memory_cannot_be_patched_to_any_status(api_client):
+    """Deleted is terminal — the route 404s before any transition check."""
+    client, repo = api_client
+    m = _seed(repo, status=Status.deleted)
+    for target in ("active", "archived", "rejected"):
+        assert _patch(client, m.id, status=target).status_code == 404
+
+
+# ── the four legal transitions still work ────────────────────────────────────
+@pytest.mark.parametrize(
+    ("current", "target", "audit_action"),
+    [
+        (Status.pending, "active", "memory_approved"),
+        (Status.pending, "rejected", "memory_rejected"),
+        (Status.active, "archived", "memory_archived"),
+        (Status.archived, "active", "memory_restored"),
+    ],
+)
+def test_legal_transitions_succeed_and_audit_the_right_action(
+    api_client, current, target, audit_action
+):
+    client, repo = api_client
+    m = _seed(repo, status=current)
+
+    r = _patch(client, m.id, status=target)
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == target
+    assert repo.get_memory("t1", "u1", m.id).status.value == target
+
+    actions = {e["action"] for e in client.get(f"/api/memories/{m.id}/audit{_Q}").json()}
+    assert audit_action in actions
+
+
+def test_restore_is_audited_distinctly_from_approve(api_client):
+    """The old handler keyed the audit action off the *target* alone, so
+    pending→active and archived→active were both 'memory_approved' — a restore was
+    indistinguishable from an approval in the audit trail."""
+    client, repo = api_client
+    restored = _seed(repo, status=Status.archived, content="was archived")
+
+    assert _patch(client, restored.id, status="active").status_code == 200
+    actions = {e["action"] for e in client.get(f"/api/memories/{restored.id}/audit{_Q}").json()}
+    assert "memory_restored" in actions
+    assert "memory_approved" not in actions
+
+
+# ── compatibility: the field and the content path are unchanged ──────────────
+def test_status_field_is_still_accepted_in_the_request_shape(api_client):
+    """This is a behavioural correction for invalid transitions, not a field removal
+    — the 1.x additive-compatibility promise holds."""
+    client, repo = api_client
+    m = _seed(repo, status=Status.pending)
+    assert _patch(client, m.id, status="active").status_code == 200
+
+
+def test_content_only_patch_is_unaffected(api_client):
+    client, repo = api_client
+    m = _seed(repo)
+    r = _patch(client, m.id, content="prefers light mode")
+    assert r.status_code == 200
+    assert r.json()["content"] == "prefers light mode"
+    assert repo.get_memory("t1", "u1", m.id).status is Status.active

--- a/services/api/tests/test_status_transition_matrix.py
+++ b/services/api/tests/test_status_transition_matrix.py
@@ -1,0 +1,93 @@
+"""The transition matrix itself, independent of HTTP.
+
+Route-level behaviour is covered in `test_status_transition_bypass.py`; this pins
+the policy so a future edit to the table is a deliberate, visible change.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from app.schemas.memory import Status
+from app.services.status_transitions import (
+    ALLOWED_TRANSITIONS,
+    TRANSITION_AUDIT,
+    UNSUPPORTED_PATCH_STATUSES,
+    InvalidTransition,
+    UnsupportedStatus,
+    validate_transition,
+)
+
+
+def test_exactly_four_transitions_are_allowed():
+    assert set(ALLOWED_TRANSITIONS) == {
+        (Status.pending, Status.active),
+        (Status.pending, Status.rejected),
+        (Status.active, Status.archived),
+        (Status.archived, Status.active),
+    }
+
+
+@pytest.mark.parametrize(
+    ("current", "requested", "action"),
+    [
+        (Status.pending, Status.active, "approve"),
+        (Status.pending, Status.rejected, "reject"),
+        (Status.active, Status.archived, "archive"),
+        (Status.archived, Status.active, "restore"),
+    ],
+)
+def test_allowed_transitions_return_their_action(current, requested, action):
+    assert validate_transition(current, requested) == action
+
+
+@pytest.mark.parametrize("target", sorted(UNSUPPORTED_PATCH_STATUSES, key=lambda s: s.value))
+@pytest.mark.parametrize("current", list(Status))
+def test_unsupported_targets_raise_regardless_of_current_state(current, target):
+    """deleted/pending/blocked are never settable via PATCH, from any state.
+
+    `deleted` is the one that mattered: it bypassed legal hold, `deleted_at`,
+    tombstones, lineage, deletion audit, and compaction eligibility.
+    """
+    with pytest.raises(UnsupportedStatus):
+        validate_transition(current, target)
+
+
+def test_unsupported_set_is_exactly_the_three_documented_statuses():
+    assert UNSUPPORTED_PATCH_STATUSES == frozenset(
+        {Status.deleted, Status.pending, Status.blocked}
+    )
+
+
+def test_every_other_combination_is_an_invalid_transition():
+    """Fail closed: anything not explicitly allowed is refused, including no-ops."""
+    for current, requested in itertools.product(Status, Status):
+        if requested in UNSUPPORTED_PATCH_STATUSES:
+            continue  # covered above, raises UnsupportedStatus
+        if (current, requested) in ALLOWED_TRANSITIONS:
+            continue
+        with pytest.raises(InvalidTransition):
+            validate_transition(current, requested)
+
+
+def test_no_transition_out_of_deleted_is_allowed():
+    """Deleted is terminal in the matrix as well as at the route (which 404s first)."""
+    for requested in Status:
+        with pytest.raises((UnsupportedStatus, InvalidTransition)):
+            validate_transition(Status.deleted, requested)
+
+
+def test_every_allowed_transition_has_a_distinct_audit_action():
+    actions = [TRANSITION_AUDIT[a][0] for a in ALLOWED_TRANSITIONS.values()]
+    assert len(actions) == len(set(actions)), "each transition needs its own audit action"
+    # Restore must not be recorded as an approval — the old handler keyed the audit
+    # action off the target status alone, so archived→active and pending→active
+    # were indistinguishable in the trail.
+    assert TRANSITION_AUDIT["restore"][0] == "memory_restored"
+    assert TRANSITION_AUDIT["approve"][0] == "memory_approved"
+
+
+def test_audit_table_covers_every_allowed_action():
+    assert set(TRANSITION_AUDIT) >= set(ALLOWED_TRANSITIONS.values())


### PR DESCRIPTION
Security hotfix. Based directly on `main` and independent of #97–#100 — review and merge ahead of them.

## The breach

`MemoryPatch.status` accepted the entire `Status` enum and the handler assigned it directly. Its branch chain only named active/rejected/archived, so any other value was written verbatim.

Reproduced against the running API:

```
POST /api/retention/legal-hold {on: true}      → 200
DELETE /api/memories/{id}                      → 409   ← correctly blocked
PATCH  /api/memories/{id} {"status":"deleted"} → 200   ← succeeded
   status: deleted     deleted_at: None
   governance still reports: legal_hold=true, eligible_for_deletion=false
```

The row satisfied the *retrieval* half of invariant #2 (hidden) while violating everything the deletion workflow exists to provide:

- `deleted_at` stayed null, so retention and compaction — which key off `deleted_at` — never reclaimed the content;
- no tombstone was stamped, so tombstone lineage (ADR-018) could not propagate to derived memories;
- audited as a generic `memory_updated`, not `memory_deleted`;
- **and it succeeded under a legal hold** that `DELETE` refuses with 409.

Worse than an ordinary bypass: the record landed in a limbo neither the deletion guarantee nor the preservation guarantee covers — invisible to the user, un-compactable by the system, still reported as held.

## The fix

Validate the **transition**, not the value. `app/services/status_transitions.py` is the single source of truth; the route consults it before any mutation, plus a route-level guard on the unsupported set so a widened schema cannot reopen the hole.

| Current | Requested | Result |
| --- | --- | --- |
| `pending` | `active` | approve → `memory_approved` |
| `pending` | `rejected` | reject → `memory_rejected` |
| `active` | `archived` | archive → `memory_archived` |
| `archived` | `active` | restore → `memory_restored` |
| *any* | `deleted` / `pending` / `blocked` | **422** |
| `deleted` | *any* | **404** (terminal, unchanged) |
| any other combination | | **409** |

`422` = never settable via PATCH. `409` = settable in general, not from this state.

Deletion stays exclusive to `DELETE /api/memories/{id}` — the only path performing legal-hold verification, `deleted_at` assignment, tombstone creation, lineage propagation, deletion audit evidence, and compaction eligibility.

## Compatibility

**No public request or response field is removed.** `status` is retained; this is a behavioural correction for invalid transitions. Every transition real clients issue — including the web UI's four actions (approve/reject/archive/restore) — works unchanged.

One audit correction: `archived → active` is now `memory_restored` rather than `memory_approved`. The old code keyed the audit action off the target status alone, so a restore was indistinguishable from an approval in the trail.

## Tests

- **`test_status_transition_bypass.py`** — the exploit as a permanent regression test, all ten assertions: legal hold on → DELETE 409 → PATCH `status=deleted` refused → memory still active → `deleted_at` still null → no tombstone → `legal_hold` still true → no `memory_deleted` event → no generic `memory_updated` falsely standing in for a deletion. **Verified to FAIL** when `deleted` is re-added as an allowed transition.
- **`test_status_transition_matrix.py`** — exhaustive over `Status × Status`.
- **`test_deletion.py`** — the deletion guarantee now has exactly one entry point; the real workflow still stamps `deleted_at` and hides the row.
- **`test_governance_api.py`** — the audit-timeline test seeded memory B `active` and rejected it. That transition is now refused, so the test would have passed **vacuously**, asserting the isolation of an event that was never written. B is now seeded `pending`, and the test asserts the event exists before asserting its absence from A's timeline.

## Acceptance gate

- 485 passed, 3 skipped
- ruff clean on `app`
- Evals PASS
- Governance benchmark PASS
- PR invariant evidence gate PASS (4 armed rules)
- Existing approve/reject/archive/restore tests green
- No public field removed

## Deliberately out of scope

Governed content editing, embedding regeneration, explicit transition endpoints, API RBAC, sensitivity expansion, SDK and web migration — all belong to the governed-update PR that follows.

Worth flagging for that PR: a `content` PATCH still bypasses the policy broker, secret scanning, and sensitivity reclassification, **and leaves the old embedding attached to the new content**. This PR does not touch that path.