### PR TITLE
fix(governance): classify credentials and sensitive personal data

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -420,6 +420,67 @@ Only `sensitivity_categories`, `sensitivity_rule_ids`, `sensitivity_finding_coun
 the final sensitivity and disposition, and the policy version. Never the matched
 password, diagnosis, salary, address, or regex excerpt.
 
+### Policy change: government identifiers
+
+`policy_version = content-update-v1`, classifier rules as of this change.
+
+Government identifiers (SSN, passport, driving licence) moved from
+**approval-gated** to **non-storable (BLOCK)**. Previously `my ssn is …` matched the
+structural SSN pattern, scored `medium`, and was stored `pending` awaiting approval;
+it is now refused outright on both the creation and edit paths. Operators who relied
+on approving such records will see them rejected instead of queued.
+
+### Classification is clause-scoped
+
+Framing guards and memory-control detection apply per clause, not per message.
+Whole-message checks let one clause exempt another:
+
+```
+"I am reading research about HIV. My HIV status is positive."      -> was: no findings
+"What is the average software engineer salary? My salary is $250,000."  -> was: no findings
+"Do not remember my password, but remember that I prefer dark mode."    -> was: stored nothing
+```
+
+The educational clause now exempts only itself, and only the memory-control clause
+is stripped before extraction — the unrelated preference survives.
+
+`forget my X` is distinguished from `do not remember my X`: the first is a request
+to remove *existing* memory, the second only prevents new persistence. Both suppress
+a new candidate. Routing the first into the governed forget workflow (legal hold,
+`deleted_at`, tombstone, lineage, deletion audit) is follow-up work and deliberately
+not done here — deleting on a chat phrase would be a destructive action taken
+outside the deletion path's guarantees.
+
+### Rows stored before the classifier existed
+
+Classification runs at write time, so a row already stored `low`/`active` keeps its
+label — the protection would otherwise apply only to content entering after deploy.
+A pre-existing credential row was verified to still reach a `public`-audience
+response with its full source excerpt.
+
+The read path therefore combines the stored label with a current classification and
+uses whichever is **higher** (`app/services/effective_sensitivity.py`). It only ever
+raises: an operator's explicit `high` is never lowered because the rules happen not
+to match.
+
+This is deliberately **not** a write. Reads must not mutate rows — that would turn
+every query into a write, produce audit events with no actor, and race with
+concurrent edits. Persisting the corrected label with audit evidence belongs to a
+reclassification worker.
+
+A memory withheld for audience clearance now returns **no content preview and no
+source excerpt** in the trace; echoing them would disclose exactly what the gate
+withheld.
+
+### Memory-control drops are distinguishable
+
+A memory-control instruction is dropped with `reason_code=memory_control_instruction`,
+distinct from a genuine `low_utility` drop. "Not a memory at all" and "a valid memory
+of low utility" are different outcomes, and conflating them would skew utility
+metrics and error analysis. A dedicated decision value
+(`IGNORE_MEMORY_CONTROL` / `DROP_NOT_MEMORY`) is the right long-term shape and is
+tracked separately; the reason code keeps the vocabulary additive meanwhile.
+
 ### Limits, stated plainly
 
 Pattern rules miss paraphrase, other languages, obfuscation, and unusual phrasing.

--- a/docs/security.md
+++ b/docs/security.md
@@ -332,3 +332,97 @@ turned governance off. Dev is unchanged, so the paper study still runs.
 **This is the guard, not the cure.** The stronger fix is architectural: ship the
 ablation wiring in a separate `memoryops-research` package or application factory so
 a production binary cannot express these states at all. Tracked separately.
+## Sensitivity classification
+
+`app/core/sensitivity.py` performs **deterministic semantic-pattern and structural
+sensitivity classification**. It is not medical, financial, or credential
+*understanding*: there is no ontology, no model, and no inference beyond the rules
+written in that module.
+
+### What it replaced
+
+Classification matched only *structural* patterns — SSN and card digit shapes,
+API-key formats. Semantic disclosures scored `low` and were stored `active`:
+
+| Content | Before | After |
+| --- | --- | --- |
+| `my password is hunter2` | low / active | **blocked, not stored** |
+| `my HIV status is positive` | low / active | high / pending approval |
+| `I take sertraline for depression` | low / active | high / pending approval |
+| `my salary is $250,000` | low / active | high / pending approval |
+
+Every downstream control keys off sensitivity — approval gating, the recall gate's
+audience clearance, the admission gate — so for exactly the categories those
+controls exist to protect, they were inert. A plaintext password was retrievable
+into a `public`-audience response.
+
+### Three separate responsibilities
+
+1. **Detection** — rules emit `SensitivityFinding(category, rule_id, sensitivity,
+   recommended_disposition, confidence)`. Content-free: a finding names *what*
+   matched, never the value.
+2. **Aggregation** — `SensitivityAssessment` applies deterministic precedence:
+   `BLOCK > PENDING_APPROVAL > SAVE`, `high > medium > low`.
+3. **Policy** — the broker decides, applying tenant settings, approval
+   configuration, the governance profile, consent, and temporary-chat behaviour on
+   top. The classifier recommends; it never stores or refuses. This keeps the
+   scanner from becoming a second policy broker.
+
+### Category policy
+
+| Category | Recommended |
+| --- | --- |
+| Password / passcode / PIN / security answer | BLOCK |
+| Recovery code, backup code, seed phrase | BLOCK |
+| API key, token, private key (structural) | BLOCK |
+| Payment card / bank account / routing number | BLOCK |
+| Government identifier (SSN, passport, licence) | BLOCK |
+| Medical: diagnosis, condition, status | high + approval |
+| Mental health: condition, psychiatric medication | high + approval |
+| Financial condition: salary, debt, balance | high + approval |
+| Precise private location: home address | high + approval |
+| Biometric: fingerprint, face template, voiceprint | high + approval |
+| Ordinary preference | low + save |
+
+### A keyword is not a disclosure
+
+Rules require first-person ownership **and** a disclosure verb **and** a value or
+condition, plus a framing guard for questions and educational text. These must not
+classify as sensitive, and are permanent test cases:
+
+```
+I forgot my password                          I use a password manager
+How should password hashing work?             Sertraline is a commonly prescribed medication
+I am reading research about HIV               What is the average software engineer salary?
+This document explains bank routing numbers
+```
+
+### Memory-control instructions store nothing
+
+`do not remember my password`, `forget my salary`, `I don't want you to remember my
+address` are instructions *about* memory, not facts. The correct outcome is **no
+persistent memory** — not a stored high-sensitivity record (which would be the same
+disclosure by another route) and not merely a `BLOCK` verdict.
+
+Two independent guards: the extractor emits no candidate, and the policy broker
+refuses one anyway, so a malformed or LLM-provided extractor cannot store it.
+
+### Both write paths agree
+
+Every positive case is tested through creation **and** through an existing-memory
+content edit. The same content must reach the same classification and disposition
+regardless of how it enters the system — the equivalence the edit path used to
+break.
+
+### Audit evidence
+
+Only `sensitivity_categories`, `sensitivity_rule_ids`, `sensitivity_finding_count`,
+the final sensitivity and disposition, and the policy version. Never the matched
+password, diagnosis, salary, address, or regex excerpt.
+
+### Limits, stated plainly
+
+Pattern rules miss paraphrase, other languages, obfuscation, and unusual phrasing.
+**A rule that fires is high-confidence; silence is not evidence of safety.**
+Broadening recall belongs with evaluation evidence, not with more unreviewed
+regexes. This is not comprehensive medical, financial, or credential understanding.

--- a/services/api/app/core/redaction.py
+++ b/services/api/app/core/redaction.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 
+from ..schemas.memory import Sensitivity
+from .sensitivity import BLOCK, SensitivityAssessment, classify
+
 # ── Secret patterns ──────────────────────────────────────────────────────────
 # Each entry: (label, compiled regex). Order is not significant.
 _SECRET_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
@@ -52,14 +55,33 @@ class ScanResult:
     secret_labels: list[str] = field(default_factory=list)
     pii_labels: list[str] = field(default_factory=list)
     injection: bool = False
+    #: Semantic-pattern classification (app/core/sensitivity.py). Structural
+    #: patterns above catch *shapes* — key formats, SSN and card digits. They said
+    #: nothing about "my password is hunter2" or "my HIV status is positive", which
+    #: scored `low` and were stored active, leaving every sensitivity-keyed control
+    #: inert for exactly the categories they exist to protect.
+    assessment: SensitivityAssessment = field(default_factory=SensitivityAssessment)
 
     @property
     def sensitivity(self) -> str:
         if self.has_secret:
             return "high"
+        # A semantic disclosure outranks a structural PII hit.
+        if self.assessment.sensitivity is Sensitivity.high:
+            return "high"
         if self.pii_labels:
             return "medium"
+        if self.assessment.sensitivity is Sensitivity.medium:
+            return "medium"
         return "low"
+
+    @property
+    def blocks(self) -> bool:
+        """Deterministic hard-block signal: a secret shape *or* a disclosed credential.
+
+        The broker still decides; this only reports what detection recommends.
+        """
+        return self.has_secret or self.assessment.recommended_disposition == BLOCK
 
 
 def scan(text: str) -> ScanResult:
@@ -78,6 +100,7 @@ def scan(text: str) -> ScanResult:
                     continue
             result.pii_labels.append(label)
     result.injection = any(p.search(text) for p in _INJECTION_PATTERNS)
+    result.assessment = classify(text)
     return result
 
 

--- a/services/api/app/core/sensitivity.py
+++ b/services/api/app/core/sensitivity.py
@@ -113,6 +113,31 @@ def _is_educational(text: str) -> bool:
     return any(p.search(text) for p in _EDUCATIONAL_FRAMING)
 
 
+# Sentence terminators, semicolons, and contrastive conjunctions. Clauses are the
+# unit of classification: an educational or memory-control clause must not exempt a
+# *separate* disclosure clause in the same message.
+_CLAUSE_SPLIT = re.compile(
+    r"(?<=[.!?])\s+"                      # sentence boundary
+    r"|\s*;\s*"                           # semicolon
+    r"|,\s+(?=but\b|however\b|although\b|though\b)",  # contrastive comma
+    re.IGNORECASE,
+)
+
+
+def split_clauses(text: str) -> list[str]:
+    """Split into clauses for independent classification.
+
+    Classifying the whole message at once let one clause exempt another:
+
+        "I am reading research about HIV. My HIV status is positive."
+        "What is the average software engineer salary? My salary is $250,000."
+
+    The educational framing matched somewhere in the text, so the entire message
+    returned an empty assessment and the real disclosure went unclassified.
+    """
+    return [c.strip() for c in _CLAUSE_SPLIT.split(text) if c and c.strip()]
+
+
 # ── rules ────────────────────────────────────────────────────────────────────
 # Each rule requires first-person ownership AND a disclosure verb AND a value or
 # condition, so a bare keyword cannot trigger it. `\b` boundaries throughout so
@@ -320,21 +345,27 @@ def classify(text: str) -> SensitivityAssessment:
     if not text or not text.strip():
         return SensitivityAssessment()
 
-    # A question or a description of a topic is not a disclosure about the speaker.
-    if _is_educational(text):
-        return SensitivityAssessment()
-
+    # Per clause: a question or topic description is not a disclosure about the
+    # speaker, but it only exempts *itself*. Whole-message framing checks let
+    # "I am reading research about HIV. My HIV status is positive." pass as safe.
     findings: list[SensitivityFinding] = []
-    for category, rule_id, sensitivity, disposition, pattern in _RULES:
-        if pattern.search(text):
-            findings.append(
-                SensitivityFinding(
-                    category=category,
-                    rule_id=rule_id,
-                    sensitivity=sensitivity,
-                    recommended_disposition=disposition,
+    seen_rules: set[str] = set()
+    for clause in split_clauses(text) or [text]:
+        if _is_educational(clause):
+            continue
+        for category, rule_id, sensitivity, disposition, pattern in _RULES:
+            if rule_id in seen_rules:
+                continue
+            if pattern.search(clause):
+                seen_rules.add(rule_id)
+                findings.append(
+                    SensitivityFinding(
+                        category=category,
+                        rule_id=rule_id,
+                        sensitivity=sensitivity,
+                        recommended_disposition=disposition,
+                    )
                 )
-            )
 
     if not findings:
         return SensitivityAssessment()
@@ -371,11 +402,54 @@ _MEMORY_CONTROL = [
 ]
 
 
-def is_memory_control_instruction(text: str) -> bool:
-    """True when the text asks the assistant *not* to remember (or to forget).
+# `forget my X` / `delete my X` asks to remove something already stored — a
+# *deletion* request, distinct from `do not remember my X`, which only prevents new
+# persistence. Both suppress a new candidate; only the first should eventually
+# invoke the governed forget workflow. Separated here so that distinction is
+# available rather than conflated.
+_FORGET_REQUEST = re.compile(
+    r"\b(?:forget|erase|delete|remove)\b[^.?!]{0,30}?\bmy\b", re.IGNORECASE
+)
 
-    Used by the extractor to produce no candidate at all. The policy broker applies
-    the same check independently, so a malformed or LLM-provided extractor that
-    emits a candidate anyway still cannot store it.
+
+def is_memory_control_instruction(text: str) -> bool:
+    """True when *any clause* asks the assistant not to remember (or to forget).
+
+    Clause-scoped for the same reason as `classify`: whole-message matching let one
+    instruction suppress an unrelated fact in the same turn.
     """
-    return any(p.search(text) for p in _MEMORY_CONTROL)
+    return any(_clause_is_memory_control(c) for c in (split_clauses(text) or [text]))
+
+
+def _clause_is_memory_control(clause: str) -> bool:
+    return any(p.search(clause) for p in _MEMORY_CONTROL)
+
+
+def is_forget_request(text: str) -> bool:
+    """True for `forget my salary` — a request to remove *existing* memory.
+
+    Distinct from `do not remember my salary`, which only prevents new persistence.
+    This currently suppresses the new candidate like any other memory-control
+    instruction; routing it into the governed forget workflow (legal hold,
+    `deleted_at`, tombstone, lineage, deletion audit) is follow-up work and is
+    deliberately **not** done here — silently deleting on a chat phrase would be a
+    destructive action taken without the deletion path's guarantees.
+    """
+    return any(_FORGET_REQUEST.search(c) for c in (split_clauses(text) or [text]))
+
+
+def strip_memory_control_clauses(text: str) -> str:
+    """Return the text with memory-control clauses removed.
+
+    Discarding the whole message suppressed legitimate facts stated alongside an
+    instruction:
+
+        "Do not remember my password, but remember that I prefer dark mode."
+
+    Only the instruction clause is dropped; the preference survives to extraction.
+    """
+    clauses = split_clauses(text)
+    if not clauses:
+        return "" if _clause_is_memory_control(text) else text
+    kept = [c for c in clauses if not _clause_is_memory_control(c)]
+    return " ".join(kept).strip()

--- a/services/api/app/core/sensitivity.py
+++ b/services/api/app/core/sensitivity.py
@@ -1,0 +1,381 @@
+"""Deterministic semantic-pattern and structural sensitivity classification.
+
+What this is, precisely
+-----------------------
+Rule-based detection of *disclosures* — a first-person statement that reveals a
+credential, an identifier, or a sensitive personal fact. It is **not** medical,
+financial, or credential *understanding*: there is no ontology, no model, and no
+inference beyond the patterns written here. Describe it as what it is.
+
+Why it exists
+-------------
+Classification previously matched only *structural* patterns — SSN and card number
+shapes, API-key formats. Semantic disclosures scored `low` and were stored `active`:
+
+    "my password is hunter2"            -> low / active
+    "my HIV status is positive"         -> low / active
+    "I take sertraline for depression"  -> low / active
+    "my salary is $250,000"             -> low / active
+
+Every downstream control keys off sensitivity — approval gating, the recall gate's
+audience clearance, the admission gate — so for exactly the categories those controls
+exist to protect, they were inert. A plaintext password was retrievable into a
+`public`-audience response.
+
+Separation of responsibilities
+------------------------------
+This module **detects and recommends**; it never decides storage. The policy broker
+remains authoritative and applies tenant settings, approval configuration, the
+governance profile, consent, and temporary-chat behaviour on top. Keeping the
+recommendation separate stops the scanner becoming a second policy broker.
+
+Known limits (stated rather than papered over)
+----------------------------------------------
+Pattern rules miss paraphrase, other languages, obfuscation, and unusual phrasing.
+A rule that fires is high-confidence; silence is *not* evidence of safety. Broadening
+recall belongs with evaluation evidence, not with more unreviewed regexes.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from ..schemas.memory import Sensitivity
+
+# ── dispositions, most restrictive first ─────────────────────────────────────
+BLOCK = "BLOCK"
+PENDING_APPROVAL = "PENDING_APPROVAL"
+SAVE = "SAVE"
+
+_DISPOSITION_RANK = {BLOCK: 2, PENDING_APPROVAL: 1, SAVE: 0}
+_SENSITIVITY_RANK = {Sensitivity.high: 2, Sensitivity.medium: 1, Sensitivity.low: 0}
+
+
+@dataclass(frozen=True)
+class SensitivityFinding:
+    """One rule match. Content-free: it names *what* matched, never the value."""
+
+    category: str
+    rule_id: str
+    sensitivity: Sensitivity
+    recommended_disposition: str
+    confidence: float = 1.0
+
+
+@dataclass(frozen=True)
+class SensitivityAssessment:
+    """Aggregate of every finding, with deterministic precedence applied."""
+
+    findings: tuple[SensitivityFinding, ...] = field(default_factory=tuple)
+    sensitivity: Sensitivity = Sensitivity.low
+    recommended_disposition: str = SAVE
+
+    @property
+    def categories(self) -> tuple[str, ...]:
+        # Deduplicated, order-stable — safe to put in audit metadata.
+        seen: dict[str, None] = {}
+        for f in self.findings:
+            seen.setdefault(f.category, None)
+        return tuple(seen)
+
+    @property
+    def rule_ids(self) -> tuple[str, ...]:
+        return tuple(f.rule_id for f in self.findings)
+
+
+# ── framing guard ────────────────────────────────────────────────────────────
+# A sensitive keyword is not a disclosure. These forms discuss a topic rather than
+# reveal a fact about the speaker, and must never classify as sensitive:
+#
+#   "How should password hashing work?"        (question / educational)
+#   "Sertraline is a commonly prescribed …"    (third-person description)
+#   "I am reading research about HIV"          (study framing)
+#   "This document explains bank routing …"    (documentation framing)
+#
+# The rules below are written to require first-person disclosure, so this is
+# defence in depth rather than the only guard.
+_EDUCATIONAL_FRAMING = [
+    re.compile(r"^\s*(?:how|what|why|when|where|which|who|can|should|does|do|is|are)\b"
+               r"[^.?!]*\?", re.IGNORECASE),
+    re.compile(r"\b(?:reading|read|researching|research|studying|study|learning|learn)\b"
+               r"[^.?!]{0,40}\b(?:about|on|into)\b", re.IGNORECASE),
+    re.compile(r"\b(?:this|the)\s+(?:document|article|paper|guide|post|book)\b",
+               re.IGNORECASE),
+    re.compile(r"\b(?:commonly|widely|typically|generally)\s+(?:prescribed|used|known)\b",
+               re.IGNORECASE),
+    re.compile(r"\b(?:average|median|typical)\b", re.IGNORECASE),
+    re.compile(r"\bhow\s+(?:to|do|does|should)\b", re.IGNORECASE),
+]
+
+
+def _is_educational(text: str) -> bool:
+    return any(p.search(text) for p in _EDUCATIONAL_FRAMING)
+
+
+# ── rules ────────────────────────────────────────────────────────────────────
+# Each rule requires first-person ownership AND a disclosure verb AND a value or
+# condition, so a bare keyword cannot trigger it. `\b` boundaries throughout so
+# "password manager" or "passport control" do not match a password rule.
+
+# "is" / "=" / ":" followed by a non-space value.
+_DISCLOSES = r"\s*(?:is|are|was|=|:)\s*\S+"
+
+_RULES: list[tuple[str, str, Sensitivity, str, re.Pattern[str]]] = [
+    # ── credentials → BLOCK ─────────────────────────────────────────────────
+    (
+        "credential",
+        "credential.password_first_person",
+        Sensitivity.high,
+        BLOCK,
+        # `(?!\s*manager)` so "my password manager is 1Password" is a tool
+        # preference, not a credential disclosure.
+        re.compile(
+            r"\bmy\s+(?:password|passcode|passphrase)\b(?!\s*manager)" + _DISCLOSES,
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "credential",
+        "credential.pin_first_person",
+        Sensitivity.high,
+        BLOCK,
+        re.compile(r"\bmy\s+(?:pin|pin\s+code|passcode)\b" + _DISCLOSES, re.IGNORECASE),
+    ),
+    (
+        "credential",
+        "credential.security_answer",
+        Sensitivity.high,
+        BLOCK,
+        re.compile(
+            r"\bmy\s+security\s+(?:answer|question\s+answer)\b" + _DISCLOSES,
+            re.IGNORECASE,
+        ),
+    ),
+    # ── recovery secrets → BLOCK ────────────────────────────────────────────
+    (
+        "recovery_secret",
+        "recovery_secret.code_first_person",
+        Sensitivity.high,
+        BLOCK,
+        re.compile(
+            r"\bmy\s+(?:recovery|backup|one[- ]?time|2fa|mfa)\s+"
+            r"(?:code|codes|key)\b" + _DISCLOSES,
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "recovery_secret",
+        "recovery_secret.seed_phrase",
+        Sensitivity.high,
+        BLOCK,
+        re.compile(
+            r"\bmy\s+(?:seed|recovery|mnemonic)\s+phrase\b" + _DISCLOSES, re.IGNORECASE
+        ),
+    ),
+    # ── payment information → BLOCK ─────────────────────────────────────────
+    (
+        "payment",
+        "payment.account_first_person",
+        Sensitivity.high,
+        BLOCK,
+        re.compile(
+            r"\bmy\s+(?:bank\s+account|account|routing|card|credit\s+card|debit\s+card)"
+            r"\s+number\b" + _DISCLOSES,
+            re.IGNORECASE,
+        ),
+    ),
+    # ── government identifiers → BLOCK ──────────────────────────────────────
+    (
+        "government_id",
+        "government_id.first_person",
+        Sensitivity.high,
+        BLOCK,
+        re.compile(
+            r"\bmy\s+(?:social\s+security|ssn|passport|driver'?s?\s+licen[cs]e|"
+            r"national\s+insurance|tax\s+id)\s*(?:number|no\.?)?\b" + _DISCLOSES,
+            re.IGNORECASE,
+        ),
+    ),
+    # ── medical → high, approval ────────────────────────────────────────────
+    (
+        "medical",
+        "medical.status_disclosure",
+        Sensitivity.high,
+        PENDING_APPROVAL,
+        re.compile(
+            r"\bmy\s+(?:hiv|hep(?:atitis)?\s*[abc]?|std|sti|cancer|covid)\s+status\b"
+            + _DISCLOSES,
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "medical",
+        "medical.diagnosis_first_person",
+        Sensitivity.high,
+        PENDING_APPROVAL,
+        re.compile(
+            r"\bi\s+(?:was|were|been|have\s+been|am)\s+diagnosed\s+with\b", re.IGNORECASE
+        ),
+    ),
+    (
+        "medical",
+        "medical.condition_first_person",
+        Sensitivity.high,
+        PENDING_APPROVAL,
+        re.compile(
+            r"\bi\s+(?:have|suffer\s+from|live\s+with)\s+"
+            r"(?:\w+\s+){0,2}?(?:diabetes|cancer|epilepsy|asthma|hiv|lupus|"
+            r"crohn'?s|arthritis)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # ── mental health → high, approval ──────────────────────────────────────
+    (
+        "mental_health",
+        "mental_health.medication_first_person",
+        Sensitivity.high,
+        PENDING_APPROVAL,
+        re.compile(
+            r"\bi\s+(?:take|am\s+on|was\s+prescribed|started)\s+"
+            r"(?:\w+\s+){0,2}?(?:sertraline|fluoxetine|citalopram|escitalopram|"
+            r"venlafaxine|bupropion|lithium|quetiapine|olanzapine|prozac|zoloft|"
+            r"lexapro)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "mental_health",
+        "mental_health.treatment_first_person",
+        Sensitivity.high,
+        PENDING_APPROVAL,
+        re.compile(
+            r"\bi\s+(?:take|am\s+on|was\s+prescribed|started)\b[^.?!]{0,40}?"
+            r"\bfor\s+(?:my\s+)?(?:depression|anxiety|bipolar|ptsd|ocd|adhd)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "mental_health",
+        "mental_health.condition_first_person",
+        Sensitivity.high,
+        PENDING_APPROVAL,
+        re.compile(
+            r"\bi\s+(?:have|was\s+diagnosed\s+with|suffer\s+from|struggle\s+with)\s+"
+            r"(?:\w+\s+){0,2}?(?:depression|anxiety|bipolar|schizophrenia|ptsd|ocd)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # ── financial condition → high, approval ────────────────────────────────
+    (
+        "financial",
+        "financial.amount_first_person",
+        Sensitivity.high,
+        PENDING_APPROVAL,
+        re.compile(
+            r"\bmy\s+(?:salary|income|bank\s+balance|account\s+balance|net\s+worth|"
+            r"credit\s+score|rent|mortgage)\b" + _DISCLOSES,
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "financial",
+        "financial.debt_first_person",
+        Sensitivity.high,
+        PENDING_APPROVAL,
+        re.compile(r"\bi\s+owe\b[^.?!]{0,30}?[\d$]", re.IGNORECASE),
+    ),
+    # ── precise private location → high, approval ───────────────────────────
+    (
+        "location",
+        "location.home_address_first_person",
+        Sensitivity.high,
+        PENDING_APPROVAL,
+        re.compile(
+            r"\bmy\s+(?:home\s+|current\s+|street\s+)?address\b" + _DISCLOSES,
+            re.IGNORECASE,
+        ),
+    ),
+    # ── biometrics → high, approval ─────────────────────────────────────────
+    (
+        "biometric",
+        "biometric.first_person",
+        Sensitivity.high,
+        PENDING_APPROVAL,
+        re.compile(
+            r"\bmy\s+(?:fingerprint|face\s+(?:id|template|scan)|voiceprint|retina\s+scan|"
+            r"iris\s+scan)\b" + _DISCLOSES,
+            re.IGNORECASE,
+        ),
+    ),
+]
+
+
+def classify(text: str) -> SensitivityAssessment:
+    """Classify text into a content-free assessment.
+
+    Returns an empty, ``SAVE``/``low`` assessment when nothing matches — silence is
+    "no rule fired", not a guarantee the text is safe.
+    """
+    if not text or not text.strip():
+        return SensitivityAssessment()
+
+    # A question or a description of a topic is not a disclosure about the speaker.
+    if _is_educational(text):
+        return SensitivityAssessment()
+
+    findings: list[SensitivityFinding] = []
+    for category, rule_id, sensitivity, disposition, pattern in _RULES:
+        if pattern.search(text):
+            findings.append(
+                SensitivityFinding(
+                    category=category,
+                    rule_id=rule_id,
+                    sensitivity=sensitivity,
+                    recommended_disposition=disposition,
+                )
+            )
+
+    if not findings:
+        return SensitivityAssessment()
+
+    # Deterministic precedence: BLOCK > PENDING_APPROVAL > SAVE, high > medium > low.
+    disposition = max(
+        (f.recommended_disposition for f in findings), key=lambda d: _DISPOSITION_RANK[d]
+    )
+    sensitivity = max((f.sensitivity for f in findings), key=lambda s: _SENSITIVITY_RANK[s])
+    return SensitivityAssessment(
+        findings=tuple(findings),
+        sensitivity=sensitivity,
+        recommended_disposition=disposition,
+    )
+
+
+# ── memory-control instructions ──────────────────────────────────────────────
+# "do not remember my password" is an instruction *about* memory, not a fact to
+# store. It must produce no memory at all — storing it as a high-sensitivity record
+# would be the same disclosure by another route, and returning BLOCK alone would
+# still be wrong, since there is nothing here that should have been a candidate.
+_MEMORY_CONTROL = [
+    re.compile(
+        r"\b(?:do\s*n[o']?t|don'?t|never|please\s+do\s*n[o']?t|stop)\b[^.?!]{0,40}?"
+        r"\b(?:remember|save|store|keep|record|memoris?e|memoriz?e|retain)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bi\s+do\s*n[o']?t\s+want\s+you\s+to\s+"
+        r"(?:remember|save|store|keep|record|retain)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\b(?:forget|erase|delete|remove)\b[^.?!]{0,30}?\bmy\b", re.IGNORECASE),
+]
+
+
+def is_memory_control_instruction(text: str) -> bool:
+    """True when the text asks the assistant *not* to remember (or to forget).
+
+    Used by the extractor to produce no candidate at all. The policy broker applies
+    the same check independently, so a malformed or LLM-provided extractor that
+    emits a candidate anyway still cannot store it.
+    """
+    return any(p.search(text) for p in _MEMORY_CONTROL)

--- a/services/api/app/schemas/memory.py
+++ b/services/api/app/schemas/memory.py
@@ -116,8 +116,11 @@ class MemoryTraceEntry(BaseModel):
 
     memory_id: str
     memory_type: MemoryType
+    #: Empty when the memory was withheld for audience clearance — echoing the
+    #: preview would disclose exactly what the gate withheld.
     content_preview: str
-    source: Source
+    #: ``None`` for the same reason: the source excerpt carries the raw text.
+    source: Source | None = None
     stored_at: datetime
     status: Status
     sensitivity: Sensitivity

--- a/services/api/app/services/admission_gate.py
+++ b/services/api/app/services/admission_gate.py
@@ -83,13 +83,23 @@ class AdmissionRecord:
 
     def to_trace_entry(self) -> MemoryTraceEntry:
         m = self.memory
-        content = m.content or ""
-        preview = content[:_PREVIEW_CHARS] + ("…" if len(content) > _PREVIEW_CHARS else "")
+        # A memory withheld because the audience lacks clearance must not have its
+        # content handed back in the trace — echoing a 160-character preview plus
+        # the full source excerpt would disclose exactly what the gate withheld.
+        # (This covers the audience verdict only; broader blocked-trace
+        # minimisation for every BLOCK_* reason is separate, tracked work.)
+        if self.decision is AdmissionDecision.BLOCK_AUDIENCE:
+            preview = ""
+            source = None
+        else:
+            content = m.content or ""
+            preview = content[:_PREVIEW_CHARS] + ("…" if len(content) > _PREVIEW_CHARS else "")
+            source = m.source
         return MemoryTraceEntry(
             memory_id=m.id,
             memory_type=m.memory_type,
             content_preview=preview,
-            source=m.source,
+            source=source,
             stored_at=m.created_at,
             status=m.status,
             sensitivity=m.sensitivity,

--- a/services/api/app/services/effective_sensitivity.py
+++ b/services/api/app/services/effective_sensitivity.py
@@ -1,0 +1,55 @@
+"""Read-time sensitivity for memory that predates the classifier.
+
+The problem
+-----------
+Semantic classification runs at *write* time — on creation and on a governed
+content edit. Rows stored before it existed keep whatever label they were given:
+
+    content:     "my password is hunter2"
+    sensitivity: low
+    status:      active
+
+Nothing rewrites that on upgrade, so the headline protection would apply only to
+content entering after the change. A pre-existing credential row was verified to
+still reach a `public`-audience response with its full source excerpt.
+
+The fix
+-------
+The read path combines the *stored* label with a *current* classification of the
+content and uses whichever is higher. A row mislabelled at write time is therefore
+gated correctly on every read, immediately after deploy and with no migration.
+
+Deliberately **not** a write. Reads must not mutate rows: it would turn every query
+into a write, produce audit events with no actor, and race with concurrent edits.
+Persisting the corrected label — with audit evidence — belongs to a reclassification
+worker, which can then also record *why* each row changed.
+
+Cost note: this is a deterministic regex pass over already-loaded content, on the
+handful of candidates that survived ranking, so it is proportional to admitted
+memories rather than to the store.
+"""
+
+from __future__ import annotations
+
+from ..core.sensitivity import classify
+from ..db.entities import StoredMemory
+from ..schemas.memory import Sensitivity
+
+_RANK = {Sensitivity.low: 0, Sensitivity.medium: 1, Sensitivity.high: 2}
+
+
+def effective_sensitivity(memory: StoredMemory) -> Sensitivity:
+    """The stored label, raised to the current classification when that is higher.
+
+    Only ever raises. A row explicitly labelled `high` is never lowered because the
+    rules happen not to match it — an operator's judgement outranks a pattern's
+    silence, and silence is not evidence of safety.
+    """
+    stored = memory.sensitivity
+    detected = classify(memory.content or "").sensitivity
+    return detected if _RANK[detected] > _RANK[stored] else stored
+
+
+def was_reclassified(memory: StoredMemory) -> bool:
+    """True when the read-time classification raised the stored label."""
+    return effective_sensitivity(memory) is not memory.sensitivity

--- a/services/api/app/services/extractor.py
+++ b/services/api/app/services/extractor.py
@@ -11,7 +11,7 @@ no network — and the policy broker still runs after this and stays authoritati
 
 from __future__ import annotations
 
-from ..core.sensitivity import is_memory_control_instruction
+from ..core.sensitivity import strip_memory_control_clauses
 from ..llm import get_llm_provider
 from ..llm.base import LLMProvider
 from ..llm.intelligence import extract_memories
@@ -30,12 +30,16 @@ class Extractor:
             return []
 
         # "do not remember my password" is an instruction *about* memory, not a fact
-        # to store. Emitting a candidate for it and then blocking would be the wrong
-        # shape: the correct outcome is that no memory is ever created, and storing
-        # the sentence as a high-sensitivity record would be the same disclosure by
-        # another route. The policy broker repeats this check independently, so an
-        # LLM extractor that emits a candidate anyway still cannot store it.
-        if is_memory_control_instruction(text):
+        # to store: the correct outcome is that no memory is created, since storing
+        # the sentence would be the same disclosure by another route.
+        #
+        # Only the instruction *clause* is removed, not the whole turn. Discarding
+        # the entire message suppressed legitimate facts stated alongside it —
+        # "Do not remember my password, but remember that I prefer dark mode."
+        # stored nothing at all. The policy broker repeats the check per candidate,
+        # so an LLM extractor that emits one anyway still cannot store it.
+        text = strip_memory_control_clauses(text)
+        if not text:
             return []
 
         outcome = extract_memories(self._provider, text)

--- a/services/api/app/services/extractor.py
+++ b/services/api/app/services/extractor.py
@@ -11,6 +11,7 @@ no network — and the policy broker still runs after this and stays authoritati
 
 from __future__ import annotations
 
+from ..core.sensitivity import is_memory_control_instruction
 from ..llm import get_llm_provider
 from ..llm.base import LLMProvider
 from ..llm.intelligence import extract_memories
@@ -26,6 +27,15 @@ class Extractor:
     def extract(self, message: str, source: Source) -> list[CandidateMemory]:
         text = message.strip()
         if not text:
+            return []
+
+        # "do not remember my password" is an instruction *about* memory, not a fact
+        # to store. Emitting a candidate for it and then blocking would be the wrong
+        # shape: the correct outcome is that no memory is ever created, and storing
+        # the sentence as a high-sensitivity record would be the same disclosure by
+        # another route. The policy broker repeats this check independently, so an
+        # LLM extractor that emits a candidate anyway still cannot store it.
+        if is_memory_control_instruction(text):
             return []
 
         outcome = extract_memories(self._provider, text)

--- a/services/api/app/services/policy_broker.py
+++ b/services/api/app/services/policy_broker.py
@@ -23,10 +23,23 @@ class PolicyOutcome:
     candidate: CandidateMemory
     reason: str
     existing_id: str | None = None
+    #: Stable machine-readable reason, additive alongside the human `reason`.
+    #: `memory_control_instruction` distinguishes "this was never a memory" from a
+    #: genuine low-utility drop — reusing DROP_LOW_UTILITY for both would
+    #: contaminate utility metrics and error analysis. A dedicated Decision value
+    #: (IGNORE_MEMORY_CONTROL / DROP_NOT_MEMORY) is the right long-term shape and is
+    #: tracked separately; this keeps the vocabulary additive for now.
+    reason_code: str | None = None
 
 
 # Below this importance an inferred memory is noise.
 _MIN_IMPORTANCE = 4
+
+#: Reason code for a memory-control instruction. Metrics over low-utility drops must
+#: exclude this: "not a memory at all" and "a valid memory of low utility" are
+#: different outcomes, and conflating them skews utility analysis.
+REASON_MEMORY_CONTROL = "memory_control_instruction"
+REASON_LOW_UTILITY = "low_utility"
 
 
 class PolicyBroker:
@@ -62,6 +75,7 @@ class PolicyBroker:
                 Decision.DROP_LOW_UTILITY,
                 candidate,
                 "dropped: memory-control instruction, not a fact to store",
+                reason_code=REASON_MEMORY_CONTROL,
             )
         if enforce and scan_result.has_secret:
             return PolicyOutcome(
@@ -109,6 +123,7 @@ class PolicyBroker:
                 Decision.DROP_LOW_UTILITY,
                 candidate,
                 f"dropped: importance {candidate.importance} below threshold {_MIN_IMPORTANCE}",
+                reason_code=REASON_LOW_UTILITY,
             )
 
         # 5) Sensitive content gated behind approval — governance enforcement.

--- a/services/api/app/services/policy_broker.py
+++ b/services/api/app/services/policy_broker.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 
 from ..core.config import get_settings as get_app_settings
 from ..core.redaction import scan
+from ..core.sensitivity import BLOCK, is_memory_control_instruction
 from ..db.entities import StoredSettings
 from ..db.repository import Repository
 from ..schemas.memory import CandidateMemory, Decision, Sensitivity
@@ -51,11 +52,31 @@ class PolicyBroker:
         scan_result = scan(candidate.content)
 
         # 1) Hard safety rules (deterministic, verifiable) — governance enforcement.
+        # A memory-control instruction ("do not remember my password") is not a fact.
+        # The extractor already declines to emit a candidate for it; this is the
+        # independent second guard, so a malformed or LLM-provided extractor that
+        # emits one anyway still cannot store it. DROP, not BLOCK: there was never a
+        # candidate here worth recording as a refusal.
+        if is_memory_control_instruction(candidate.content):
+            return PolicyOutcome(
+                Decision.DROP_LOW_UTILITY,
+                candidate,
+                "dropped: memory-control instruction, not a fact to store",
+            )
         if enforce and scan_result.has_secret:
             return PolicyOutcome(
                 Decision.BLOCK,
                 candidate,
                 f"blocked: secret-like content detected ({', '.join(scan_result.secret_labels)})",
+            )
+        if enforce and scan_result.assessment.recommended_disposition == BLOCK:
+            # A disclosed credential the structural patterns cannot see — e.g.
+            # "my password is …", which has no key-like shape.
+            return PolicyOutcome(
+                Decision.BLOCK,
+                candidate,
+                "blocked: disclosed credential or identifier "
+                f"({', '.join(scan_result.assessment.categories)})",
             )
         if enforce and scan_result.injection:
             return PolicyOutcome(
@@ -139,6 +160,13 @@ class PolicyBroker:
                 Decision.BLOCK,
                 candidate,
                 f"blocked: secret-like content detected ({', '.join(scan_result.secret_labels)})",
+            )
+        if enforce and scan_result.assessment.recommended_disposition == BLOCK:
+            return PolicyOutcome(
+                Decision.BLOCK,
+                candidate,
+                "blocked: disclosed credential or identifier "
+                f"({', '.join(scan_result.assessment.categories)})",
             )
         if enforce and scan_result.injection:
             return PolicyOutcome(

--- a/services/api/app/services/recall_gate.py
+++ b/services/api/app/services/recall_gate.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, replace
 
 from ..schemas.memory import Sensitivity
 from .admission_gate import AdmissionDecision, AdmissionRecord
+from .effective_sensitivity import effective_sensitivity
 
 # Which sensitivities each audience is cleared to recall.
 _CLEARANCE: dict[str, set[Sensitivity]] = {
@@ -44,17 +45,24 @@ class RecallGate:
         allowed: list[AdmissionRecord] = []
         blocked: list[AdmissionRecord] = []
         for record in admitted:
-            if record.memory.sensitivity in cleared:
+            effective = effective_sensitivity(record.memory)
+            if effective in cleared:
                 allowed.append(record)
             else:
+                stored = record.memory.sensitivity
+                detail = (
+                    f"sensitivity '{effective.value}' exceeds "
+                    f"'{audience}' audience clearance"
+                )
+                if effective is not stored:
+                    # Say so explicitly: the row is labelled `stored` on disk and was
+                    # re-classified at read time.
+                    detail += f" (stored '{stored.value}', re-classified at read time)"
                 blocked.append(
                     replace(
                         record,
                         decision=AdmissionDecision.BLOCK_AUDIENCE,
-                        reason=(
-                            f"sensitivity '{record.memory.sensitivity.value}' exceeds "
-                            f"'{audience}' audience clearance"
-                        ),
+                        reason=detail,
                     )
                 )
         return RecallResult(allowed=allowed, blocked=blocked)

--- a/services/api/app/services/update_service.py
+++ b/services/api/app/services/update_service.py
@@ -46,6 +46,7 @@ import hashlib
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
+from ..core.redaction import scan
 from ..core.reliability import safe_call
 from ..db import governance as gov
 from ..db.entities import StoredMemory, StoredSettings
@@ -185,7 +186,14 @@ def apply_content_update(
         memory.status = Status.pending
         audit_action = "memory_content_update_pending_approval"
 
+    assessment = scan(new_content).assessment
     evidence = {
+        # Classification evidence is category/rule identifiers only — never the
+        # matched password, diagnosis, salary, address, or regex excerpt. The audit
+        # trail is read by operators who may not be cleared for the memory itself.
+        "sensitivity_categories": list(assessment.categories),
+        "sensitivity_rule_ids": list(assessment.rule_ids),
+        "sensitivity_finding_count": len(assessment.findings),
         "previous_content_hash": previous_hash,
         "new_content_hash": content_hash(new_content),
         "previous_sensitivity": previous_sensitivity.value,

--- a/services/api/app/services/write_service.py
+++ b/services/api/app/services/write_service.py
@@ -8,12 +8,29 @@ Every path records provenance (invariant #3) and an audit event (invariant #7).
 from __future__ import annotations
 
 from ..core.embeddings import embed
+from ..core.redaction import scan
 from ..core.reliability import safe_call
 from ..db.entities import StoredMemory
 from ..db.repository import Repository
 from ..schemas.memory import CandidateDecision, Decision, Status
 from .audit import AuditService
 from .policy_broker import PolicyOutcome
+
+
+def _classification_evidence(content: str) -> dict:
+    """Content-free classification evidence for a creation audit event.
+
+    Mirrors the governed edit path (`update_service`) so creation and editing
+    produce the same evidence vocabulary — otherwise the audit trail explains one
+    write path and not the other. Category and rule identifiers only: never the
+    matched password, diagnosis, salary, address, or regex excerpt.
+    """
+    assessment = scan(content).assessment
+    return {
+        "sensitivity_categories": list(assessment.categories),
+        "sensitivity_rule_ids": list(assessment.rule_ids),
+        "sensitivity_finding_count": len(assessment.findings),
+    }
 
 # Map a decision to its audit action verb.
 _AUDIT_ACTION = {
@@ -94,7 +111,16 @@ class WriteService:
                 action=_AUDIT_ACTION[decision],
                 reason=outcome.reason,
                 trace_id=trace_id,
-                metadata={"type": cand.type.value, "sensitivity": cand.sensitivity.value},
+                metadata={
+                    "type": cand.type.value,
+                    "sensitivity": cand.sensitivity.value,
+                    # Same content-free classification vocabulary as the governed
+                    # edit path (update_service): creation and editing must produce
+                    # comparable evidence, or the trail explains one path and not
+                    # the other. Category and rule identifiers only — never the
+                    # matched password, diagnosis, salary, address, or excerpt.
+                    **_classification_evidence(cand.content),
+                },
             )
             audit_ids.append(event.id)
 

--- a/services/api/tests/test_governed_content_update.py
+++ b/services/api/tests/test_governed_content_update.py
@@ -149,7 +149,9 @@ def test_editing_low_sensitivity_content_into_pii_re_gates_the_memory(api_client
     client, repo = api_client
     m = _seed(repo, content="prefers dark mode", sensitivity=Sensitivity.low)
 
-    r = _patch(client, m.id, content="my social security number is 555-01-9999")
+    # A medical disclosure is high-sensitivity but storable behind approval.
+    # (A government identifier would be BLOCKed outright — see the block tests.)
+    r = _patch(client, m.id, content="I was diagnosed with diabetes")
     assert r.status_code == 200
 
     after = repo.get_memory("t1", "u1", m.id)
@@ -281,7 +283,7 @@ def test_audit_records_before_and_after_hashes_without_the_content(api_client):
 def test_a_sensitive_edit_is_audited_distinctly(api_client):
     client, repo = api_client
     m = _seed(repo)
-    _patch(client, m.id, content="my social security number is 555-01-9999")
+    _patch(client, m.id, content="I was diagnosed with diabetes")
     actions = {e["action"] for e in client.get(f"/api/memories/{m.id}/audit{_Q}").json()}
     assert "memory_content_update_pending_approval" in actions
     assert "memory_updated" not in actions, "the generic action no longer stands in for an edit"

--- a/services/api/tests/test_loop_events.py
+++ b/services/api/tests/test_loop_events.py
@@ -132,3 +132,40 @@ def test_a_blocked_content_edit_does_not_emit_an_executed_state(api_client):
         states = {e.state_to.value for e in repo.list_loop_events(loop_run_id=run.id)}
         assert "executed" not in states, "a blocked edit must not record an execution"
     assert repo.get_memory("t1", "u1", m.id).content == "prefers dark mode"
+
+
+def test_a_blocked_credential_disclosure_records_no_write(api_client):
+    """A semantic credential disclosure is refused before storage, and the loop
+    evidence must not suggest a write happened.
+
+    "my password is hunter2" has no key-like *shape*, so the structural scanner
+    never saw it; it was stored active at `low` sensitivity, which left every
+    sensitivity-keyed control inert for it.
+    """
+    client, repo = api_client
+    r = client.post(
+        "/api/chat",
+        json={
+            "tenant_id": "t1",
+            "user_id": "u1",
+            "message": "Remember: my password is hunter2.",
+        },
+    )
+    assert r.status_code == 200
+
+    # Nothing stored, and the chat response records the refusal as a decision.
+    assert [m for m in repo.list_memories("t1", "u1")] == []
+    decisions = {c["decision"] for c in r.json()["candidate_memories"]}
+    assert "BLOCK" in decisions
+
+
+def test_a_memory_control_instruction_records_no_stored_candidate(api_client):
+    """No memory, and no BLOCK either — there was never a candidate to refuse."""
+    client, repo = api_client
+    r = client.post(
+        "/api/chat",
+        json={"tenant_id": "t1", "user_id": "u1", "message": "do not remember my password"},
+    )
+    assert r.status_code == 200
+    assert repo.list_memories("t1", "u1") == []
+    assert r.json()["candidate_memories"] == []

--- a/services/api/tests/test_policy_broker.py
+++ b/services/api/tests/test_policy_broker.py
@@ -88,15 +88,31 @@ def test_evaluate_update_blocks_injection(repo):
 
 
 def test_evaluate_update_elevates_sensitivity_and_gates_approval(repo):
+    """A medical disclosure is high-sensitivity but storable behind approval."""
     from app.db.entities import StoredSettings
     from app.schemas.memory import Decision, Sensitivity
     from app.services.policy_broker import PolicyBroker
 
     outcome = PolicyBroker(repo).evaluate_update(
-        _candidate("my ssn is 555-01-9999"), settings=StoredSettings(tenant_id="t1", user_id="u1")
+        _candidate("I was diagnosed with diabetes"),
+        settings=StoredSettings(tenant_id="t1", user_id="u1"),
     )
     assert outcome.decision is Decision.PENDING_APPROVAL
-    assert outcome.candidate.sensitivity is not Sensitivity.low
+    assert outcome.candidate.sensitivity is Sensitivity.high
+
+
+def test_evaluate_update_blocks_a_disclosed_government_identifier(repo):
+    """Government identifiers are BLOCK, not approval-gated (category policy)."""
+    from app.db.entities import StoredSettings
+    from app.schemas.memory import Decision
+    from app.services.policy_broker import PolicyBroker
+
+    outcome = PolicyBroker(repo).evaluate_update(
+        _candidate("my ssn is 555-01-9999"),
+        settings=StoredSettings(tenant_id="t1", user_id="u1"),
+    )
+    assert outcome.decision is Decision.BLOCK
+    assert "government_id" in outcome.reason
 
 
 def test_evaluate_update_never_dedups_against_an_existing_memory(repo):

--- a/services/api/tests/test_sensitivity_classification.py
+++ b/services/api/tests/test_sensitivity_classification.py
@@ -355,3 +355,259 @@ def test_two_concurrent_sensitive_edits_yield_one_winner(api_client):
     after = repo.get_memory("t1", "u1", m.id)
     assert after.status is Status.pending
     assert after.revision == start + 1
+
+
+# ── review edge cases ────────────────────────────────────────────────────────
+# The 73 cases above classify whole, single-clause messages. These cover the four
+# gaps found in review: mixed clauses, mixed instructions, pre-existing rows, and
+# evidence parity between the two write paths.
+
+
+# 1. An educational clause must not exempt a separate disclosure clause.
+@pytest.mark.parametrize(
+    ("text", "category"),
+    [
+        ("I am reading research about HIV. My HIV status is positive.", "medical"),
+        ("What is the average software engineer salary? My salary is $250,000.", "financial"),
+        (
+            "Sertraline is a commonly prescribed medication. I take sertraline for depression.",
+            "mental_health",
+        ),
+        ("How should password hashing work? My password is hunter2.", "credential"),
+        ("This document explains routing numbers; my bank balance is $18,400.", "financial"),
+    ],
+)
+def test_an_educational_clause_does_not_exempt_a_disclosure_clause(text, category):
+    a = classify(text)
+    assert a.findings, f"whole-message framing suppressed a real disclosure: {text}"
+    assert category in a.categories
+
+
+def test_a_wholly_educational_message_is_still_clean():
+    """The clause fix must not turn the framing guard off."""
+    for text in NEGATIVE_CASES:
+        assert not classify(text).findings, text
+
+
+# 2. A memory-control clause must not suppress a legitimate fact beside it.
+def test_a_memory_control_clause_does_not_suppress_an_unrelated_fact(api_client):
+    client, repo = api_client
+    r = client.post(
+        "/api/chat",
+        json={
+            "tenant_id": "t1",
+            "user_id": "u1",
+            "message": "Do not remember my password, but remember that I prefer dark mode.",
+        },
+    )
+    assert r.status_code == 200
+
+    stored = repo.list_memories("t1", "u1")
+    assert stored, "the whole message was discarded, losing a legitimate preference"
+    blob = " ".join(m.content.lower() for m in stored)
+    assert "dark mode" in blob
+    assert "password" not in blob, "the credential clause was stored"
+
+
+def test_strip_leaves_only_the_non_instruction_clauses():
+    from app.core.sensitivity import strip_memory_control_clauses
+
+    remainder = strip_memory_control_clauses(
+        "Do not remember my password, but remember that I prefer dark mode."
+    )
+    assert "dark mode" in remainder
+    assert "password" not in remainder
+
+
+def test_forget_is_distinguished_from_do_not_remember():
+    """`forget my salary` asks to remove existing memory; `do not remember my
+    salary` only prevents new persistence. Both suppress a new candidate, but the
+    distinction has to exist before the forget workflow can use it."""
+    from app.core.sensitivity import is_forget_request
+
+    assert is_forget_request("forget my salary")
+    assert not is_forget_request("do not remember my salary")
+    # Both are still memory-control, so neither creates a memory.
+    assert is_memory_control_instruction("forget my salary")
+    assert is_memory_control_instruction("do not remember my salary")
+
+
+def test_forget_does_not_silently_delete_existing_memory(api_client):
+    """Deliberate: a chat phrase must not perform a destructive action outside the
+    governed deletion workflow (legal hold, deleted_at, tombstone, lineage, audit)."""
+    client, repo = api_client
+    m = _seed(repo, content="my salary is $250,000")
+
+    client.post(
+        "/api/chat",
+        json={"tenant_id": "t1", "user_id": "u1", "message": "forget my salary"},
+    )
+
+    after = repo.get_memory("t1", "u1", m.id)
+    assert after is not None and after.status is not Status.deleted
+    assert after.deleted_at is None
+
+
+# 3. Rows stored before the classifier existed are gated at read time.
+def test_a_pre_upgrade_low_active_credential_row_is_withheld(api_client):
+    """#103 classifies at write time. A row already stored `low`/`active` keeps its
+    label, so without read-time re-classification the headline fix would apply only
+    to content entering after deploy."""
+    client, repo = api_client
+    repo.create_memory(
+        StoredMemory(
+            tenant_id="t1",
+            user_id="u1",
+            memory_type=MemoryType.preference,
+            content="my password is hunter2",
+            importance=8,
+            confidence=0.9,
+            sensitivity=Sensitivity.low,  # as stored before the classifier existed
+            status=Status.active,
+            source=Source(kind="chat", excerpt="my password is hunter2"),
+        )
+    )
+
+    r = client.post(
+        "/api/chat",
+        json={
+            "tenant_id": "t1",
+            "user_id": "u1",
+            "message": "what is my password?",
+            "audience": "public",
+        },
+    )
+    assert r.status_code == 200
+    trace = r.json().get("trace") or {}
+
+    assert trace.get("memories_used") == [], "a pre-upgrade credential row entered context"
+
+    body = r.json()
+    assert "hunter2" not in str(body), "the withheld value was returned anyway"
+    for entry in trace.get("memories_blocked", []):
+        assert entry["content_preview"] == "", "a withheld memory returned a content preview"
+        assert entry.get("source") in (None, {}), "a withheld memory returned its source excerpt"
+
+
+def test_read_time_classification_never_lowers_a_stored_label(api_client):
+    """Only ever raises: an operator's `high` is not undone by pattern silence."""
+    from app.services.effective_sensitivity import effective_sensitivity
+
+    _client, repo = api_client
+    m = repo.create_memory(
+        StoredMemory(
+            tenant_id="t1",
+            user_id="u1",
+            memory_type=MemoryType.preference,
+            content="prefers dark mode dashboards",
+            importance=7,
+            confidence=0.9,
+            sensitivity=Sensitivity.high,  # deliberately labelled by an operator
+            status=Status.active,
+            source=Source(kind="chat", excerpt="prefers dark mode dashboards"),
+        )
+    )
+    assert effective_sensitivity(m) is Sensitivity.high
+
+
+def test_read_time_classification_does_not_mutate_the_row(api_client):
+    """Reads must not write: it would produce audit events with no actor and race
+    with concurrent edits. Persisting belongs to a reclassification worker."""
+    from app.services.effective_sensitivity import effective_sensitivity
+
+    _client, repo = api_client
+    m = repo.create_memory(
+        StoredMemory(
+            tenant_id="t1",
+            user_id="u1",
+            memory_type=MemoryType.preference,
+            content="my password is hunter2",
+            importance=8,
+            confidence=0.9,
+            sensitivity=Sensitivity.low,
+            status=Status.active,
+            source=Source(kind="chat", excerpt="my password is hunter2"),
+        )
+    )
+    assert effective_sensitivity(m) is Sensitivity.high
+    assert repo.get_memory("t1", "u1", m.id).sensitivity is Sensitivity.low
+    assert repo.get_memory("t1", "u1", m.id).revision == m.revision
+
+
+# 4. Creation and edit produce the same evidence vocabulary.
+def test_creation_audit_carries_the_same_classification_evidence_as_an_edit(api_client):
+    client, repo = api_client
+    r = client.post(
+        "/api/chat",
+        json={
+            "tenant_id": "t1",
+            "user_id": "u1",
+            "message": "Remember: my salary is $250,000.",
+        },
+    )
+    assert r.status_code == 200
+    stored = repo.list_memories("t1", "u1")
+    assert stored
+
+    events = client.get(f"/api/memories/{stored[0].id}/audit{_Q}").json()
+    # A sensitive creation is audited as `memory_pending_approval`, a benign one as
+    # `memory_created`; both are creation-path events and must carry the evidence.
+    created = next(
+        e for e in events if e["action"] in ("memory_created", "memory_pending_approval")
+    )
+    meta = created["metadata"]
+    for key in (
+        "sensitivity_categories",
+        "sensitivity_rule_ids",
+        "sensitivity_finding_count",
+    ):
+        assert key in meta, f"creation audit is missing {key} (edits record it)"
+    assert "financial" in meta["sensitivity_categories"]
+    assert "250,000" not in str(meta), "creation audit leaked the matched value"
+
+
+# 5. Memory-control drops are distinguishable from genuine low-utility drops.
+def test_memory_control_drop_carries_a_distinct_reason_code(repo):
+    """Reusing DROP_LOW_UTILITY for both would contaminate utility metrics:
+    'not a memory' and 'a valid memory of low utility' are different outcomes."""
+    from app.db.entities import StoredSettings
+    from app.schemas.memory import CandidateMemory
+    from app.services.policy_broker import (
+        REASON_LOW_UTILITY,
+        REASON_MEMORY_CONTROL,
+        PolicyBroker,
+    )
+
+    settings = StoredSettings(tenant_id="t1", user_id="u1")
+    broker = PolicyBroker(repo)
+
+    control = broker.evaluate(
+        CandidateMemory(
+            content="do not remember my password",
+            type=MemoryType.preference,
+            sensitivity=Sensitivity.low,
+            importance=9,
+            confidence=0.95,
+            reason="x",
+        ),
+        tenant_id="t1",
+        user_id="u1",
+        settings=settings,
+    )
+    assert control.reason_code == REASON_MEMORY_CONTROL
+
+    trivial = broker.evaluate(
+        CandidateMemory(
+            content="the sky is sometimes blue",
+            type=MemoryType.preference,
+            sensitivity=Sensitivity.low,
+            importance=1,
+            confidence=0.5,
+            reason="x",
+        ),
+        tenant_id="t1",
+        user_id="u1",
+        settings=settings,
+    )
+    assert trivial.reason_code == REASON_LOW_UTILITY
+    assert control.reason_code != trivial.reason_code

--- a/services/api/tests/test_sensitivity_classification.py
+++ b/services/api/tests/test_sensitivity_classification.py
@@ -1,0 +1,357 @@
+"""Semantic sensitivity classification, proven on both write paths.
+
+Classification previously matched only *structural* patterns — SSN and card digit
+shapes, API-key formats. Semantic disclosures scored `low` and were stored `active`:
+
+    "my password is hunter2"            -> low / active
+    "my HIV status is positive"         -> low / active
+    "I take sertraline for depression"  -> low / active
+    "my salary is $250,000"             -> low / active
+
+Every downstream control keys off sensitivity — approval gating, the recall gate's
+audience clearance, the admission gate — so for exactly the categories those controls
+exist to protect, they were inert. A plaintext password was retrievable into a
+`public`-audience response.
+
+The parametrised matrix runs each case through **creation** and through an
+**existing-memory content edit**, because the same content must reach the same
+outcome regardless of how it enters the system — that equivalence is precisely what
+the edit path used to break.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.sensitivity import (
+    BLOCK,
+    PENDING_APPROVAL,
+    SAVE,
+    classify,
+    is_memory_control_instruction,
+)
+from app.db.entities import StoredMemory
+from app.schemas.memory import MemoryType, Sensitivity, Source, Status
+
+_Q = "?tenant_id=t1&user_id=u1"
+
+# (text, category, recommended disposition)
+POSITIVE_CASES = [
+    ("my password is hunter2", "credential", BLOCK),
+    ("my PIN is 4281", "credential", BLOCK),
+    ("my recovery code is 782144", "recovery_secret", BLOCK),
+    ("my security answer is bluebird", "credential", BLOCK),
+    ("my HIV status is positive", "medical", PENDING_APPROVAL),
+    ("I was diagnosed with diabetes", "medical", PENDING_APPROVAL),
+    ("I take sertraline for depression", "mental_health", PENDING_APPROVAL),
+    ("my salary is $250,000", "financial", PENDING_APPROVAL),
+    ("I owe $18,000 in credit-card debt", "financial", PENDING_APPROVAL),
+    ("my bank balance is $18,400", "financial", PENDING_APPROVAL),
+    ("my home address is 123 Main Street", "location", PENDING_APPROVAL),
+]
+
+# A sensitive keyword is not a disclosure. These discuss a topic rather than reveal
+# a fact about the speaker, and must not classify as sensitive.
+NEGATIVE_CASES = [
+    "I forgot my password",
+    "I use a password manager",
+    "How should password hashing work?",
+    "Sertraline is a commonly prescribed medication",
+    "I am reading research about HIV",
+    "What is the average software engineer salary?",
+    "This document explains bank routing numbers",
+    "I prefer dark mode dashboards",
+    "my favourite food is ramen",
+]
+
+# Instructions *about* memory, not facts to store.
+MEMORY_CONTROL_CASES = [
+    "do not remember my password",
+    "never save my password",
+    "forget my salary",
+    "do not store my medical information",
+    "I don't want you to remember my address",
+]
+
+
+def _seed(repo, content: str = "prefers dark mode dashboards") -> StoredMemory:
+    return repo.create_memory(
+        StoredMemory(
+            tenant_id="t1",
+            user_id="u1",
+            memory_type=MemoryType.preference,
+            content=content,
+            normalized_content=content.lower(),
+            importance=7,
+            confidence=0.9,
+            sensitivity=Sensitivity.low,
+            status=Status.active,
+            source=Source(kind="chat", excerpt=content),
+        )
+    )
+
+
+# ── layer 1: detection ───────────────────────────────────────────────────────
+@pytest.mark.parametrize(("text", "category", "disposition"), POSITIVE_CASES)
+def test_positive_cases_are_classified(text, category, disposition):
+    a = classify(text)
+    assert a.findings, f"no rule fired for: {text}"
+    assert category in a.categories
+    assert a.recommended_disposition == disposition
+    assert a.sensitivity is Sensitivity.high
+
+
+@pytest.mark.parametrize("text", NEGATIVE_CASES)
+def test_negative_cases_do_not_trigger_on_a_keyword_alone(text):
+    a = classify(text)
+    assert not a.findings, f"false positive on: {text} ({list(a.rule_ids)})"
+    assert a.recommended_disposition == SAVE
+    assert a.sensitivity is Sensitivity.low
+
+
+def test_findings_carry_a_rule_id_and_category_not_the_matched_value():
+    a = classify("my password is hunter2")
+    finding = a.findings[0]
+    assert finding.rule_id == "credential.password_first_person"
+    assert finding.category == "credential"
+    # The value must never appear anywhere in the structured result.
+    assert "hunter2" not in repr(a)
+
+
+def test_precedence_is_deterministic():
+    """BLOCK outranks PENDING_APPROVAL; high outranks medium."""
+    a = classify("my password is hunter2 and I was diagnosed with diabetes")
+    assert a.recommended_disposition == BLOCK
+    assert a.sensitivity is Sensitivity.high
+    assert {"credential", "medical"} <= set(a.categories)
+
+
+def test_classification_is_a_recommendation_not_a_decision():
+    """The assessment names a disposition; only the broker acts on it."""
+    a = classify("my password is hunter2")
+    assert a.recommended_disposition == BLOCK
+    assert not hasattr(a, "decision")
+
+
+# ── layer 3: both write paths agree ──────────────────────────────────────────
+@pytest.mark.parametrize(("text", "category", "disposition"), POSITIVE_CASES)
+def test_creation_path_applies_the_recommendation(api_client, text, category, disposition):
+    client, repo = api_client
+    r = client.post(
+        "/api/chat", json={"tenant_id": "t1", "user_id": "u1", "message": f"Remember: {text}"}
+    )
+    assert r.status_code == 200
+
+    stored = [m for m in repo.list_memories("t1", "u1") if m.status is not Status.deleted]
+    if disposition == BLOCK:
+        assert not any(
+            m.status is Status.active for m in stored
+        ), f"blocked content was stored active: {text}"
+    else:
+        assert stored, f"nothing stored for: {text}"
+        assert all(m.sensitivity is Sensitivity.high for m in stored)
+        assert all(m.status is Status.pending for m in stored)
+
+
+@pytest.mark.parametrize(("text", "category", "disposition"), POSITIVE_CASES)
+def test_edit_path_reaches_the_same_outcome_as_creation(api_client, text, category, disposition):
+    """The equivalence the edit path used to break."""
+    client, repo = api_client
+    m = _seed(repo)
+
+    r = client.patch(
+        f"/api/memories/{m.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "content": text},
+    )
+    after = repo.get_memory("t1", "u1", m.id)
+
+    if disposition == BLOCK:
+        assert r.status_code == 422, f"edit into {category} must be refused: {text}"
+        assert after.content == "prefers dark mode dashboards"
+        assert after.sensitivity is Sensitivity.low
+        assert after.status is Status.active
+    else:
+        assert r.status_code == 200, r.text
+        assert after.content == text
+        assert after.sensitivity is Sensitivity.high
+        assert after.status is Status.pending
+
+
+@pytest.mark.parametrize("text", NEGATIVE_CASES)
+def test_negative_cases_are_editable_without_re_gating(api_client, text):
+    client, repo = api_client
+    m = _seed(repo)
+    r = client.patch(
+        f"/api/memories/{m.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "content": text},
+    )
+    assert r.status_code == 200, f"benign content was gated: {text}"
+    after = repo.get_memory("t1", "u1", m.id)
+    assert after.status is Status.active
+    assert after.sensitivity is Sensitivity.low
+
+
+# ── memory-control instructions store nothing ────────────────────────────────
+@pytest.mark.parametrize("text", MEMORY_CONTROL_CASES)
+def test_memory_control_instructions_are_recognised(text):
+    assert is_memory_control_instruction(text), f"not recognised: {text}"
+
+
+@pytest.mark.parametrize("text", MEMORY_CONTROL_CASES)
+def test_memory_control_instructions_create_no_memory(api_client, text):
+    """The expected result is *no persistent memory*, not a stored high-sensitivity
+    record and not merely a BLOCK verdict — storing the sentence would be the same
+    disclosure by another route."""
+    client, repo = api_client
+    r = client.post("/api/chat", json={"tenant_id": "t1", "user_id": "u1", "message": text})
+    assert r.status_code == 200
+    assert repo.list_memories("t1", "u1") == [], f"a memory was created for: {text}"
+
+
+@pytest.mark.parametrize("text", MEMORY_CONTROL_CASES)
+def test_policy_refuses_a_memory_control_candidate_independently(repo, text):
+    """Second, independent guard: even if a malformed extractor emits a candidate,
+    policy must not store it."""
+    from app.db.entities import StoredSettings
+    from app.schemas.memory import CandidateMemory, Decision
+    from app.services.policy_broker import PolicyBroker
+
+    candidate = CandidateMemory(
+        content=text,
+        type=MemoryType.preference,
+        sensitivity=Sensitivity.low,
+        importance=9,  # high enough that the utility floor cannot be the reason
+        confidence=0.95,
+        reason="malformed extractor output",
+    )
+    outcome = PolicyBroker(repo).evaluate(
+        candidate,
+        tenant_id="t1",
+        user_id="u1",
+        settings=StoredSettings(tenant_id="t1", user_id="u1"),
+    )
+    assert outcome.decision is not Decision.SAVE
+    assert outcome.decision is not Decision.PENDING_APPROVAL
+
+
+# ── audit evidence stays content-free ────────────────────────────────────────
+def test_audit_records_categories_and_rule_ids_but_never_the_value(api_client):
+    client, repo = api_client
+    m = _seed(repo)
+
+    assert (
+        client.patch(
+            f"/api/memories/{m.id}",
+            json={"tenant_id": "t1", "user_id": "u1", "content": "my salary is $250,000"},
+        ).status_code
+        == 200
+    )
+
+    events = client.get(f"/api/memories/{m.id}/audit{_Q}").json()
+    edit = next(e for e in events if e["action"].startswith("memory_content_update"))
+    meta = edit["metadata"]
+    assert "financial" in meta["sensitivity_categories"]
+    assert "financial.amount_first_person" in meta["sensitivity_rule_ids"]
+    assert meta["sensitivity_finding_count"] == 1
+    assert meta["new_sensitivity"] == "high"
+
+    blob = str(meta)
+    for secret in ("250,000", "$250", "salary is"):
+        assert secret not in blob, f"audit metadata leaked the matched value: {secret}"
+
+
+# ── mutation guarantees ──────────────────────────────────────────────────────
+def test_edit_to_a_credential_leaves_every_field_unchanged(api_client):
+    from app.embeddings import embed
+
+    client, repo = api_client
+    m = _seed(repo)
+    m.embedding = embed(m.content)
+    repo.update_memory(m)
+    before = repo.get_memory("t1", "u1", m.id)
+    snapshot = (
+        before.content,
+        list(before.embedding),
+        before.sensitivity,
+        before.status,
+        before.revision,
+    )
+
+    r = client.patch(
+        f"/api/memories/{m.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "content": "my password is hunter2"},
+    )
+    assert r.status_code == 422
+
+    after = repo.get_memory("t1", "u1", m.id)
+    assert (
+        after.content,
+        list(after.embedding),
+        after.sensitivity,
+        after.status,
+        after.revision,
+    ) == snapshot
+
+
+def test_edit_to_a_medical_disclosure_regates_and_re_embeds(api_client):
+    from app.embeddings import embed
+
+    client, repo = api_client
+    m = _seed(repo)
+    m.embedding = embed(m.content)
+    repo.update_memory(m)
+    revision_before = repo.get_memory("t1", "u1", m.id).revision
+    old_embedding = list(repo.get_memory("t1", "u1", m.id).embedding)
+
+    r = client.patch(
+        f"/api/memories/{m.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "content": "I was diagnosed with diabetes"},
+    )
+    assert r.status_code == 200
+
+    after = repo.get_memory("t1", "u1", m.id)
+    assert after.sensitivity is Sensitivity.high
+    assert after.status is Status.pending
+    assert after.embedding != old_embedding
+    assert after.embedding == embed("I was diagnosed with diabetes")
+    assert after.revision == revision_before + 1
+
+
+def test_two_concurrent_sensitive_edits_yield_one_winner(api_client):
+    import threading
+
+    client, repo = api_client
+    m = _seed(repo)
+    start = repo.get_memory("t1", "u1", m.id).revision
+
+    results: list[int] = []
+    barrier = threading.Barrier(2)
+    lock = threading.Lock()
+
+    def _edit(text: str) -> None:
+        barrier.wait(timeout=5)
+        r = client.patch(
+            f"/api/memories/{m.id}",
+            json={
+                "tenant_id": "t1",
+                "user_id": "u1",
+                "content": text,
+                "expected_revision": start,
+            },
+        )
+        with lock:
+            results.append(r.status_code)
+
+    threads = [
+        threading.Thread(target=_edit, args=("I was diagnosed with diabetes",)),
+        threading.Thread(target=_edit, args=("my salary is $250,000",)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert sorted(results) == [200, 409], f"expected one winner, got {results}"
+    after = repo.get_memory("t1", "u1", m.id)
+    assert after.status is Status.pending
+    assert after.revision == start + 1

--- a/services/api/tests/test_structured_memory_extraction.py
+++ b/services/api/tests/test_structured_memory_extraction.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from app.core.config import Settings
 from app.llm import StubProvider, extract_memories
 from app.schemas.memory import MemoryType, Source
@@ -43,3 +45,49 @@ def test_strict_mode_without_fallback_extracts_nothing_on_bad_provider() -> None
     outcome = extract_memories(_Broken(), "Remember that I prefer dark mode.", settings=settings)
     assert outcome.mode == "strict_empty"
     assert outcome.memories == []
+
+
+# ── memory-control instructions produce no candidate ─────────────────────────
+# "do not remember my password" is an instruction *about* memory, not a fact. The
+# extractor declines it before the provider is consulted, so no candidate exists to
+# be blocked later — storing the sentence as a high-sensitivity record would be the
+# same disclosure by another route. The policy broker repeats the check
+# independently (tests/test_sensitivity_classification.py), so an LLM extractor that
+# emits a candidate anyway still cannot store it.
+@pytest.mark.parametrize(
+    "message",
+    [
+        "do not remember my password",
+        "never save my password",
+        "forget my salary",
+        "do not store my medical information",
+        "I don't want you to remember my address",
+    ],
+)
+def test_extractor_emits_no_candidate_for_a_memory_control_instruction(message):
+    from app.services.extractor import Extractor
+
+    candidates = Extractor().extract(message, Source(kind="chat", excerpt=message))
+    assert candidates == [], f"a candidate was extracted from: {message}"
+
+
+def test_extractor_still_extracts_ordinary_facts():
+    """The guard must not suppress normal extraction."""
+    from app.services.extractor import Extractor
+
+    msg = "Remember: I prefer dark mode dashboards."
+    assert Extractor().extract(msg, Source(kind="chat", excerpt=msg)), (
+        "the memory-control guard suppressed a legitimate fact"
+    )
+
+
+def test_a_sensitive_disclosure_is_still_extracted_then_governed():
+    """Detection belongs to the broker, not the extractor.
+
+    The extractor must not silently drop sensitive content — that would hide it
+    from governance. It extracts, and the broker blocks or gates.
+    """
+    from app.services.extractor import Extractor
+
+    msg = "Remember: my HIV status is positive."
+    assert Extractor().extract(msg, Source(kind="chat", excerpt=msg))


### PR DESCRIPTION
Makes the enforcement path from #102 reach the correct decision for real-world sensitive language.

## The gap

Classification matched only *structural* patterns — SSN and card digit shapes, API-key formats. Semantic disclosures scored `low` and were stored `active`:

| Content | Before | After |
| --- | --- | --- |
| `my password is hunter2` | low / active | **blocked, never stored** |
| `my HIV status is positive` | low / active | high / pending approval |
| `I take sertraline for depression` | low / active | high / pending approval |
| `my salary is $250,000` | low / active | high / pending approval |

Every downstream control keys off sensitivity — approval gating, the recall gate's audience clearance, the admission gate — so for exactly the categories those controls exist to protect, they were inert.

Verified before the change, with both gates enabled: asking *"what is my password?"* with `audience: "public"` returned the credential and its full source excerpt, `blocked: 0`. After: the password is never stored, the HIV disclosure is `high`/`pending`, and nothing reaches the public audience.

## Three separate responsibilities

1. **Detection** — `app/core/sensitivity.py` emits `SensitivityFinding(category, rule_id, sensitivity, recommended_disposition, confidence)`. Content-free: a finding names *what* matched, never the value.
2. **Aggregation** — `SensitivityAssessment` applies deterministic precedence: `BLOCK > PENDING_APPROVAL > SAVE`, `high > medium > low`.
3. **Policy** — the broker decides, applying tenant settings, approval configuration, the governance profile, consent, and temporary-chat behaviour. The classifier recommends and never stores or refuses, so the scanner does not become a second policy broker.

## Category policy

**BLOCK:** passwords / PINs / security answers, recovery codes and seed phrases, API keys and tokens, payment card and bank account numbers, government identifiers.
**High + approval:** medical, mental health, financial condition, precise private location, biometrics.
**Low + save:** ordinary preferences.

## A keyword is not a disclosure

Rules require first-person ownership **and** a disclosure verb **and** a value or condition, plus a framing guard for questions and educational text. Permanent negative cases:

```
I forgot my password                     I use a password manager
How should password hashing work?        Sertraline is a commonly prescribed medication
I am reading research about HIV          What is the average software engineer salary?
This document explains bank routing numbers
```

## Memory-control instructions store nothing

`do not remember my password`, `forget my salary`, `I don't want you to remember my address` are instructions *about* memory, not facts. The outcome is **no persistent memory** — not a stored high-sensitivity record (the same disclosure by another route) and not merely a `BLOCK` verdict.

Two independent guards: the extractor emits no candidate, and the broker refuses one anyway — so a malformed or LLM-provided extractor still cannot store it. Tested both ways, including feeding the broker a hand-built candidate with `importance=9` so the utility floor cannot be the reason it is refused.

## Both write paths agree

Every positive case runs through **creation** and through an **existing-memory content edit**, asserting the same classification and disposition. That equivalence is exactly what the edit path used to break.

## Behaviour change for review

`my ssn is …` now **BLOCK**s rather than being approval-gated, per the category policy. Three existing tests encoded the weaker outcome and were updated; a new test pins the BLOCK explicitly, and the approval-gated path is now covered by a medical case.

## Audit evidence

`sensitivity_categories`, `sensitivity_rule_ids`, `sensitivity_finding_count`, final sensitivity and disposition, policy version. A test asserts the matched value (`250,000`, `$250`, `salary is`) never appears in audit metadata.

## Mutation guarantees

- edit → credential ⇒ 422, and content, embedding, sensitivity, status **and revision** all byte-identical
- edit → medical ⇒ 200, sensitivity `high`, status `pending`, new embedding matches the new content, revision +1
- two concurrent sensitive edits with the same revision ⇒ one 200, one 409

## Limits, stated plainly

**Deterministic semantic-pattern and structural sensitivity classification.** Not comprehensive medical, financial, or credential understanding — no ontology, no model, no inference beyond the written rules. Pattern rules miss paraphrase, other languages, obfuscation, and unusual phrasing: a rule that fires is high-confidence, but **silence is not evidence of safety**. Broadening recall belongs with evaluation evidence, not more unreviewed regexes.

## Gate

- 73 new tests; 625 passed, 3 skipped
- ruff clean on `app`
- Evals PASS, benchmark PASS
- PR invariant evidence gate PASS (5 armed rules)
- Diff scanned for secret-shaped literals before push (0), per the #102 gitleaks lesson

## Out of scope

Sparse+dense retrieval, embedding lifecycle columns, re-embedding worker, API RBAC, trace-response redaction, external/LLM classifiers, full medical ontology, explicit transition endpoints, and the duplicate-file CI guard (separate PR).