### PR TITLE
fix(ops): remove unused Redis and make readiness truthful (recovers #99)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,9 +29,6 @@ POSTGRES_HOST=db
 POSTGRES_PORT=5432
 DATABASE_URL=postgresql+psycopg://memoryops:memoryops@db:5432/memoryops
 
-# Redis (session/working memory cache; optional in Phase 1)
-REDIS_URL=redis://redis:6379/0
-
 # LLM provider adapter. Leave provider=heuristic to run with NO API keys.
 # provider options: heuristic | openai | anthropic | gemini
 LLM_PROVIDER=heuristic

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,8 +83,9 @@ docker compose up --build
 ## Deployment workflow (Railway-only — v0.3.2)
 
 Deployment target is **Railway only**. Do **not** add or suggest a Vercel path.
-One project (`memoryops-ai`), five services: `memoryops-web`, `memoryops-api`,
-`memoryops-worker`, Railway Postgres (+pgvector), Railway Redis.
+One project (`memoryops-ai`), four services: `memoryops-web`, `memoryops-api`,
+`memoryops-worker`, Railway Postgres (+pgvector). Redis was removed — it was
+declared and health-gated but no runtime code ever read `REDIS_URL`.
 
 - Config-as-code lives in `railway/{api,web,worker}.railway.json`; point each
   Railway service at its file. Builder is `DOCKERFILE`.
@@ -92,8 +93,10 @@ One project (`memoryops-ai`), five services: `memoryops-web`, `memoryops-api`,
   repo root. Full settings + deploy order: `docs/deployment/railway.md`.
 - Env var contract per service: `docs/deployment/railway-env.md`. The system runs
   with **no provider keys** (heuristic LLM + stub embeddings); set
-  `MEMORYOPS_STORAGE=postgres`, `DATABASE_URL`, `REDIS_URL` for production, and
-  build-time `NEXT_PUBLIC_API_URL` for web.
+  `MEMORYOPS_PROFILE=production`, `MEMORYOPS_STORAGE=postgres`, `DATABASE_URL`,
+  `MEMORYOPS_AUTH_MODE`, `MEMORYOPS_CORS_ALLOW_ORIGINS` for production, and
+  build-time `NEXT_PUBLIC_API_URL` for web. The production profile is fail-closed:
+  missing/unsafe values stop startup rather than degrading silently.
 - After deploy, run `scripts/railway_smoke_test.py` (see
   `docs/deployment/railway-smoke-test.md`).
 - When changing deployment, update `railway/`, the three `docs/deployment/*`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,23 +18,12 @@ services:
       timeout: 5s
       retries: 10
 
-  redis:
-    image: redis:7-alpine
-    ports:
-      - "6379:6379"
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-
   api:
     build:
       context: ./services/api
     environment:
       MEMORYOPS_STORAGE: postgres
       DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-memoryops}:${POSTGRES_PASSWORD:-memoryops}@db:5432/${POSTGRES_DB:-memoryops}
-      REDIS_URL: redis://redis:6379/0
       LLM_PROVIDER: ${LLM_PROVIDER:-heuristic}
       EMBEDDINGS_PROVIDER: ${EMBEDDINGS_PROVIDER:-heuristic}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
@@ -42,8 +31,6 @@ services:
       - "8000:8000"
     depends_on:
       db:
-        condition: service_healthy
-      redis:
         condition: service_healthy
 
   worker:
@@ -53,11 +40,8 @@ services:
     environment:
       MEMORYOPS_STORAGE: postgres
       DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-memoryops}:${POSTGRES_PASSWORD:-memoryops}@db:5432/${POSTGRES_DB:-memoryops}
-      REDIS_URL: redis://redis:6379/0
     depends_on:
       db:
-        condition: service_healthy
-      redis:
         condition: service_healthy
 
   web:

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -277,14 +277,34 @@ See [docs/enterprise-evidence.md](enterprise-evidence.md), ADR-024.
   (v2.3, ADR-027). When that connection is unconfigured it returns
   `{ healthy: null, detail: "operational access not configured", hint: … }` — an
   actionable, non-fatal state, not a `500`.
-- `GET /readyz` → `{ ready, profile, storage, llm_provider, embeddings_provider,
-  embedding_dim, detail, checks }` (v2.3). `checks` is a per-dependency map —
-  `storage`, `schema`, `vector_backend`, `worker_runtime`, `llm_provider`,
-  `embedding_provider` — each `{ status: ok|skipped|error, … }`; `ready` is false iff
-  any dependency is in `error` (a `skipped`, unselected backend never blocks it). The
-  pre-v2.3 top-level fields (`storage`, `llm_provider`, `embeddings_provider`,
-  `embedding_dim`, `detail`) are **retained** alongside `profile`/`checks` so the
-  response stays additive under the `1.x` promise. Every probe is no-throw.
+- `GET /readyz` → `{ ready, degraded, profile, storage, llm_provider,
+  embeddings_provider, embedding_dim, detail, checks }`. `checks` is a per-dependency
+  map — `storage`, `schema`, `vector_backend`, `worker_runtime`, `llm_provider`,
+  `embedding_provider` — each `{ status: ok|degraded|error|skipped, reason_code?, … }`.
+  `ready` is false iff any dependency is in `error` (a `skipped`, unselected backend
+  never blocks it); `degraded` is true iff any dependency is `degraded` — a new
+  top-level boolean, additive under the `1.x` promise.
+
+  **Provider checks report capability, not configuration.** `llm_provider` and
+  `embedding_provider` previously returned a hardcoded `ok` derived from the
+  configured provider *name*, so `MEMORYOPS_LLM_PROVIDER=openai` with no key and no
+  SDK reported fully green while every request was served by the deterministic stub.
+  `vector_backend` likewise reported `ok` for any external backend. They now verify
+  key + SDK presence, and the vector probe calls the backend's real `available()`.
+  Severity is profile-aware: selected-but-unusable is `degraded` in `dev` (the
+  fallback is the intended offline experience) and `error` in `production`.
+  `worker_runtime` also reports freshness — `worker_heartbeat_stale` (an `error`)
+  once the newest run is older than three scheduler intervals, so a silently dead
+  worker no longer reports `ok` indefinitely.
+
+  Responses carry a `reason_code` (`missing_api_key`, `sdk_not_installed`,
+  `client_not_installed`, `backend_unreachable`, `probe_failed`, `probe_raised`,
+  `worker_heartbeat_stale`, `dead_lettered_jobs`, `no_runs_recorded`) and never a
+  key, DSN, or raw provider error. The pre-v2.3 top-level fields (`storage`,
+  `llm_provider`, `embeddings_provider`, `embedding_dim`, `detail`) are **retained**
+  alongside `profile`/`checks`. Every probe is no-throw *and* individually wrapped,
+  so `/readyz` — the endpoint operators hit when things are broken — cannot itself
+  return a `500`.
 - `GET /metrics` → **Prometheus text exposition** (v1.1; format `0.0.4`). Process-wide,
   content-free, low-cardinality (no `tenant_id`/`user_id` labels): HTTP traffic,
   retrieval latency/mode, policy-decision rate, worker run counts. Toggle with

--- a/docs/deployment/railway-env.md
+++ b/docs/deployment/railway-env.md
@@ -5,9 +5,11 @@ Every variable consumed by MemoryOps AI, per service. Settings are typed in
 (`env_prefix=""`, so each field maps to its **UPPERCASE** name) plus the
 explicit `MEMORYOPS_*` aliases resolved in `get_settings()`.
 
-`DATABASE_URL` and `REDIS_URL` are provided automatically when you reference the
-Railway Postgres / Redis plugins — use Railway's **variable references** rather
-than copying values.
+`DATABASE_URL` is provided automatically when you reference the Railway Postgres
+plugin — use Railway's **variable references** rather than copying values.
+
+> Redis is no longer part of the topology: `REDIS_URL` was declared and health-gated
+> but never read by any runtime code. See [railway.md](railway.md).
 
 ## `memoryops-api`
 
@@ -16,7 +18,11 @@ than copying values.
 | `PORT` | auto | — | Injected by Railway; bind uvicorn to it. |
 | `MEMORYOPS_STORAGE` | ✅ | `memory` | Set to `postgres` in production. |
 | `DATABASE_URL` | ✅ (postgres) | local dsn | `postgresql+psycopg://…`. Reference the Postgres plugin. |
-| `REDIS_URL` | ✅ | `redis://localhost:6379/0` | Reference the Redis plugin. |
+| `MEMORYOPS_PROFILE` | ✅ (prod) | `dev` | Set to `production`; fail-closed startup checks. |
+| `MEMORYOPS_AUTH_MODE` | ✅ (prod) | `none` | `jwt` or `trusted_header`; `none` is rejected in production. |
+| `MEMORYOPS_CORS_ALLOW_ORIGINS` | ✅ (prod) | `*` | Explicit origin list; `*` is rejected in production. |
+| `MEMORYOPS_PUBLIC_EVALS` | ✅ (prod) | `false` | Must stay `false` (denial-of-wallet vector). |
+| `OPERATIONAL_DATABASE_URL` | — | *(unset)* | Restricted monitoring role; enables `/healthz/workers`. Fails closed when unset. |
 | `LLM_PROVIDER` | — | `heuristic` | `heuristic` needs no keys (v0.3.x). `openai`/`anthropic`/`gemini` land in v0.4. |
 | `MEMORYOPS_EMBEDDING_PROVIDER` | — | `stub` | `stub` is deterministic/offline; `openai` needs a key. |
 | `EMBEDDING_DIM` | — | `1536` | Must match the pgvector column dimension. |
@@ -64,7 +70,7 @@ than copying values.
 |----------|----------|---------|-------|
 | `MEMORYOPS_STORAGE` | ✅ | `memory` | Set to `postgres` to share the API store. |
 | `DATABASE_URL` | ✅ (postgres) | local dsn | Reference the Postgres plugin. |
-| `REDIS_URL` | ✅ | `redis://localhost:6379/0` | Reference the Redis plugin. |
+| `MEMORYOPS_WORKER_SCOPES` | ✅ | `tenant_demo:user_demo` | `"tenant:user,…"` scopes to process. |
 | `WORKER_INTERVAL_SECONDS` | — | `60` | Scheduler tick interval. |
 
 ## Railway Postgres plugin
@@ -72,22 +78,40 @@ than copying values.
 Provides `DATABASE_URL` (and `PGHOST`/`PGPORT`/`PGUSER`/`PGPASSWORD`/`PGDATABASE`).
 MemoryOps uses `DATABASE_URL` with the `postgresql+psycopg://` driver prefix —
 if the plugin emits a bare `postgres://`, set `DATABASE_URL` explicitly with the
-`+psycopg` prefix. Enable the `vector` extension and apply
-`infra/db/migrations/001…005` in order.
+`+psycopg` prefix. Enable the `vector` extension, then apply **every** file in
+`infra/db/migrations` in lexical order:
 
-## Railway Redis plugin
+```bash
+for f in infra/db/migrations/*.sql; do
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"
+done
+```
 
-Provides `REDIS_URL`. Used for queue/cache; the worker and API both reference it.
+Do not hand-maintain a migration range here. This page previously said `001…005`
+and the deployment guide said `001…007`, while the repository had migrations
+through `011` — two different stale answers, both producing an incomplete schema.
 
 ## Minimum production set
 
-The smallest working production config:
+`MEMORYOPS_PROFILE=production` is fail-closed, so this is the smallest config that
+actually **boots**. The previous version of this list omitted the profile, auth,
+CORS, and evals variables that the profile itself requires.
 
 ```
-# api + worker
+# api
+MEMORYOPS_PROFILE=production
+MEMORYOPS_STORAGE=postgres
+MEMORYOPS_AUTH_MODE=jwt                       # or trusted_header
+MEMORYOPS_CORS_ALLOW_ORIGINS=https://memoryops-web.up.railway.app
+MEMORYOPS_PUBLIC_EVALS=false
+DATABASE_URL=<reference Postgres plugin, +psycopg prefix>
+OPERATIONAL_DATABASE_URL=<restricted monitoring role>
+
+# worker
+MEMORYOPS_PROFILE=production
 MEMORYOPS_STORAGE=postgres
 DATABASE_URL=<reference Postgres plugin, +psycopg prefix>
-REDIS_URL=<reference Redis plugin>
+MEMORYOPS_WORKER_SCOPES=<tenant:user,…>
 
 # web
 NEXT_PUBLIC_API_URL=https://memoryops-api.up.railway.app

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -18,11 +18,19 @@ networking, and the deploy story in a single place.
 | 2 | `memoryops-api` | FastAPI backend | `services/api/Dockerfile` | `GET /healthz`, `GET /readyz` |
 | 3 | `memoryops-worker` | Background jobs (decay/reflection/learning loop) | `services/worker/Dockerfile` | process liveness (no HTTP) |
 | 4 | Railway **Postgres** | Primary store + pgvector | Railway plugin | managed |
-| 5 | Railway **Redis** | Queue / cache | Railway plugin | managed |
 
-All five run inside the same project so they share Railway's private network and
-reference each other through Railway-provided variables (e.g. `DATABASE_URL`,
-`REDIS_URL`). See [railway-env.md](railway-env.md) for the full variable matrix.
+All four run inside the same project so they share Railway's private network and
+reference each other through Railway-provided variables (e.g. `DATABASE_URL`).
+See [railway-env.md](railway-env.md) for the full variable matrix.
+
+> **Redis was removed from the topology.** It was previously listed as a required
+> fifth service, started by Compose, and health-gated by both the API and the worker
+> — but no runtime code ever read `REDIS_URL`, and no Redis client was imported
+> anywhere in the repo. A declared-but-unused dependency is pure cost: another
+> managed service to pay for, another health check that can fail a deploy, and a
+> misleading architecture diagram. Reinstate it when something actually uses it
+> (distributed rate limiting, job queueing, caching, pub/sub, cross-replica
+> coordination).
 
 ## Config-as-code
 
@@ -75,16 +83,54 @@ config files is resolved relative to the service **Root Directory**.
 
 Provision and deploy in this order so dependencies are ready:
 
-1. **Postgres** plugin — then run migrations from `infra/db/migrations` (apply
-   `001…007` in order; `007_retention_legal_hold_consent.sql` is the latest).
-2. **Redis** plugin.
-3. **`memoryops-api`** — set `MEMORYOPS_STORAGE=postgres`, `DATABASE_URL`,
-   `REDIS_URL`. Wait for `/readyz` to report `ready: true`.
-4. **`memoryops-worker`** — same `DATABASE_URL` / `REDIS_URL` / `MEMORYOPS_STORAGE`.
-5. **`memoryops-web`** — set `NEXT_PUBLIC_API_URL` to the public API domain, then
+1. **Postgres** plugin — then apply every migration in `infra/db/migrations` in
+   lexical order:
+
+   ```bash
+   for f in infra/db/migrations/*.sql; do
+     echo "-- applying $f"
+     psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"
+   done
+   ```
+
+   Do **not** hand-maintain a migration list here. This guide previously said to
+   apply `001…007` and called `007_retention_legal_hold_consent.sql` "the latest"
+   while the repository had migrations through `011` — following it produced a
+   database missing the scope-id, operational-evidence, transactional audit-chain,
+   and chain-head schema. The glob above cannot go stale.
+
+2. **`memoryops-api`** — set the production variables below. Wait for `/readyz` to
+   report `ready: true` (and check `degraded: false`).
+3. **`memoryops-worker`** — same `DATABASE_URL` / `MEMORYOPS_STORAGE`, plus
+   `MEMORYOPS_WORKER_SCOPES`.
+4. **`memoryops-web`** — set `NEXT_PUBLIC_API_URL` to the public API domain, then
    deploy (build-time inline).
 
-After all five are up, run the smoke test
+### Minimum production variables
+
+`MEMORYOPS_PROFILE=production` is fail-closed: the API refuses to start if any of
+these is unsafe (`Settings.production_readiness_errors`). The previous "minimum
+set" in this guide omitted several values the profile itself requires, so following
+it produced a service that would not boot.
+
+```bash
+MEMORYOPS_PROFILE=production
+MEMORYOPS_STORAGE=postgres
+MEMORYOPS_AUTH_MODE=jwt              # or trusted_header; 'none' is rejected
+MEMORYOPS_CORS_ALLOW_ORIGINS=https://<your-web-domain>   # '*' is rejected
+MEMORYOPS_PUBLIC_EVALS=false
+DATABASE_URL=<reference the Postgres plugin>
+OPERATIONAL_DATABASE_URL=<restricted monitoring role>    # enables /healthz/workers
+MEMORYOPS_WORKER_SCOPES=<tenant:user,…>                  # worker service
+NEXT_PUBLIC_API_URL=https://<your-api-domain>            # web service, build-time
+```
+
+If you select a networked provider, its SDK ships in the production image but the
+key must be set — `MEMORYOPS_LLM_PROVIDER=openai` without `OPENAI_API_KEY` is a
+startup error in this profile rather than a silent downgrade to the stub. See
+[dependency-management.md](../dependency-management.md).
+
+After all four are up, run the smoke test
 ([railway-smoke-test.md](railway-smoke-test.md)).
 
 ## Optional: Playground demo service (v0.12)

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -61,21 +61,57 @@ remain, instead of silently serving production traffic with them. It rejects:
 | open CORS (`*`) | `MEMORYOPS_CORS_ALLOW_ORIGINS=https://app.example.com,…` |
 | bundled demo DB credentials / `localhost` DSN | real `MEMORYOPS_DATABASE_URL` / `DATABASE_URL` |
 | `MEMORYOPS_PUBLIC_EVALS=true` (denial-of-wallet) | `MEMORYOPS_PUBLIC_EVALS=false` |
+| networked `llm_provider`/`embeddings_provider` with no API key or SDK | set the key, install the extra, or select `stub` |
+| external `vector_index` whose client isn't installed | `pip install 'memoryops-api[qdrant\|lancedb\|weaviate]'` |
+
+The last two exist because every provider adapter imports its SDK lazily and
+degrades to the stub when it is absent. That is correct for dev and required for
+offline tests, but in production it meant an operator could select OpenAI, see a
+healthy service, and be served deterministic stub output indefinitely — with only a
+log line. See [dependency-management.md](dependency-management.md).
 
 The check is enforced only under the production profile (`dev` is unchanged) and is
 implemented in `Settings.production_readiness_errors()` — see `tests/test_production_profile.py`.
 
-**Readiness** (`GET /readyz`) reports **dependency-specific** states rather than one
-combined string: `storage`, `schema` (migration revision), `vector_backend`,
-`worker_runtime`, `llm_provider`, `embedding_provider` — each `ok` / `skipped` /
-`error`. `ready` is false iff any dependency is in `error` (a `skipped` backend that
-isn't selected never blocks readiness). Every probe is no-throw (invariant #4).
+### Readiness (`GET /readyz`)
+
+Reports **dependency-specific** states rather than one combined string: `storage`,
+`schema` (migration revision), `vector_backend`, `worker_runtime`, `llm_provider`,
+`embedding_provider`.
+
+| Status | Meaning | Blocks `ready`? |
+|--------|---------|-----------------|
+| `ok` | usable | no |
+| `degraded` | selected but falling back (dev), or dead-lettered work present | no — surfaces as top-level `degraded: true` |
+| `error` | selected and unusable, or a probe failed | **yes** |
+| `skipped` | not selected / not applicable | no |
+
+Severity is profile-aware: a selected-but-unusable provider is `degraded` in dev
+(the fallback is the intended offline experience) and `error` in production (the
+deployment asked for it).
+
+`llm_provider` and `embedding_provider` previously reported `ok` from the configured
+*name* alone, and `vector_backend` reported `ok` for any external backend with a note
+that it "degrades to keyword-only if unreachable" — so a missing key, a missing SDK,
+or a wrong Qdrant URL all looked green while requests were silently served by the
+stub or by keyword-only ranking. They now verify key + SDK presence, and the vector
+probe calls the backend's real `available()` check.
+
+`worker_runtime` additionally reports **freshness**: a worker that died silently used
+to keep reporting `ok` forever, because the probe only asked whether *past* runs had
+failed. It now errors when the newest run is older than three scheduler intervals
+(`worker_heartbeat_stale`).
+
+Every probe is no-throw and each is additionally wrapped, so `/readyz` — the endpoint
+operators hit when things are broken — cannot itself 500. Responses carry a
+`reason_code`, never a key, DSN, or raw provider error.
 
 ## Deploying
 
-Railway-only: one project, five core services (web/api/worker + Postgres + Redis).
-Run migrations from `infra/db/migrations`; set `MEMORYOPS_STORAGE=postgres` and
-`MEMORYOPS_PROFILE=production`.
+Railway-only: one project, four core services (web/api/worker + Postgres). Redis
+was removed — it was declared and health-gated but no runtime code ever read it.
+Apply **every** migration in `infra/db/migrations` (glob the directory; do not follow
+a hardcoded range); set `MEMORYOPS_STORAGE=postgres` and `MEMORYOPS_PROFILE=production`.
 Configure authentication: either enable a built-in auth adapter
 (`MEMORYOPS_AUTH_MODE=jwt` or `trusted_header`, which verify identity and enforce
 tenant/user scope — see [auth-adapters.md](auth-adapters.md)), or, with the default

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -40,7 +40,6 @@ docker compose up --build
 # web  → http://localhost:3000
 # api  → http://localhost:8000/docs
 # db   → localhost:5432 (postgres/pgvector)
-# redis→ localhost:6379
 ```
 
 Compose runs migrations from `infra/db/migrations` on first boot and sets

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -132,7 +132,14 @@ class Settings(BaseSettings):
     # request-scoped, RLS-enforced connection. See docs/worker-runtime.md.
     operational_database_url: str = ""
 
-    redis_url: str = "redis://localhost:6379/0"
+    # NOTE: `redis_url` was removed. Redis was declared here, started by Compose, and
+    # listed as a required Railway service, but no runtime code ever read it — no
+    # client was imported anywhere in the repo. A declared-but-unused infrastructure
+    # dependency is pure cost: another managed service to pay for, another health
+    # check that can fail the deploy, and a misleading architecture diagram. Reinstate
+    # it when something actually uses it (distributed rate limiting, job queueing,
+    # caching, pub/sub, cross-replica coordination). `extra="ignore"` above means a
+    # leftover REDIS_URL in an existing environment is harmlessly ignored.
 
     # LLM + embeddings. "stub" requires no API keys and keeps the system fully
     # functional offline (graceful degradation, invariant #4). "heuristic" is a

--- a/services/api/app/routes/health.py
+++ b/services/api/app/routes/health.py
@@ -70,22 +70,26 @@ def readyz() -> dict:
     """
     settings = get_settings()
     checks: dict[str, dict] = {
-        "storage": _check_storage(settings),
-        "schema": _check_schema(settings),
-        "vector_backend": _check_vector_backend(settings),
-        "worker_runtime": _check_worker_runtime(settings),
-        "llm_provider": {"status": "ok", "provider": settings.llm_provider},
-        "embedding_provider": {
-            "status": "ok",
-            "provider": settings.embeddings_provider,
-            "dim": settings.embedding_dim,
-        },
+        name: _safe_check(name, probe, settings)
+        for name, probe in (
+            ("storage", _check_storage),
+            ("schema", _check_schema),
+            ("vector_backend", _check_vector_backend),
+            ("worker_runtime", _check_worker_runtime),
+            ("llm_provider", _check_llm_provider),
+            ("embedding_provider", _check_embedding_provider),
+        )
     }
     ready = all(c["status"] != "error" for c in checks.values())
+    degraded = any(c["status"] == "degraded" for c in checks.values())
     errored = [name for name, c in checks.items() if c["status"] == "error"]
-    detail = "ready" if ready else "not ready: " + ", ".join(errored)
+    if ready:
+        detail = "ready (degraded)" if degraded else "ready"
+    else:
+        detail = "not ready: " + ", ".join(errored)
     return {
         "ready": ready,
+        "degraded": degraded,
         "profile": settings.profile,
         # ── retained pre-v2.3 top-level fields (additive-compat) ──────────────
         "storage": settings.storage,
@@ -96,6 +100,88 @@ def readyz() -> dict:
         # ── v2.3 dependency-specific view ─────────────────────────────────────
         "checks": checks,
     }
+
+
+# ── provider readiness ───────────────────────────────────────────────────────
+# These used to report {"status": "ok"} from the *configured name* alone, so an
+# operator who set MEMORYOPS_LLM_PROVIDER=openai saw a green probe whether or not a
+# key or SDK was present — while every request was silently served by the stub. The
+# adapters import their SDKs lazily and degrade on purpose, which is right for dev
+# and for offline tests, but it must be visible rather than asserted away.
+#
+# Severity depends on the profile: in production a selected-but-unusable provider is
+# an `error` (the deployment asked for it); in dev it is `degraded` (the fallback is
+# the intended experience). Secrets and raw provider errors are never exposed —
+# only a `reason_code`.
+_LLM_SDK_MODULES = {
+    # provider -> (module the adapter imports, install extra)
+    "openai": ("openai", "openai"),
+    "anthropic": ("anthropic", "anthropic"),
+    # Legacy SDK: app/llm/gemini_provider.py imports google.generativeai.
+    "gemini": ("google.generativeai", "gemini"),
+}
+
+
+def _module_missing(module: str) -> bool:
+    from importlib.util import find_spec
+
+    try:
+        return find_spec(module) is None
+    except (ImportError, ValueError):  # namespace/partial install
+        return True
+
+
+def _provider_fault(settings, reason_code: str, **extra) -> dict:
+    """A selected provider that cannot actually serve: error in prod, degraded in dev."""
+    status = "error" if settings.profile == "production" else "degraded"
+    return {"status": status, "reason_code": reason_code, "fallback": "stub", **extra}
+
+
+def _check_llm_provider(settings) -> dict:
+    provider = settings.llm_provider
+    if provider not in _LLM_SDK_MODULES:  # stub / heuristic
+        return {"status": "ok", "provider": provider}
+    module, extra = _LLM_SDK_MODULES[provider]
+    key = {
+        "openai": settings.openai_api_key,
+        "anthropic": settings.anthropic_api_key,
+        "gemini": settings.gemini_api_key,
+    }[provider]
+    if not key:
+        return _provider_fault(settings, "missing_api_key", provider=provider)
+    if _module_missing(module):
+        return _provider_fault(
+            settings, "sdk_not_installed", provider=provider, install_extra=extra
+        )
+    # Deliberately no live call: a readiness probe must stay fast and must not spend
+    # tokens or rate limit on every scrape. Configuration is verified, not liveness.
+    return {"status": "ok", "provider": provider, "liveness": "not_probed"}
+
+
+def _check_embedding_provider(settings) -> dict:
+    provider = settings.embeddings_provider
+    base = {"provider": provider, "dim": settings.embedding_dim}
+    if provider != "openai":
+        return {"status": "ok", **base}
+    if not settings.openai_api_key:
+        return _provider_fault(settings, "missing_api_key", **base)
+    if _module_missing("openai"):
+        return _provider_fault(settings, "sdk_not_installed", install_extra="openai", **base)
+    return {"status": "ok", "liveness": "not_probed", **base}
+
+
+def _safe_check(name: str, probe, settings) -> dict:
+    """Run one probe, converting any escape into an `error` state.
+
+    Each probe already owns a no-throw contract, but readiness is exactly the
+    endpoint an operator hits when things are broken — it must never be the thing
+    that 500s. Only the exception *type* is surfaced, never its message, which could
+    carry a DSN or key.
+    """
+    try:
+        return probe(settings)
+    except Exception as exc:  # noqa: BLE001 — readiness must not raise
+        return {"status": "error", "reason_code": "probe_raised", "detail": type(exc).__name__}
 
 
 def _check_storage(settings) -> dict:
@@ -122,15 +208,55 @@ def _check_schema(settings) -> dict:
 
 
 def _check_vector_backend(settings) -> dict:
-    if settings.vector_index == "memory":
-        return {"status": "ok", "backend": "memory"}
-    # External backends degrade to keyword-only if unreachable (never fatal), so this
-    # is informational: report the selected backend without failing readiness.
-    return {
-        "status": "ok",
-        "backend": settings.vector_index,
-        "note": "degrades to keyword-only if unreachable",
-    }
+    """Report whether the selected index is actually usable, not merely selected.
+
+    This previously returned ``ok`` for every external backend with a note that it
+    "degrades to keyword-only if unreachable" — so an operator running Qdrant with
+    the wrong URL, or without ``qdrant-client`` installed at all, saw a green probe
+    while every query silently fell back to keyword-only ranking. ``VectorIndex``
+    exposes a real ``available()`` check; use it.
+    """
+    backend = settings.vector_index
+    if backend == "memory":
+        return {"status": "ok", "backend": backend}
+
+    client_module = {
+        "qdrant": "qdrant_client",
+        "lancedb": "lancedb",
+        "weaviate": "weaviate",
+    }.get(backend)
+    if client_module and _module_missing(client_module):
+        return _provider_fault(
+            settings,
+            "client_not_installed",
+            backend=backend,
+            install_extra=backend,
+            fallback="keyword_only",
+        )
+
+    try:
+        from ..db.vector.factory import create_vector_index
+
+        index = create_vector_index(
+            backend,
+            url=settings.vector_index_url,
+            uri=settings.vector_index_uri,
+            api_key=settings.vector_index_api_key,
+            collection=settings.vector_index_collection,
+        )
+        if not index.available():
+            return _provider_fault(
+                settings, "backend_unreachable", backend=backend, fallback="keyword_only"
+            )
+    except Exception as exc:  # noqa: BLE001 — readiness must not raise
+        return _provider_fault(
+            settings,
+            "probe_failed",
+            backend=backend,
+            fallback="keyword_only",
+            detail=type(exc).__name__,
+        )
+    return {"status": "ok", "backend": backend}
 
 
 def _check_worker_runtime(settings) -> dict:
@@ -143,13 +269,59 @@ def _check_worker_runtime(settings) -> dict:
     from ..workers.orchestrator import summarize_runtime_health
 
     try:
-        summary = summarize_runtime_health(get_repository(), limit=1)
-        return {
+        summary = summarize_runtime_health(
+            get_repository(), limit=settings.worker_run_history_limit
+        )
+        result = {
             "status": "ok",
             "dead_letter_count": summary.get("dead_letter_count", 0),
             "failed_count": summary.get("failed_count", 0),
         }
+        # Freshness. A worker that died silently kept reporting `ok` here forever,
+        # because the check only asked whether *past* runs had failed — never
+        # whether the worker was still running at all. Stale beyond a few intervals
+        # means lifecycle work (decay, retention, compaction) has stopped.
+        staleness = _worker_staleness_seconds(summary)
+        if staleness is None:
+            result.update(status="degraded", reason_code="no_runs_recorded")
+            return result
+        result["last_run_age_seconds"] = round(staleness)
+        budget = max(settings.worker_interval_seconds, 1) * _STALE_INTERVALS
+        result["stale_after_seconds"] = budget
+        if staleness > budget:
+            result.update(status="error", reason_code="worker_heartbeat_stale")
+        elif summary.get("dead_letter_count", 0) > 0:
+            # Dead-lettered work is real, replayable work that was given up on.
+            result.update(status="degraded", reason_code="dead_lettered_jobs")
+        return result
     except OperationalAccessUnavailable:
         return {"status": "skipped", "detail": "operational access not configured"}
     except Exception as exc:  # noqa: BLE001
         return {"status": "error", "detail": type(exc).__name__}
+
+
+# How many scheduling intervals may pass with no worker run before the runtime is
+# considered stale. Three tolerates one missed pass plus jitter without flapping.
+_STALE_INTERVALS = 3
+
+
+def _worker_staleness_seconds(summary: dict) -> float | None:
+    """Age of the most recent run across scopes, or None when nothing has run."""
+    from datetime import UTC, datetime
+
+    newest: datetime | None = None
+    for entry in summary.get("last_run_per_scope", {}).values():
+        raw = entry.get("started_at")
+        if not raw:
+            continue
+        try:
+            started = datetime.fromisoformat(raw)
+        except (TypeError, ValueError):
+            continue
+        if started.tzinfo is None:
+            started = started.replace(tzinfo=UTC)
+        if newest is None or started > newest:
+            newest = started
+    if newest is None:
+        return None
+    return (datetime.now(UTC) - newest).total_seconds()

--- a/services/api/tests/test_no_unused_infrastructure.py
+++ b/services/api/tests/test_no_unused_infrastructure.py
@@ -1,0 +1,86 @@
+"""Redis stays out of the topology until something actually uses it.
+
+Redis was declared in `Settings` (`redis_url`), started by Compose, health-gated by
+both the API and the worker (`depends_on: condition: service_healthy`), and listed
+as one of five required Railway services. No runtime code ever read it: `redis_url`
+was referenced exactly once — its own declaration — and no Redis client was imported
+anywhere in the repository.
+
+A declared-but-unused infrastructure dependency is pure cost: another managed
+service to pay for, another health check that can fail a deploy, and an
+architecture diagram that misleads everyone who reads it.
+
+These tests fail if Redis creeps back in *as configuration*. They are deliberately
+not a ban: reinstate it the moment something genuinely uses it (distributed rate
+limiting, job queueing, caching, pub/sub, cross-replica coordination) — at which
+point a real client import will exist and these tests should be updated to assert
+that instead.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+API_APP = REPO_ROOT / "services" / "api" / "app"
+
+
+def test_settings_has_no_unused_redis_url():
+    from app.core.config import Settings
+
+    assert not hasattr(Settings(), "redis_url"), (
+        "redis_url is back in Settings — only add it alongside a real consumer"
+    )
+
+
+def test_no_redis_client_is_imported_anywhere():
+    """If this ever fails, Redis is genuinely in use and the tests above should change."""
+    offenders = []
+    for path in API_APP.rglob("*.py"):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if "import redis" in text or "from redis" in text:
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+    assert not offenders, f"a Redis client is imported in: {offenders}"
+
+
+@pytest.mark.parametrize(
+    "relative",
+    ["docker-compose.yml", ".env.example"],
+)
+def test_compose_and_env_do_not_declare_redis(relative):
+    path = REPO_ROOT / relative
+    if not path.exists():  # pragma: no cover - repo layout guard
+        pytest.skip(f"{relative} not present")
+    text = path.read_text(encoding="utf-8").lower()
+    assert "redis" not in text, (
+        f"{relative} declares Redis again — the API and worker were previously "
+        "health-gated on a service nothing used"
+    )
+
+
+def test_compose_services_are_the_four_real_ones():
+    yaml = pytest.importorskip("yaml")
+    compose = yaml.safe_load((REPO_ROOT / "docker-compose.yml").read_text())
+    services = set(compose["services"])
+    # `benchmark` is opt-in via a Compose profile, not part of the running stack.
+    assert services == {"db", "api", "worker", "web", "benchmark"}
+
+
+def test_deployment_docs_do_not_hardcode_a_migration_range():
+    """Migration lists go stale silently and produce an incomplete schema.
+
+    railway.md said `001…007` was "the latest" and railway-env.md said `001…005`,
+    while the repository had migrations through `011`. Both must use a glob.
+    """
+    migrations = sorted((REPO_ROOT / "infra" / "db" / "migrations").glob("*.sql"))
+    assert migrations, "no migrations found — has the layout changed?"
+    latest = migrations[-1].name
+
+    for doc in ("docs/deployment/railway.md", "docs/deployment/railway-env.md"):
+        text = (REPO_ROOT / doc).read_text(encoding="utf-8")
+        assert "infra/db/migrations/*.sql" in text, (
+            f"{doc} must tell operators to glob the migrations directory, not "
+            f"enumerate a range that goes stale (latest is currently {latest})"
+        )

--- a/services/api/tests/test_readiness_probes.py
+++ b/services/api/tests/test_readiness_probes.py
@@ -29,7 +29,7 @@ def test_readyz_reports_per_dependency_states(api_client):
     checks = body["checks"]
     for name in _DEPENDENCIES:
         assert name in checks, name
-        assert checks[name]["status"] in ("ok", "skipped", "error")
+        assert checks[name]["status"] in ("ok", "degraded", "skipped", "error")
     # In-memory dev store: schema + worker runtime are not applicable → skipped,
     # not error (an unselected/optional dependency must never block readiness).
     assert checks["schema"]["status"] == "skipped"

--- a/services/api/tests/test_readiness_truthfulness.py
+++ b/services/api/tests/test_readiness_truthfulness.py
@@ -1,0 +1,195 @@
+"""Readiness must report what a dependency *can do*, not what it was *named*.
+
+`/readyz` previously derived `llm_provider` and `embedding_provider` status purely
+from the configured provider name — both were hardcoded `{"status": "ok"}`. An
+operator who set `MEMORYOPS_LLM_PROVIDER=openai` with no key and no SDK installed
+saw a fully green probe while every request was served by the deterministic stub.
+`vector_backend` was the same: any external backend reported `ok` with a note that
+it "degrades to keyword-only if unreachable", so a misconfigured Qdrant URL — or a
+missing client library — looked healthy while all ranking silently fell back.
+
+Severity is profile-aware: in production a selected-but-unusable provider is an
+`error` (the deployment asked for it); in dev it is `degraded` (the fallback is the
+intended offline experience). No probe may leak a key, DSN, or raw provider error.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.routes import health
+
+
+@pytest.fixture
+def no_sdks(monkeypatch):
+    """Simulate an image with none of the optional provider SDKs installed."""
+    monkeypatch.setattr(health, "_module_missing", lambda module: True)
+
+
+@pytest.fixture
+def all_sdks(monkeypatch):
+    monkeypatch.setattr(health, "_module_missing", lambda module: False)
+
+
+def _settings(**overrides):
+    from app.core.config import Settings
+
+    base = dict(profile="dev", storage="memory")
+    return Settings(**{**base, **overrides})
+
+
+# ── LLM provider ─────────────────────────────────────────────────────────────
+def test_stub_llm_provider_is_ok_without_any_sdk(no_sdks):
+    assert health._check_llm_provider(_settings(llm_provider="stub"))["status"] == "ok"
+
+
+def test_selected_llm_provider_without_key_is_not_reported_ok(all_sdks):
+    check = health._check_llm_provider(_settings(llm_provider="openai", openai_api_key=""))
+    assert check["status"] == "degraded"
+    assert check["reason_code"] == "missing_api_key"
+    assert check["fallback"] == "stub"
+
+
+def test_selected_llm_provider_without_sdk_is_not_reported_ok(no_sdks):
+    check = health._check_llm_provider(
+        _settings(llm_provider="anthropic", anthropic_api_key="sk-real")
+    )
+    assert check["status"] == "degraded"
+    assert check["reason_code"] == "sdk_not_installed"
+    assert check["install_extra"] == "anthropic"
+
+
+def test_unusable_provider_is_an_error_in_production(all_sdks):
+    check = health._check_llm_provider(
+        _settings(profile="production", llm_provider="openai", openai_api_key="")
+    )
+    assert check["status"] == "error", "production asked for a real provider; say so"
+
+
+def test_fully_configured_llm_provider_is_ok(all_sdks):
+    check = health._check_llm_provider(
+        _settings(llm_provider="openai", openai_api_key="sk-real")
+    )
+    assert check["status"] == "ok"
+    # Configuration is verified; liveness deliberately is not (a probe must not
+    # spend tokens or hit a rate limit on every scrape).
+    assert check["liveness"] == "not_probed"
+
+
+def test_gemini_probe_uses_the_module_the_adapter_imports(monkeypatch):
+    seen: list[str] = []
+    monkeypatch.setattr(health, "_module_missing", lambda m: seen.append(m) or False)
+    health._check_llm_provider(_settings(llm_provider="gemini", gemini_api_key="k"))
+    assert seen == ["google.generativeai"]
+
+
+# ── embedding provider ───────────────────────────────────────────────────────
+def test_openai_embeddings_without_key_is_not_reported_ok(all_sdks):
+    check = health._check_embedding_provider(
+        _settings(embeddings_provider="openai", openai_api_key="")
+    )
+    assert check["status"] == "degraded"
+    assert check["reason_code"] == "missing_api_key"
+
+
+def test_stub_embeddings_are_ok(no_sdks):
+    assert health._check_embedding_provider(_settings())["status"] == "ok"
+
+
+# ── vector backend ───────────────────────────────────────────────────────────
+def test_memory_vector_backend_is_ok(no_sdks):
+    assert health._check_vector_backend(_settings(vector_index="memory"))["status"] == "ok"
+
+
+def test_external_vector_backend_without_client_is_not_reported_ok(no_sdks):
+    check = health._check_vector_backend(_settings(vector_index="qdrant"))
+    assert check["status"] == "degraded"
+    assert check["reason_code"] == "client_not_installed"
+    assert check["fallback"] == "keyword_only"
+
+
+def test_unreachable_vector_backend_is_not_reported_ok(all_sdks, monkeypatch):
+    """The real regression: a selected-but-unreachable index used to report ok."""
+
+    class _Unavailable:
+        def available(self) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        "app.db.vector.factory.create_vector_index", lambda name, **kw: _Unavailable()
+    )
+    check = health._check_vector_backend(_settings(vector_index="qdrant"))
+    assert check["status"] == "degraded"
+    assert check["reason_code"] == "backend_unreachable"
+
+
+def test_vector_backend_probe_never_raises(all_sdks, monkeypatch):
+    def _boom(name, **kw):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr("app.db.vector.factory.create_vector_index", _boom)
+    check = health._check_vector_backend(_settings(vector_index="weaviate"))
+    assert check["status"] == "degraded"
+    assert check["reason_code"] == "probe_failed"
+
+
+# ── worker freshness ─────────────────────────────────────────────────────────
+def test_worker_staleness_is_none_when_nothing_has_run():
+    assert health._worker_staleness_seconds({"last_run_per_scope": {}}) is None
+
+
+def test_worker_staleness_uses_the_most_recent_run():
+    from datetime import UTC, datetime, timedelta
+
+    now = datetime.now(UTC)
+    summary = {
+        "last_run_per_scope": {
+            "t1:u1": {"started_at": (now - timedelta(seconds=600)).isoformat()},
+            "t2:u2": {"started_at": (now - timedelta(seconds=30)).isoformat()},
+        }
+    }
+    age = health._worker_staleness_seconds(summary)
+    assert age is not None and age < 60, "must use the newest run, not the oldest"
+
+
+def test_worker_staleness_tolerates_malformed_timestamps():
+    assert health._worker_staleness_seconds(
+        {"last_run_per_scope": {"t:u": {"started_at": "not-a-date"}}}
+    ) is None
+
+
+# ── response shape + secret hygiene ──────────────────────────────────────────
+def test_readyz_exposes_a_degraded_flag(api_client):
+    client, _repo = api_client
+    body = client.get("/readyz").json()
+    assert "degraded" in body
+    assert isinstance(body["degraded"], bool)
+
+
+def test_readyz_never_leaks_secrets_even_when_degraded(api_client, monkeypatch):
+    client, _repo = api_client
+    monkeypatch.setattr(health, "_module_missing", lambda m: True)
+    blob = json.dumps(client.get("/readyz").json())
+    for secret in ("sk-", "postgresql://", "postgresql+psycopg://", "password", "@localhost"):
+        assert secret not in blob, f"readiness leaked {secret!r}"
+
+
+def test_readyz_never_raises_even_if_a_probe_explodes(api_client, monkeypatch):
+    """Readiness is what an operator hits when things are broken — it must not 500."""
+
+    def _boom(_settings):
+        raise RuntimeError("connection string postgresql://user:hunter2@db/x is bad")
+
+    monkeypatch.setattr(health, "_check_storage", _boom)
+    client, _repo = api_client
+    r = client.get("/readyz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ready"] is False
+    assert body["checks"]["storage"]["status"] == "error"
+    assert body["checks"]["storage"]["reason_code"] == "probe_raised"
+    # Only the exception type, never its message (which carried a DSN + password).
+    assert "hunter2" not in json.dumps(body)
+    assert body["checks"]["storage"]["detail"] == "RuntimeError"


### PR DESCRIPTION
**Recovers #99, whose changes never reached `main`.** Based directly on current `main`, no stacking.

## Why this PR exists

GitHub records #99 as **MERGED**, but its changes are not on `main`:

```
#97 squash-merged to main   14:42:09  → 1e1c6a2 (on main)
#99 merged into fix/platform-dependency-unification
                            14:43:16  → 5646197 (NOT an ancestor of main)
```

#99 was stacked on #97's branch. Squash-merging #97 replaced that history on `main` with a single new commit, so 67 seconds later #99 merged into a branch that no longer led anywhere. Its merge commit is orphaned.

The regressions are live on `main` today:

| Check | State on `main` |
| --- | --- |
| `redis_url` in `Settings` | present (unused) |
| Redis refs in `docker-compose.yml` | 7 |
| `railway.md` stale migration range `001…007` | present (repo has 012) |
| `/readyz` hardcoded provider `ok` | present |
| `test_no_unused_infrastructure.py` | missing |
| `test_readiness_truthfulness.py` | missing |

## Contents

Unchanged from #99 — Redis removal, truthful provider/vector/worker readiness with a `degraded` state and `reason_code`, migration-glob docs, corrected Railway topology, and the full minimum production variable set.

Cherry-picked cleanly onto current `main` with no conflicts.

## Verification on this branch

566 passed, 3 skipped · ruff clean · evals PASS · invariant gate PASS.

## Process note

Do not stack the next PRs on an unmerged branch. Either base each on `main`, or rebase and retarget to `main` **before** the parent merges — squash-merging a parent silently orphans anything merged into its branch afterwards.