### PR TITLE
chore(deps): point Dependabot at authoritative manifests only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,49 @@
 # regardless of the schedule.
 version: 2
 updates:
-  # ── Python: API (runtime + dev + Postgres extras all live under services/api) ──
+  # ── Python: API — the ONLY authoritative Python manifest ──
+  # services/api/pyproject.toml is the source of truth (#97). Every
+  # `requirements*.txt` under services/api is GENERATED from it by
+  # scripts/sync_dependencies.py, and CI fails on drift. Dependabot edits the
+  # manifest; the mirrors are regenerated, never hand-edited.
   - package-ecosystem: pip
     directory: /services/api
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # Grouped by blast radius rather than "everything". A single `patterns: ["*"]`
+    # group produced one PR bundling FastAPI, Uvicorn, SQLAlchemy, psycopg, pgvector,
+    # pytest, Ruff and setuptools — a red result would not say which upgrade caused
+    # it, and a green one would not say the others were exercised.
     groups:
-      python-api:
-        patterns: ["*"]
+      api-runtime:
+        patterns:
+          - "fastapi"
+          - "starlette"
+          - "uvicorn*"
+          - "pydantic"
+          - "pydantic-settings"
+      database:
+        patterns:
+          - "sqlalchemy"
+          - "psycopg*"
+      provider-sdks:
+        patterns:
+          - "openai"
+          - "anthropic"
+          - "google-generativeai"
+    # These change behaviour, not just versions, so they are upgraded deliberately
+    # in their own PRs with a compatibility review — not proposed automatically.
+    #   pgvector : vector semantics and index behaviour
+    #   pytest   : collection and fixture behaviour
+    #   ruff     : lint rule set, so a bump can fail CI on untouched code
+    ignore:
+      - dependency-name: "pgvector"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "pytest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "ruff"
+        update-types: ["version-update:semver-major"]
 
   # ── Python: SDK ──
   - package-ecosystem: pip
@@ -23,24 +57,25 @@ updates:
       python-sdk:
         patterns: ["*"]
 
-  # ── Python: worker ──
-  - package-ecosystem: pip
-    directory: /services/worker
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
-
-  # ── Python: Streamlit demos (playground + results dashboard) ──
-  - package-ecosystem: pip
-    directory: /apps/playground
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 3
-  - package-ecosystem: pip
-    directory: /apps/results-dashboard
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 3
+  # ── NOT monitored: generated dependency mirrors ──
+  #
+  # services/worker, apps/playground and apps/results-dashboard were watched as if
+  # they were independent pip projects. They are not:
+  #
+  #   services/worker/requirements.txt   ->  -r ../api/requirements.txt
+  #   apps/playground/requirements.txt   ->  -r ../../services/api/requirements.txt  (+ streamlit)
+  #
+  # Because Dependabot resolves those includes, it opened PRs *labelled* for the
+  # worker or the playground that in fact edited services/api/requirements.txt — a
+  # generated file. Those changes are erased by the next
+  # `scripts/sync_dependencies.py` run and fail the packaging drift gate, so they
+  # could never merge. Four such PRs (#104, #105, #107, #108) were closed.
+  #
+  # Upgrades reach these directories by changing services/api/pyproject.toml and
+  # regenerating. Reinstate an entry here only if one of these gains a genuinely
+  # authoritative manifest of its own — services/worker/pyproject.toml declares only
+  # `memoryops-api==<version>`, which is deliberately pinned to the API it ships
+  # with and must not drift independently.
 
   # ── Node: web frontend ──
   - package-ecosystem: npm

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -41,6 +41,44 @@ Generated files (all carry a DO-NOT-EDIT banner):
 | `requirements-production.txt` | `production` extra | API + worker images |
 | `requirements-dev.txt` | `dev` extra + `-r requirements.txt` | tests, lint |
 
+## Dependabot targets the manifest, never the mirrors
+
+Only **authoritative** manifests are watched:
+
+| Watched | Why |
+| --- | --- |
+| `/services/api` | `pyproject.toml` is the source of truth |
+| `/packages/memoryops-sdk` | declares its own dependencies |
+| `/apps/web` | `package.json` |
+| `/` (github-actions) | workflow pins |
+
+`services/worker`, `apps/playground` and `apps/results-dashboard` are **not**
+watched. Their requirements files are `-r` includes:
+
+```
+services/worker/requirements.txt   ->  -r ../api/requirements.txt
+apps/playground/requirements.txt   ->  -r ../../services/api/requirements.txt  (+ streamlit)
+```
+
+Dependabot resolves those includes, so it opened PRs *labelled* for the worker or
+playground that in fact edited `services/api/requirements.txt` — a generated file.
+Those edits are erased by the next `scripts/sync_dependencies.py` run and fail the
+drift gate, so they could never merge. Four were closed (#104, #105, #107, #108).
+
+Upgrades reach those directories by changing `services/api/pyproject.toml` and
+regenerating.
+
+### Grouped by blast radius
+
+A single `patterns: ["*"]` group produced one PR bundling FastAPI, Uvicorn,
+SQLAlchemy, psycopg, pgvector, pytest, Ruff and setuptools (#109, closed). A red
+result would not say which upgrade caused it; a green one would not say the others
+were exercised. Groups are now `api-runtime`, `database` and `provider-sdks`.
+
+**pgvector, pytest and Ruff are excluded** from automatic proposals — they change
+behaviour, not just versions: vector semantics, test collection, and a lint rule set
+that can fail CI on untouched code. Upgrade them deliberately, one PR each.
+
 ## Optional extras
 
 ```bash

--- a/services/api/tests/test_packaging.py
+++ b/services/api/tests/test_packaging.py
@@ -154,3 +154,67 @@ def test_production_extra_covers_postgres_and_all_providers(pyproject):
         assert any(name.startswith(required) for name in production), (
             f"production extra is missing {required}: {sorted(production)}"
         )
+
+
+# ── Dependabot targets authoritative manifests only ─────────────────────────
+def test_dependabot_does_not_watch_generated_dependency_mirrors():
+    """Dependabot watched services/worker and apps/playground as if they were
+    independent pip projects. They are not — their requirements files are
+    `-r` includes of the generated services/api/requirements.txt.
+
+    Because Dependabot resolves those includes, it opened PRs *labelled* for the
+    worker or playground that in fact edited a generated file. Those edits are
+    erased by the next `scripts/sync_dependencies.py` run and fail the drift gate,
+    so they could never merge. Four were closed (#104, #105, #107, #108).
+    """
+    yaml = pytest.importorskip("yaml")
+    config = yaml.safe_load((REPO_ROOT / ".github" / "dependabot.yml").read_text())
+    pip_dirs = {u["directory"] for u in config["updates"] if u["package-ecosystem"] == "pip"}
+
+    for mirror in ("/services/worker", "/apps/playground", "/apps/results-dashboard"):
+        assert mirror not in pip_dirs, (
+            f"{mirror} is a generated dependency mirror, not an authoritative manifest"
+        )
+    assert "/services/api" in pip_dirs, "the authoritative API manifest must stay watched"
+
+
+def test_the_watched_directories_really_are_authoritative():
+    """Guards the rule rather than the current list: anything Dependabot watches
+    for pip must own its dependencies, not `-r` include another project's."""
+    yaml = pytest.importorskip("yaml")
+    config = yaml.safe_load((REPO_ROOT / ".github" / "dependabot.yml").read_text())
+
+    for update in config["updates"]:
+        if update["package-ecosystem"] != "pip":
+            continue
+        directory = REPO_ROOT / update["directory"].lstrip("/")
+        requirements = directory / "requirements.txt"
+        if not requirements.exists():
+            continue  # declares deps in pyproject.toml only
+        includes = [
+            line.strip()
+            for line in requirements.read_text().splitlines()
+            if line.strip().startswith("-r ")
+        ]
+        assert not includes, (
+            f"{update['directory']} mirrors another project's requirements "
+            f"({includes}); Dependabot would edit the generated file instead"
+        )
+
+
+def test_behaviour_changing_upgrades_are_not_auto_grouped():
+    """pgvector, pytest and Ruff change behaviour rather than just versions, so a
+    grouped bump hides which upgrade broke (or was never exercised by) CI."""
+    yaml = pytest.importorskip("yaml")
+    config = yaml.safe_load((REPO_ROOT / ".github" / "dependabot.yml").read_text())
+    api = next(
+        u for u in config["updates"]
+        if u["package-ecosystem"] == "pip" and u["directory"] == "/services/api"
+    )
+    ignored = {entry["dependency-name"] for entry in api.get("ignore", [])}
+    assert {"pgvector", "pytest", "ruff"} <= ignored
+
+    # And the catch-all group is gone: one PR bundling runtime, database, vector,
+    # packaging and test tooling is not a reviewable unit.
+    patterns = [p for g in api.get("groups", {}).values() for p in g.get("patterns", [])]
+    assert "*" not in patterns, "a catch-all group re-creates the unreviewable bundle"


### PR DESCRIPTION
Config and docs only — **no runtime behaviour change**. Runs in parallel with route coverage.

## Why the six PRs were invalid update paths

Dependabot watched `services/worker`, `apps/playground` and `apps/results-dashboard` as independent pip projects. They aren't:

```
services/worker/requirements.txt  ->  -r ../api/requirements.txt
apps/playground/requirements.txt  ->  -r ../../services/api/requirements.txt  (+ streamlit)
```

Dependabot resolves those includes, so it opened PRs **labelled** for the worker or playground that in fact edited `services/api/requirements.txt` — generated from `pyproject.toml` since #97. Those edits are erased by the next `scripts/sync_dependencies.py` run and fail the drift gate, so they could never merge.

Closed: #104, #105, #107, #108.

`services/worker/pyproject.toml` is not watched either — it declares only `memoryops-api==<version>`, deliberately pinned to the API it ships with.

## Grouping by blast radius

`patterns: ["*"]` produced one PR bundling FastAPI, Uvicorn, SQLAlchemy, psycopg, pgvector, pytest, Ruff and setuptools (#109, closed). A red result wouldn't say which upgrade caused it; a green one wouldn't say the others were exercised.

Now: `api-runtime`, `database`, `provider-sdks`.

**pgvector, pytest and Ruff excluded** from automatic proposals — they change behaviour rather than versions (vector semantics, test collection, and a lint rule set that can fail CI on untouched code). Deliberate single-dependency PRs with compatibility review.

#114 was closed separately: it moved ESLint and `eslint-config-next` across majors without the Next.js migration those majors belong to. Replaced by `chore/web-next16-security-upgrade`.

## Guards

Three tests. The middle one guards the **rule**, not the list: anything watched for pip must own its dependencies, and it fails if a watched directory's `requirements.txt` `-r` includes another project's. That prevents the class of PR rather than the four instances.

734 passed, 3 skipped · ruff clean · invariant gate PASS.