### PR TITLE
fix(auth): treat an explicitly empty role claim as zero permissions

### DIFF
--- a/docs/security/endpoint-authorization-matrix.md
+++ b/docs/security/endpoint-authorization-matrix.md
@@ -19,10 +19,15 @@ Role resolution has **three** states, not two:
 
 | Credential | Result |
 | --- | --- |
-| no role claim, `auth_require_role_claim=false` | falls back to `memory_reader` |
-| no role claim, `auth_require_role_claim=true` (production default) | **no permissions** |
+| claim **omitted**, `auth_require_role_claim=false` | falls back to `memory_reader` |
+| claim **omitted**, `auth_require_role_claim=true` (production) | **no permissions** |
 | claim names recognised roles | those roles |
 | claim present but names nothing recognised | **no permissions** |
+| claim present but **empty** (`[]`, `""`) | **no permissions** |
+
+An omitted claim is a *compatibility* question the deployment answers. An empty
+claim is an *authorization decision the issuer already made* — a credential the IdP
+deliberately granted no roles must receive nothing, not the fallback.
 
 The last row matters: collapsing it into `memory_reader` would mean
 `roles=["service_workre"]` — a typo — silently receives `memory:read:self` and

--- a/services/api/app/auth/roles.py
+++ b/services/api/app/auth/roles.py
@@ -146,16 +146,25 @@ def parse_roles(raw: object) -> frozenset[Role]:
 
 
 def resolve_roles(raw: object) -> tuple[frozenset[Role], bool]:
-    """Return `(roles, claim_present)` so callers can tell the three states apart.
+    """Return `(roles, claim_present)` so callers can tell the four states apart.
 
-    * claim absent            -> `(frozenset(), False)`
+    * claim omitted           -> `(frozenset(), False)`  — compatibility fallback
     * claim valid             -> `(roles, True)`
-    * claim present, invalid  -> `(frozenset(), True)`
+    * claim present, invalid  -> `(frozenset(), True)`   — zero permissions
+    * claim present, empty    -> `(frozenset(), True)`   — zero permissions
 
-    The third case must not fall back to a default role.
+    Presence is `raw is not None` and nothing more. Treating `[]` and `""` as
+    absent conflated two different statements: an issuer that deliberately grants a
+    credential **no roles** was indistinguishable from an older credential that
+    predates roles entirely, so an explicitly empty role set silently received the
+    `memory_reader` fallback — `memory:read:self` and `memory:write:self` for an
+    identity the issuer said should have nothing.
+
+    An omitted claim is a *compatibility* question the deployment answers
+    (`auth_require_role_claim`). An empty claim is an *authorization decision the
+    issuer already made*, and must be honoured.
     """
-    present = raw is not None and raw != "" and raw != []
-    return parse_roles(raw), present
+    return parse_roles(raw), raw is not None
 
 
 def permissions_for(roles: frozenset[Role]) -> frozenset[Permission]:

--- a/services/api/tests/test_api_rbac.py
+++ b/services/api/tests/test_api_rbac.py
@@ -262,14 +262,9 @@ def test_a_role_claim_naming_nothing_recognised_grants_nothing():
     assert not p.has(Permission.MEMORY_READ_SELF)
 
 
-def test_resolve_roles_distinguishes_absent_from_invalid():
-    from app.auth.roles import resolve_roles
-
-    assert resolve_roles(None) == (frozenset(), False)
-    assert resolve_roles("") == (frozenset(), False)
-    assert resolve_roles([]) == (frozenset(), False)
-    assert resolve_roles("auditor") == (frozenset({Role.AUDITOR}), True)
-    assert resolve_roles("nonsense") == (frozenset(), True)
+# NOTE: an earlier two-state version of this test asserted that "" and [] were
+# *absent*. That is the behaviour this change corrects, so it is superseded by
+# `test_presence_distinguishes_all_four_states` below rather than kept alongside it.
 
 
 def test_a_missing_claim_can_be_required_instead_of_defaulted():
@@ -345,3 +340,74 @@ def test_authorization_is_a_no_op_when_auth_is_disabled(api_client):
     client, _repo = api_client
     assert client.get("/api/audit?tenant_id=t1").status_code == 200
     assert client.get("/api/metrics?tenant_id=t1").status_code == 200
+
+
+# ── an explicitly empty role claim is a decision, not an absence ─────────────
+# Presence was `raw is not None and raw != "" and raw != []`, so an issuer that
+# deliberately granted a credential *no roles* was indistinguishable from an older
+# credential that predates roles entirely. The empty set silently received the
+# `memory_reader` fallback — memory:read:self and memory:write:self for an identity
+# the issuer said should have nothing.
+def _principal(raw):
+    from app.auth.principal import Principal
+    from app.auth.roles import resolve_roles
+
+    roles, present = resolve_roles(raw)
+    return Principal(
+        tenant_id="t", user_id="u", provider="jwt",
+        roles=roles, role_claim_present=present,
+    )
+
+
+@pytest.mark.parametrize("empty", [[], "", (), frozenset()])
+def test_an_explicitly_empty_role_claim_grants_nothing(empty):
+    p = _principal(empty)
+    assert p.effective_roles == frozenset()
+    assert p.permissions == frozenset()
+    assert not p.has(Permission.MEMORY_READ_SELF)
+    assert not p.has(Permission.MEMORY_WRITE_SELF)
+
+
+def test_an_omitted_claim_still_falls_back_where_permitted():
+    """Omission is a compatibility question the deployment answers; emptiness is an
+    authorization decision the issuer already made."""
+    p = _principal(None)
+    assert p.effective_roles == frozenset({DEFAULT_ROLE})
+    assert p.has(Permission.MEMORY_READ_SELF)
+
+
+def test_presence_distinguishes_all_four_states():
+    from app.auth.roles import resolve_roles
+
+    assert resolve_roles(None) == (frozenset(), False)          # omitted
+    assert resolve_roles([]) == (frozenset(), True)             # present, empty
+    assert resolve_roles("") == (frozenset(), True)             # present, empty
+    assert resolve_roles("auditor") == (frozenset({Role.AUDITOR}), True)
+    assert resolve_roles("nonsense") == (frozenset(), True)     # present, invalid
+
+
+def test_a_trusted_header_present_but_empty_grants_nothing():
+    from app.auth.providers import TrustedHeaderProvider
+
+    provider = TrustedHeaderProvider(
+        "X-MemoryOps-Tenant", "X-MemoryOps-User", "X-MemoryOps-Roles"
+    )
+    absent = provider.resolve({"x-memoryops-tenant": "t", "x-memoryops-user": "u"})
+    assert absent is not None and absent.effective_roles == frozenset({DEFAULT_ROLE})
+
+    empty = provider.resolve(
+        {"x-memoryops-tenant": "t", "x-memoryops-user": "u", "x-memoryops-roles": ""}
+    )
+    assert empty is not None
+    assert empty.role_claim_present is True
+    assert empty.permissions == frozenset()
+
+
+def test_a_production_credential_without_roles_gets_nothing():
+    p = _principal(None)
+    strict = type(p)(
+        tenant_id="t", user_id="u", provider="jwt",
+        roles=p.roles, role_claim_present=p.role_claim_present,
+        require_role_claim=True,
+    )
+    assert strict.permissions == frozenset()


### PR DESCRIPTION
Small corrective PR on the RBAC foundation (#115), ahead of route coverage.

## The edge

`resolve_roles` determined presence with:

```python
present = raw is not None and raw != "" and raw != []
```

So `roles=[]` and `roles=""` were classified as **absent** and received the `memory_reader` compatibility fallback.

Reproduced on merged `main` (`ae9988b`):

```
omitted        present=False  perms=3
empty list     present=False  perms=3   ← wrong
empty string   present=False  perms=3   ← wrong
valid          present=True   perms=7
invalid        present=True   perms=0
```

An identity provider that deliberately grants a credential **no roles** was indistinguishable from an older credential that predates roles entirely — and got `memory:read:self` + `memory:write:self` for an identity the issuer said should have nothing.

## The distinction

An **omitted** claim is a *compatibility* question the deployment answers (`auth_require_role_claim`). An **empty** claim is an *authorization decision the issuer already made*, and must be honoured.

Presence is now `raw is not None` and nothing more:

| Claim | Result |
| --- | --- |
| omitted | fallback where permitted; **none** in production |
| valid | mapped permissions |
| present but invalid | **zero permissions** |
| present but empty (`[]`, `""`) | **zero permissions** |

## Tests

Covers all four states, both providers, and the production path — including a trusted header that is *present but empty*, which is now distinguishable from an absent header.

An earlier two-state test asserted `""` and `[]` were absent. That is precisely the behaviour being corrected, so it is superseded by the four-state test rather than kept alongside it, with a note recording why.

731 passed, 3 skipped · ruff clean · evals PASS · invariant gate PASS.