### PR TITLE
fix(security): reject governance ablation under the production profile

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -298,3 +298,37 @@ widening the window considerably.
 The 409 is raised **after** tenant scoping, so it is not a cross-tenant oracle: a
 request for another tenant's memory returns `404` whether or not the revision would
 have matched.
+
+## Production rejects governance ablation
+
+The research-ablation switches (`MEMORYOPS_GOVERNANCE_PROFILE=disabled`,
+`MEMORYOPS_ABLATE_*`) exist so the paper study can measure a governed system against
+a mechanism-matched ungoverned twin. They ship in the same binary as production, and
+nothing stopped them being combined with `MEMORYOPS_PROFILE=production`.
+
+Verified before this guard existed: a **fully hardened** production config —
+Postgres, JWT auth, explicit CORS allow-list, real DSN, evals off — plus
+`MEMORYOPS_GOVERNANCE_PROFILE=disabled` produced **no** readiness errors, and a live
+API key was stored with `status=active`. The policy broker's BLOCK never ran. Every
+one of the seven invariants could be disabled by an environment variable while the
+deployment reported itself production-ready.
+
+`Settings.production_readiness_errors()` now rejects, under the production profile:
+
+| Setting | What breaks |
+| --- | --- |
+| `governance_profile != full` | the ablation cascade below |
+| `govern_policy_enforcement=false` | the broker does not run before storage (invariant #5) |
+| `govern_transactional_evidence=false` | mutations and audit events stop committing atomically (invariant #7) |
+| `govern_tombstone_propagation=false` | deletion stops propagating to derived memories (invariant #2) |
+| `admission_gate_enabled=false` | nothing is checked for admissibility before entering context |
+| `recall_gate_enabled=false` | audience clearance is not enforced on recall |
+| `output_gate_enabled=false` | answers are not checked for disclosure of blocked memory |
+| any `MEMORYOPS_ABLATE_*` present | any value flips its control off, so presence is disqualifying |
+
+All seven default to enabled, so this rejects only deployments that explicitly
+turned governance off. Dev is unchanged, so the paper study still runs.
+
+**This is the guard, not the cure.** The stronger fix is architectural: ship the
+ablation wiring in a separate `memoryops-research` package or application factory so
+a production binary cannot express these states at all. Tracked separately.

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -310,6 +310,89 @@ class Settings(BaseSettings):
                 "public — set MEMORYOPS_PUBLIC_EVALS=false."
             )
         errors.extend(self._provider_readiness_errors())
+        errors.extend(self._governance_readiness_errors())
+        return errors
+
+    def _governance_readiness_errors(self) -> list[str]:
+        """Reject a production deployment with governance switched off.
+
+        The research-ablation switches (`MEMORYOPS_GOVERNANCE_PROFILE=disabled`,
+        `MEMORYOPS_ABLATE_*`) exist so the paper study can measure a governed system
+        against a mechanism-matched ungoverned twin. They ship in the same binary as
+        production, and nothing stopped them being combined with
+        `MEMORYOPS_PROFILE=production`.
+
+        Verified before this check existed: a fully hardened production config
+        (postgres, jwt, explicit CORS, real DSN, evals off) plus
+        `MEMORYOPS_GOVERNANCE_PROFILE=disabled` produced **no** readiness errors and
+        stored a live API key with `status=active` — the policy broker's BLOCK never
+        ran. Every one of the seven invariants could be disabled by an env var while
+        the deployment reported itself production-ready.
+
+        All seven flags default to enabled, so this rejects only deployments that
+        explicitly turned governance off.
+
+        This is the guard, not the cure. The stronger fix is architectural — ship the
+        ablation wiring in a separate `memoryops-research` package or application
+        factory so a production binary cannot express these states at all. Tracked
+        separately; this closes the hole now.
+        """
+        import os
+
+        errors: list[str] = []
+        if self.governance_profile != "full":
+            errors.append(
+                f"governance_profile={self.governance_profile!r}: research ablation "
+                "disables the policy broker, transactional evidence, tombstone "
+                "propagation and the context gates — unset "
+                "MEMORYOPS_GOVERNANCE_PROFILE for production."
+            )
+        for attr, env, what in (
+            (
+                "govern_policy_enforcement",
+                "MEMORYOPS_ABLATE_POLICY_BROKER",
+                "the policy broker would not run before storage (invariant #5): "
+                "secrets and injection payloads would be stored active",
+            ),
+            (
+                "govern_transactional_evidence",
+                "MEMORYOPS_ABLATE_TRANSACTIONAL_EVIDENCE",
+                "lifecycle mutations and their audit events would no longer commit "
+                "atomically (invariant #7)",
+            ),
+            (
+                "govern_tombstone_propagation",
+                "MEMORYOPS_ABLATE_TOMBSTONE_PROPAGATION",
+                "deletion would not propagate to derived memories (invariant #2)",
+            ),
+            (
+                "admission_gate_enabled",
+                "MEMORYOPS_ADMISSION_GATE",
+                "no memory would be checked for admissibility before entering context",
+            ),
+            (
+                "recall_gate_enabled",
+                "MEMORYOPS_RECALL_GATE",
+                "audience clearance would not be enforced on recall",
+            ),
+            (
+                "output_gate_enabled",
+                "MEMORYOPS_OUTPUT_GATE",
+                "generated answers would not be checked for disclosure of blocked memory",
+            ),
+        ):
+            if not getattr(self, attr):
+                errors.append(f"{attr}=false: {what} — set {env} back on for production.")
+
+        # An ABLATE_* variable set to *any* value flips its control off, so its mere
+        # presence is disqualifying regardless of the value.
+        present = sorted(k for k in os.environ if k.startswith("MEMORYOPS_ABLATE_"))
+        if present:
+            errors.append(
+                f"research ablation variables set in a production environment: "
+                f"{', '.join(present)} — these disable governance controls and must "
+                "be unset."
+            )
         return errors
 
     def _provider_readiness_errors(self) -> list[str]:

--- a/services/api/tests/test_production_profile.py
+++ b/services/api/tests/test_production_profile.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import subprocess
 import sys
 
+import pytest
+
 from app.core.config import Settings
 
 
@@ -246,3 +248,128 @@ def _env() -> dict:
 
     # Inherit PATH/PYTHONPATH etc. but drop any MEMORYOPS_* the caller set.
     return {k: v for k, v in os.environ.items() if not k.startswith("MEMORYOPS_")}
+
+
+# ── governance ablation must never combine with the production profile ───────
+# The research switches (MEMORYOPS_GOVERNANCE_PROFILE=disabled, MEMORYOPS_ABLATE_*)
+# ship in the same binary as production so the paper study can measure a governed
+# system against a mechanism-matched ungoverned twin. Nothing stopped them being
+# combined with MEMORYOPS_PROFILE=production.
+#
+# Verified before this guard existed: a fully hardened production config plus
+# `MEMORYOPS_GOVERNANCE_PROFILE=disabled` produced NO readiness errors, and a live
+# API key was stored with status=active — the policy broker's BLOCK never ran.
+def test_production_rejects_the_disabled_governance_profile():
+    errors = _hardened(governance_profile="disabled").production_readiness_errors()
+    assert any("governance_profile" in e for e in errors)
+
+
+@pytest.mark.parametrize(
+    ("flag", "invariant_hint"),
+    [
+        ("govern_policy_enforcement", "policy broker"),
+        ("govern_transactional_evidence", "atomically"),
+        ("govern_tombstone_propagation", "derived memories"),
+        ("admission_gate_enabled", "admissibility"),
+        ("recall_gate_enabled", "audience clearance"),
+        ("output_gate_enabled", "disclosure"),
+    ],
+)
+def test_production_rejects_each_disabled_governance_control(flag, invariant_hint):
+    errors = _hardened(**{flag: False}).production_readiness_errors()
+    assert any(flag in e for e in errors), f"{flag}=false was accepted in production"
+    assert any(invariant_hint in e for e in errors), "the error must say what breaks"
+
+
+def test_production_rejects_any_ablate_environment_variable(monkeypatch):
+    """Presence is disqualifying: any value flips the control off."""
+    monkeypatch.setenv("MEMORYOPS_ABLATE_POLICY_BROKER", "0")
+    errors = _hardened().production_readiness_errors()
+    assert any("MEMORYOPS_ABLATE_POLICY_BROKER" in e for e in errors)
+
+
+def test_all_governance_controls_default_to_enabled():
+    """The guard must reject only deployments that explicitly turned governance off,
+    never a config that simply never mentioned it."""
+    s = Settings()
+    assert s.governance_profile == "full"
+    for flag in (
+        "govern_policy_enforcement",
+        "govern_transactional_evidence",
+        "govern_tombstone_propagation",
+        "admission_gate_enabled",
+        "recall_gate_enabled",
+        "output_gate_enabled",
+    ):
+        assert getattr(s, flag) is True, f"{flag} does not default to enabled"
+
+
+def test_a_clean_production_config_is_still_accepted():
+    assert _hardened().production_readiness_errors() == []
+
+
+def test_app_refuses_to_import_with_governance_disabled_in_production():
+    """Fail-closed startup, end to end — not merely a list of strings."""
+    proc = subprocess.run(
+        [sys.executable, "-c", "import app.main"],
+        cwd=_api_dir(),
+        env={
+            **_env(),
+            "MEMORYOPS_PROFILE": "production",
+            "MEMORYOPS_STORAGE": "postgres",
+            "MEMORYOPS_AUTH_MODE": "trusted_header",
+            "MEMORYOPS_CORS_ALLOW_ORIGINS": "https://app.example.com",
+            "MEMORYOPS_DATABASE_URL": "postgresql+psycopg://real:secret@db.internal:5432/memoryops",
+            "MEMORYOPS_GOVERNANCE_PROFILE": "disabled",
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0, "production started with governance disabled"
+    assert "governance_profile" in proc.stderr
+
+
+def test_research_ablation_still_works_outside_the_production_profile(monkeypatch):
+    """The paper study must keep running — the guard is production-only.
+
+    The per-control cascade lives in `get_settings()` (it resolves the env vars),
+    not in the `Settings` constructor, so this exercises the real entry point.
+    """
+    from app.core import config
+
+    monkeypatch.setenv("MEMORYOPS_GOVERNANCE_PROFILE", "disabled")
+    config.get_settings.cache_clear()
+    try:
+        s = config.get_settings()
+        assert s.profile == "dev"
+        assert s.governance_profile == "disabled"
+        # The ablation genuinely takes effect in dev...
+        assert s.govern_policy_enforcement is False
+        # ...and is not treated as a production violation, because it is not production.
+        assert s.production_readiness_errors() == []
+    finally:
+        config.get_settings.cache_clear()
+
+
+def test_the_env_var_cascade_is_what_production_rejects(monkeypatch):
+    """The real-world shape of the hole: env vars, resolved through get_settings()."""
+    from app.core import config
+
+    for key, value in {
+        "MEMORYOPS_PROFILE": "production",
+        "MEMORYOPS_STORAGE": "postgres",
+        "MEMORYOPS_AUTH_MODE": "jwt",
+        "MEMORYOPS_CORS_ALLOW_ORIGINS": "https://app.example.com",
+        "MEMORYOPS_DATABASE_URL": "postgresql+psycopg://real:secret@db.internal:5432/memoryops",
+        "MEMORYOPS_PUBLIC_EVALS": "false",
+        "MEMORYOPS_GOVERNANCE_PROFILE": "disabled",
+    }.items():
+        monkeypatch.setenv(key, value)
+    config.get_settings.cache_clear()
+    try:
+        errors = config.get_settings().production_readiness_errors()
+        assert errors, "a hardened production config with governance disabled was accepted"
+        assert any("governance_profile" in e for e in errors)
+        assert any("govern_policy_enforcement" in e for e in errors)
+    finally:
+        config.get_settings.cache_clear()


### PR DESCRIPTION
Closes the highest-severity finding that no other open PR covers. Based directly on `main`.

## Reproduced on current `main`

A **fully hardened** production config — Postgres, JWT auth, explicit CORS allow-list, real DSN, evals off — plus `MEMORYOPS_GOVERNANCE_PROFILE=disabled`:

```
production_readiness_errors() -> NONE

POST /api/chat  "Remember: my API key is sk-live-0123456789abcdefghij."
stored:  status=active  sensitivity=high
```

The policy broker's `BLOCK` never ran. **Every one of the seven invariants could be disabled by an environment variable while the deployment reported itself production-ready.**

The switches exist so the paper study can measure a governed system against a mechanism-matched ungoverned twin. They ship in the same binary as production, and nothing connected them to the production gate.

## What now fails startup

Under `MEMORYOPS_PROFILE=production` only:

| Setting | What breaks |
| --- | --- |
| `governance_profile != full` | the whole ablation cascade |
| `govern_policy_enforcement=false` | broker does not run before storage (invariant #5) |
| `govern_transactional_evidence=false` | mutations and audit events stop committing atomically (invariant #7) |
| `govern_tombstone_propagation=false` | deletion stops propagating to derived memories (invariant #2) |
| `admission_gate_enabled=false` | nothing checked for admissibility before context |
| `recall_gate_enabled=false` | audience clearance not enforced on recall |
| `output_gate_enabled=false` | answers not checked for disclosure of blocked memory |
| any `MEMORYOPS_ABLATE_*` present | any value flips its control off, so presence is disqualifying |

Each error names the invariant that breaks, not just the flag.

## Compatibility

All seven controls **default to enabled**, so this rejects only deployments that explicitly disabled governance. A config that never mentions these is unaffected — a test asserts the defaults. Dev is untouched, so the paper study still runs; a test asserts that too.

## Tests

The per-control cascade lives in `get_settings()` (it resolves the env vars), not the `Settings` constructor — so the headline test drives the **env-var path end to end** rather than a constructed object. Fail-closed startup is proven by importing `app.main` in a subprocess and requiring a non-zero exit.

555 passed, 3 skipped · ruff clean · evals PASS · benchmark PASS · invariant gate PASS.

## This is the guard, not the cure

The stronger fix is architectural: ship the ablation wiring in a separate `memoryops-research` package or application factory so a production binary **cannot express** these states. Tracked separately — this closes the hole now.