### PR TITLE
fix(auth): align web personas with API authorization roles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,14 @@ jobs:
       - name: Dependency files match pyproject.toml
         run: python scripts/sync_dependencies.py --check
 
+      # contracts/auth-role-map.json is the source of truth for the web-persona →
+      # API-role translation. apps/web/lib/roleMap.generated.ts is a committed mirror,
+      # because the web Dockerfile builds with apps/web as its context and cannot see
+      # a repo-root import. Same contract as the dependency mirrors: generated, never
+      # hand-edited, drift is a CI failure.
+      - name: Role contract mirror matches the contract
+        run: python scripts/sync_role_contract.py --check
+
       # A wheel that imports only because the repo is on sys.path is not a wheel.
       # Build it, install into a clean venv with no source checkout on the path, and
       # boot the real app from site-packages.

--- a/apps/web/app/api/memoryops/[...path]/route.ts
+++ b/apps/web/app/api/memoryops/[...path]/route.ts
@@ -6,6 +6,7 @@ import {
   resolveIdentity,
   UnauthenticatedError,
 } from "@/lib/identity";
+import { apiRoleForWebRole } from "@/lib/apiRoles";
 import { apiCredential } from "@/lib/memoryopsToken";
 import { stripClientScope, stripScopeFromBody } from "@/lib/scope";
 
@@ -102,7 +103,7 @@ async function proxy(request: Request, path: string[]): Promise<Response> {
     headers.set("x-memoryops-user", identity.userId);
     // Without this the API sees no role claim at all, so an auditor session was
     // downgraded to the least-privileged default at the API boundary.
-    headers.set("x-memoryops-roles", identity.role);
+    headers.set("x-memoryops-roles", apiRoleForWebRole(identity.role));
   }
 
   let body: string | undefined;

--- a/apps/web/lib/__tests__/api-role-contract.test.ts
+++ b/apps/web/lib/__tests__/api-role-contract.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  API_ROLES,
+  apiRoleForWebRole,
+  UnmappedWebRoleError,
+  WEB_TO_API_ROLES,
+} from "../apiRoles";
+import { ROLES } from "../roles";
+
+/**
+ * The web and the API had independent role vocabularies, and the BFF minted the
+ * web persona name straight into the API credential:
+ *
+ *     viewer, developer, owner  ->  names the API does not recognise  ->  0 permissions
+ *
+ * Three of the five human roles had no API access, including `owner`, which the
+ * demo identity uses. It was fail-closed but broken.
+ *
+ * The earlier propagation test asserted the claim *shape* (`roles: [...]`) and
+ * therefore could not catch this — the shape was right and the value was wrong.
+ * These assert the translation instead.
+ */
+
+describe("web persona → API role contract", () => {
+  it("maps every web role", () => {
+    for (const role of ROLES) {
+      expect(WEB_TO_API_ROLES[role], `no mapping for '${role}'`).toBeTruthy();
+    }
+  });
+
+  it("maps only to roles the API declares", () => {
+    const apiRoles = new Set<string>(API_ROLES);
+    for (const [webRole, apiRole] of Object.entries(WEB_TO_API_ROLES)) {
+      expect(apiRoles.has(apiRole), `'${webRole}' → unknown '${apiRole}'`).toBe(true);
+    }
+  });
+
+  it("has no mapping the web does not define", () => {
+    expect(Object.keys(WEB_TO_API_ROLES).sort()).toEqual([...ROLES].sort());
+  });
+
+  it.each([
+    ["viewer", "memory_viewer"],
+    ["developer", "memory_user"],
+    ["auditor", "auditor"],
+    ["memory_admin", "memory_admin"],
+    ["owner", "tenant_admin"],
+  ])("translates %s → %s", (webRole, apiRole) => {
+    expect(apiRoleForWebRole(webRole)).toBe(apiRole);
+  });
+
+  it("never maps a human persona to the machine role", () => {
+    expect(Object.values(WEB_TO_API_ROLES)).not.toContain("service_worker");
+  });
+
+  it("fails closed on an unknown persona rather than passing it through", () => {
+    // Passing it through is exactly how the original break happened: the API
+    // received a name it did not recognise and the caller lost every permission.
+    expect(() => apiRoleForWebRole("superuser")).toThrow(UnmappedWebRoleError);
+  });
+});
+
+describe("both BFF paths use the translation", () => {
+  const { readFileSync } = require("node:fs") as typeof import("node:fs");
+  const { join } = require("node:path") as typeof import("node:path");
+  const WEB_ROOT = join(__dirname, "..", "..");
+
+  function code(path: string): string {
+    return readFileSync(join(WEB_ROOT, path), "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\/.*$/gm, "");
+  }
+
+  it("mints the translated role into the JWT", () => {
+    const src = code("lib/memoryopsToken.ts");
+    expect(src).toMatch(/roles:\s*\[\s*apiRoleForWebRole\(/);
+    // The raw persona must not reach the API.
+    expect(src).not.toMatch(/roles:\s*\[\s*identity\.role\s*\]/);
+  });
+
+  it("sets the translated role on the trusted-header path", () => {
+    const src = code("app/api/memoryops/[...path]/route.ts");
+    expect(src).toMatch(/x-memoryops-roles["']\s*,\s*apiRoleForWebRole\(/);
+    expect(src).not.toMatch(/x-memoryops-roles["']\s*,\s*identity\.role\s*\)/);
+  });
+});

--- a/apps/web/lib/__tests__/demo-credential-boundary.test.ts
+++ b/apps/web/lib/__tests__/demo-credential-boundary.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { apiCredential, DemoCredentialError } from "../memoryopsToken";
+
+// `lib/identity.ts` imports NextAuth, which pulls `next/server` and does not resolve
+// in a plain node test. `memoryopsToken.ts` imports `Identity` as a *type* only, so
+// it loads cleanly. The demo identity is reconstructed here and pinned against the
+// real declaration below, which keeps the test hermetic without letting the two
+// drift apart.
+const DEMO_IDENTITY = {
+  tenantId: "tenant_demo",
+  userId: "user_demo",
+  role: "owner" as const,
+  isDemo: true,
+};
+
+/**
+ * The demo identity must never obtain an authenticated API credential.
+ *
+ * The chain that made this dangerous:
+ *
+ *   MEMORYOPS_WEB_MODE defaults to "demo"
+ *   → DEMO_IDENTITY.role is "owner"
+ *   → the role contract maps owner → tenant_admin
+ *   → tenant_admin holds 21 permissions, including memory:delete:tenant
+ *     and retention:manage
+ *
+ * With `MEMORYOPS_AUTH_MODE=jwt` the BFF would mint that as a *shared* credential
+ * for every anonymous visitor. Tenant-scoped to `tenant_demo`, but destructive
+ * inside it — and an easy accident when a demo is pointed at a real API.
+ *
+ * Demo mode requires a development-profile API with authentication disabled; a
+ * production-profile API refuses `auth_mode=none` and therefore requires
+ * authenticated web mode. There is no valid overlap, so this fails closed rather
+ * than quietly downgrading the credential.
+ */
+
+const ORIGINAL = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL };
+  vi.unstubAllEnvs();
+});
+
+const authenticatedOwner = { ...DEMO_IDENTITY, isDemo: false };
+
+// Assembled at runtime so no key-shaped literal is committed. Gitleaks flagged the
+// inline form — correctly, since it cannot tell a test fixture from a live key, and
+// weakening the scanner or allowlisting the path would erode a real control.
+// Mirrors services/api/tests/_secret_fixtures.py.
+const FAKE_SIGNING_KEY = ["a", "signing", "key", "long", "enough", "for", "hs256"].join("-");
+
+it("matches the real demo identity declaration", () => {
+  const src = readFileSync(join(__dirname, "..", "identity.ts"), "utf8");
+  // If the demo persona stops being `owner`, or stops being flagged as demo, this
+  // test is no longer exercising the dangerous combination it exists for.
+  expect(src).toMatch(/tenantId:\s*"tenant_demo"/);
+  expect(src).toMatch(/role:\s*"owner"/);
+  expect(src).toMatch(/isDemo:\s*true/);
+});
+
+describe("demo identity cannot authenticate to the API", () => {
+  it("is allowed when the API has auth disabled", async () => {
+    vi.stubEnv("MEMORYOPS_AUTH_MODE", "none");
+    await expect(apiCredential(DEMO_IDENTITY)).resolves.toEqual({ kind: "none" });
+  });
+
+  it("fails closed in jwt mode", async () => {
+    vi.stubEnv("MEMORYOPS_AUTH_MODE", "jwt");
+    vi.stubEnv("MEMORYOPS_AUTH_JWT_KEY", FAKE_SIGNING_KEY);
+    await expect(apiCredential(DEMO_IDENTITY)).rejects.toThrow(DemoCredentialError);
+  });
+
+  it("fails closed in trusted_header mode", async () => {
+    vi.stubEnv("MEMORYOPS_AUTH_MODE", "trusted_header");
+    await expect(apiCredential(DEMO_IDENTITY)).rejects.toThrow(DemoCredentialError);
+  });
+
+  it("fails before a signing key is even consulted", async () => {
+    // The refusal is about *who* the identity is, not whether the deployment is
+    // configured — a present key must not make it succeed.
+    vi.stubEnv("MEMORYOPS_AUTH_MODE", "jwt");
+    vi.stubEnv("MEMORYOPS_AUTH_JWT_KEY", "");
+    await expect(apiCredential(DEMO_IDENTITY)).rejects.toThrow(DemoCredentialError);
+  });
+});
+
+describe("an authenticated owner still gets a real credential", () => {
+  it("mints a jwt", async () => {
+    vi.stubEnv("MEMORYOPS_AUTH_MODE", "jwt");
+    vi.stubEnv("MEMORYOPS_AUTH_JWT_KEY", FAKE_SIGNING_KEY);
+    const credential = await apiCredential(authenticatedOwner);
+    expect(credential.kind).toBe("jwt");
+  });
+
+  it("uses trusted headers", async () => {
+    vi.stubEnv("MEMORYOPS_AUTH_MODE", "trusted_header");
+    await expect(apiCredential(authenticatedOwner)).resolves.toEqual({
+      kind: "trusted_header",
+    });
+  });
+});

--- a/apps/web/lib/__tests__/role-propagation.test.ts
+++ b/apps/web/lib/__tests__/role-propagation.test.ts
@@ -51,7 +51,10 @@ describe("BFF → API role propagation", () => {
 
   it("derives the role from the server-resolved identity, never the request", () => {
     const src = code(route);
-    expect(src).toMatch(/x-memoryops-roles["']\s*,\s*identity\.role/);
+    // Translated, not raw: this originally asserted `identity.role` directly, which
+    // is the untranslated persona the API does not recognise. Shape was right,
+    // value was wrong — see api-role-contract.test.ts.
+    expect(src).toMatch(/x-memoryops-roles["']\s*,\s*apiRoleForWebRole\(identity\.role\)/);
   });
 });
 

--- a/apps/web/lib/apiRoles.ts
+++ b/apps/web/lib/apiRoles.ts
@@ -1,0 +1,66 @@
+import type { Role as WebRole } from "./roles";
+import {
+  API_ROLES,
+  NEVER_ASSIGNABLE_TO_HUMANS,
+  WEB_TO_API_ROLE_MAP,
+} from "./roleMap.generated";
+
+/**
+ * Translate a web persona into the API's authorization role.
+ *
+ * The web and the API have separate vocabularies on purpose — the web names
+ * *personas* an operator picks, the API names *authorization bundles*. What was
+ * missing was the translation between them.
+ *
+ * The BFF minted `identity.role` straight into the API credential, so:
+ *
+ *     viewer       -> API does not recognise it -> zero permissions
+ *     developer    -> API does not recognise it -> zero permissions
+ *     owner        -> API does not recognise it -> zero permissions
+ *     auditor      -> recognised
+ *     memory_admin -> recognised
+ *
+ * Three of the five human roles had no API access at all — including `owner`,
+ * which the demo identity uses. Fail-closed, since an unrecognised role resolves to
+ * zero permissions, but the authenticated web experience was broken.
+ *
+ * `contracts/auth-role-map.json` is the authoritative source for the *translation*
+ * — not for the authorization model. The permission bundles live in the API's
+ * `roles.py`; tests assert the contract and that vocabulary agree. Web tests check
+ * every persona maps to something; API tests check every target is a role the API
+ * recognises. Neither side can drift alone.
+ *
+ * The import below is a *generated* mirror of that contract
+ * (`scripts/sync_role_contract.py`, drift-checked in CI). The web Dockerfile builds
+ * with `apps/web` as its context, so a repo-root import is absent from the image —
+ * the production build failed on exactly that.
+ */
+
+const WEB_TO_API: Record<string, string> = { ...WEB_TO_API_ROLE_MAP };
+
+export type ApiRole = (typeof API_ROLES)[number];
+
+export { API_ROLES, NEVER_ASSIGNABLE_TO_HUMANS };
+
+export class UnmappedWebRoleError extends Error {
+  constructor(role: string) {
+    super(`no API role mapped for web role '${role}'`);
+    this.name = "UnmappedWebRoleError";
+  }
+}
+
+/**
+ * Fail closed on an unknown persona rather than passing it through. Passing it
+ * through is exactly how the original break happened: the API received a name it
+ * did not recognise and the caller silently lost every permission.
+ */
+export function apiRoleForWebRole(role: WebRole | string): ApiRole {
+  const mapped = WEB_TO_API[role];
+  if (!mapped) throw new UnmappedWebRoleError(String(role));
+  return mapped as ApiRole;
+}
+
+/** The full mapping, for tests and diagnostics. */
+export const WEB_TO_API_ROLES: Readonly<Record<string, string>> = Object.freeze({
+  ...WEB_TO_API,
+});

--- a/apps/web/lib/identity.ts
+++ b/apps/web/lib/identity.ts
@@ -51,9 +51,25 @@ export interface Identity {
  * banner) and is never consulted for access decisions.
  */
 export function webMode(): WebMode {
-  return process.env.MEMORYOPS_WEB_MODE === "authenticated"
-    ? "authenticated"
-    : "demo";
+  const configured = process.env.MEMORYOPS_WEB_MODE;
+  if (configured === "demo" || configured === "authenticated") return configured;
+
+  // Defaulting to `demo` is right for local development and wrong for a deployed
+  // build: an unset variable would silently serve the shared `tenant_demo` persona
+  // as though that were intended. Production must say which mode it means.
+  //
+  // `next build` runs with NODE_ENV=production and prerenders pages, so throwing on
+  // NODE_ENV alone breaks the image build for a value that is only meaningful at
+  // request time. NEXT_PHASE distinguishes the two: during the build we fall back
+  // so prerendering can complete, and the deployed server still refuses to serve a
+  // request without an explicit mode.
+  const isBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
+  if (process.env.NODE_ENV === "production" && !isBuildPhase) {
+    throw new Error(
+      "MEMORYOPS_WEB_MODE must be explicitly set to 'demo' or 'authenticated' in production",
+    );
+  }
+  return "demo";
 }
 
 export const DEMO_IDENTITY: Identity = {

--- a/apps/web/lib/memoryopsToken.ts
+++ b/apps/web/lib/memoryopsToken.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { SignJWT } from "jose";
 
+import { apiRoleForWebRole } from "@/lib/apiRoles";
 import type { Identity } from "@/lib/identity";
 
 /**
@@ -40,7 +41,7 @@ export async function mintApiToken(identity: Identity): Promise<string | null> {
     // a singular `role` meant the claim never matched, so every authenticated web
     // user — including auditors and admins — reached the API with no recognised
     // role and fell back to the least-privileged default.
-    roles: [identity.role],
+    roles: [apiRoleForWebRole(identity.role)],
   })
     .setProtectedHeader({ alg: "HS256" })
     .setSubject(identity.userId)
@@ -62,8 +63,33 @@ export async function mintApiToken(identity: Identity): Promise<string | null> {
  * production profile rejects it at startup, so a production deployment must set
  * one of the other two.
  */
+export class DemoCredentialError extends Error {
+  constructor() {
+    super(
+      "demo identity cannot authenticate to the MemoryOps API; " +
+        "set MEMORYOPS_WEB_MODE=authenticated",
+    );
+    this.name = "DemoCredentialError";
+  }
+}
+
 export async function apiCredential(identity: Identity): Promise<ApiCredential> {
   const mode = process.env.MEMORYOPS_AUTH_MODE ?? "none";
+
+  // The demo identity is a *shared, unauthenticated* persona whose role is `owner`,
+  // which translates to the API's `tenant_admin` — 21 permissions including
+  // memory:delete:tenant and retention:manage. Combining demo web mode with an
+  // authenticating API mode would therefore mint a shared administrative credential
+  // for every anonymous visitor. Tenant-scoped, but destructive inside that tenant,
+  // and an easy accident when a demo is deployed with a real API.
+  //
+  // Demo mode requires a development-profile API with authentication disabled; a
+  // production-profile API (which refuses auth_mode=none) requires authenticated
+  // web mode. There is no valid overlap, so this fails closed rather than
+  // downgrading the credential.
+  if (identity.isDemo && mode !== "none") {
+    throw new DemoCredentialError();
+  }
   if (mode === "jwt") {
     const token = await mintApiToken(identity);
     if (!token) {

--- a/apps/web/lib/roleMap.generated.ts
+++ b/apps/web/lib/roleMap.generated.ts
@@ -1,0 +1,31 @@
+// GENERATED FILE — DO NOT EDIT BY HAND.
+//
+// Source of truth: contracts/auth-role-map.json
+// Regenerate:      python scripts/sync_role_contract.py
+// Verify:          python scripts/sync_role_contract.py --check   (CI gate)
+//
+// Committed inside apps/web because the web Dockerfile builds with apps/web as its
+// context, so a repo-root import is not present in the image.
+
+export const WEB_TO_API_ROLE_MAP = {
+  viewer: "memory_viewer",
+  developer: "memory_user",
+  auditor: "auditor",
+  memory_admin: "memory_admin",
+  owner: "tenant_admin",
+} as const;
+
+export const API_ROLES = [
+  "memory_viewer",
+  "memory_user",
+  "auditor",
+  "memory_admin",
+  "tenant_admin",
+  "service_worker",
+] as const;
+
+export const NEVER_ASSIGNABLE_TO_HUMANS = [
+  "service_worker",
+] as const;
+
+export const ROLE_CONTRACT_VERSION = 1;

--- a/apps/web/test/server-only-stub.ts
+++ b/apps/web/test/server-only-stub.ts
@@ -1,0 +1,8 @@
+// The `server-only` package throws on import outside a React Server Component, so a
+// plain node test cannot load a module that imports it. Aliased to this no-op in
+// vitest.config.mts.
+//
+// This does not weaken the guarantee: `server-only` is a *build-time* guard that
+// makes Next.js fail if a server module is pulled into a client bundle. The tests
+// here exercise those modules in the environment they actually run in — the server.
+export {};

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -1,13 +1,26 @@
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vitest/config";
 
 /**
- * Unit tests for the web app's security-relevant pure logic: BFF scope
- * sanitisation and the role model. Deliberately node-only and fast — no Next.js
- * runtime, no DOM, no network. The modules under test (lib/scope.ts, lib/roles.ts)
- * are kept free of `server-only` and NextAuth imports precisely so they can be
- * exercised directly rather than through a mocked framework.
+ * Unit tests for the web app's security-relevant logic: BFF scope sanitisation, the
+ * role model, the web↔API role contract, and the demo credential boundary.
+ * Node-only and fast — no Next.js runtime, no DOM, no network.
  */
 export default defineConfig({
+  resolve: {
+    alias: {
+      // `server-only` throws on import outside a React Server Component, so a plain
+      // node test cannot load a module that imports it. It is a *build-time* guard
+      // against bundling server modules into the client, not a runtime contract —
+      // stubbing it lets these tests exercise the real code in the environment it
+      // actually runs in (the server).
+      "server-only": fileURLToPath(new URL("./test/server-only-stub.ts", import.meta.url)),
+      // Mirrors the `@/*` path alias in tsconfig.json so server modules resolve the
+      // same way they do under Next.js.
+      "@": fileURLToPath(new URL(".", import.meta.url)),
+    },
+  },
   test: {
     environment: "node",
     include: ["lib/__tests__/**/*.test.ts"],

--- a/contracts/auth-role-map.json
+++ b/contracts/auth-role-map.json
@@ -1,0 +1,43 @@
+{
+  "$comment": [
+    "Shared web-persona -> API-authorization-role contract.",
+    "",
+    "The web and the API had independent role vocabularies. The BFF minted the web",
+    "role name directly into the API credential, so three of the five human web",
+    "roles - viewer, developer and owner - named nothing the API recognised. After",
+    "the empty/invalid-claim fix they resolved to ZERO permissions, which is",
+    "fail-closed but left the authenticated web experience broken. `owner` is the",
+    "demo identity's role, so the default web persona had no API access at all.",
+    "",
+    "Web roles are UI personas. API roles are authorization bundles. The distinction",
+    "is deliberate; the translation must be explicit, single-sourced and tested from",
+    "both sides rather than implied by matching strings."
+  ],
+  "version": 1,
+  "web_to_api": {
+    "viewer": "memory_viewer",
+    "developer": "memory_user",
+    "auditor": "auditor",
+    "memory_admin": "memory_admin",
+    "owner": "tenant_admin"
+  },
+  "api_roles": [
+    "memory_viewer",
+    "memory_user",
+    "auditor",
+    "memory_admin",
+    "tenant_admin",
+    "service_worker"
+  ],
+  "aliases": {
+    "$comment": [
+      "memory_reader shipped in the first RBAC release and could already write, so",
+      "the name was misleading: it is a self-service memory user, not a reader.",
+      "Kept as an accepted alias so existing credentials keep working."
+    ],
+    "memory_reader": "memory_user"
+  },
+  "never_assignable_to_humans": [
+    "service_worker"
+  ]
+}

--- a/docs/security/endpoint-authorization-matrix.md
+++ b/docs/security/endpoint-authorization-matrix.md
@@ -7,13 +7,48 @@ Generated behaviour is asserted in `services/api/tests/test_api_rbac.py`.
 
 ## Roles
 
-| Role | Intent |
-| --- | --- |
-| `memory_reader` | Read and write **their own** memory. The default for an authenticated caller with no recognised role claim. |
-| `memory_admin` | Manage memory across the tenant: approve, archive, delete, retention, consent. |
-| `auditor` | Read governance evidence tenant-wide. **Cannot mutate memory** — an auditor who can edit what they audit is not an auditor. |
-| `tenant_admin` | Every permission, within one tenant. |
-| `service_worker` | Machine identity for the worker fleet: operational reads and replay only, never memory content. |
+| API role | Web persona | Intent |
+| --- | --- | --- |
+| `memory_viewer` | `viewer` | Read their own memory and audit. No writes. |
+| `memory_user` | `developer` | Full self-service over their **own** records — read, write, archive, **delete**. The default where a fallback is permitted. |
+| `auditor` | `auditor` | Read governance evidence tenant-wide. **Cannot mutate memory** — an auditor who can edit what they audit is not an auditor. |
+| `memory_admin` | `memory_admin` | Manage memory across the tenant: approve, reject, archive, delete, retention, consent. Does **not** inherit tenant-wide audit. |
+| `tenant_admin` | `owner` | Every permission, within one tenant. |
+| `service_worker` | *(none — machine only)* | Operational reads and replay. Never memory content. |
+
+`memory_reader` remains an accepted **alias** for `memory_user`. It shipped in the
+first RBAC release and could already write, so the name was misleading.
+
+### Web personas are translated, not assumed
+
+The web names *personas*; the API names *authorization bundles*.
+`contracts/auth-role-map.json` is the authoritative source for the **translation
+between them** — not for the authorization model itself. The permission bundles
+live in `services/api/app/auth/roles.py`; tests assert that the contract and the API
+role vocabulary agree.
+
+This was a real defect: the BFF minted the web persona name straight into the API
+credential, so `viewer`, `developer` and `owner` named nothing the API recognised and
+resolved to **zero permissions** — three of the five human roles, including the one
+the demo identity uses. Fail-closed, but broken.
+
+Web tests assert every persona maps to something and that both BFF paths use the
+translation; API tests assert every target is a role the API recognises and grants
+the intended permissions. Neither side can drift alone.
+
+### Capabilities, not ranks
+
+`auditor` and `memory_admin` are separate capabilities. A memory administrator does
+**not** automatically receive tenant-wide audit, and an auditor cannot mutate. Someone
+needing both carries both, or is a `tenant_admin`.
+
+### Scope is part of the permission
+
+`memory:delete:self` and `memory:delete:tenant` are different powers, so the scope is
+in the name rather than inferred. `memory:delete:self` belongs to an ordinary user —
+removing your own memory is a user-control guarantee, and requiring tenant-admin for
+it would invert that. Approval and rejection are tenant-only: a user approving their
+own pending sensitive memory would defeat the queue that put it there.
 
 Role resolution has **three** states, not two:
 

--- a/scripts/sync_role_contract.py
+++ b/scripts/sync_role_contract.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Generate apps/web/lib/roleMap.generated.ts from contracts/auth-role-map.json.
+
+Why generate instead of importing the JSON directly
+---------------------------------------------------
+`contracts/auth-role-map.json` is the single source of truth for the web-persona →
+API-role translation, and it lives at the repository root so both sides can read it.
+The API reads it in tests, which run from a checkout — fine.
+
+The web app needs it at *build* time, and `apps/web/Dockerfile` builds with
+`apps/web` as its context, so a `../../../contracts/...` import is simply not
+present in the image. The production build failed exactly there.
+
+Rather than widen the Docker context to the whole repository, this mirrors the
+pattern already proven for dependencies (`scripts/sync_dependencies.py`): the
+contract stays authoritative, a generated file is committed inside the build
+context, and CI fails on drift so the two cannot diverge.
+
+Usage:
+    python scripts/sync_role_contract.py            # regenerate
+    python scripts/sync_role_contract.py --check    # exit 1 on drift (CI gate)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = REPO_ROOT / "contracts" / "auth-role-map.json"
+GENERATED = REPO_ROOT / "apps" / "web" / "lib" / "roleMap.generated.ts"
+
+
+def render(contract: dict) -> str:
+    web_to_api = contract["web_to_api"]
+    api_roles = contract["api_roles"]
+    never_human = contract.get("never_assignable_to_humans", [])
+
+    entries = "\n".join(f'  {k}: "{v}",' for k, v in web_to_api.items())
+    roles = "\n".join(f'  "{r}",' for r in api_roles)
+    machine = "\n".join(f'  "{r}",' for r in never_human)
+
+    return f"""// GENERATED FILE — DO NOT EDIT BY HAND.
+//
+// Source of truth: contracts/auth-role-map.json
+// Regenerate:      python scripts/sync_role_contract.py
+// Verify:          python scripts/sync_role_contract.py --check   (CI gate)
+//
+// Committed inside apps/web because the web Dockerfile builds with apps/web as its
+// context, so a repo-root import is not present in the image.
+
+export const WEB_TO_API_ROLE_MAP = {{
+{entries}
+}} as const;
+
+export const API_ROLES = [
+{roles}
+] as const;
+
+export const NEVER_ASSIGNABLE_TO_HUMANS = [
+{machine}
+] as const;
+
+export const ROLE_CONTRACT_VERSION = {contract.get("version", 1)};
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="exit 1 on drift")
+    args = parser.parse_args()
+
+    expected = render(json.loads(CONTRACT.read_text()))
+    current = GENERATED.read_text() if GENERATED.exists() else None
+
+    if current == expected:
+        print("✓ apps/web/lib/roleMap.generated.ts matches contracts/auth-role-map.json")
+        return 0
+
+    if args.check:
+        print(
+            "Role contract drift: apps/web/lib/roleMap.generated.ts no longer matches\n"
+            "contracts/auth-role-map.json, which is the source of truth.\n\n"
+            "    python scripts/sync_role_contract.py\n\n"
+            "then commit the regenerated file.",
+            file=sys.stderr,
+        )
+        return 1
+
+    GENERATED.write_text(expected)
+    print(f"✓ wrote {GENERATED.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/api/app/auth/roles.py
+++ b/services/api/app/auth/roles.py
@@ -38,14 +38,21 @@ from enum import Enum
 class Permission(str, Enum):
     """What a caller may do. Checked directly by routes."""
 
-    # Memory lifecycle, scoped to the caller's own user.
+    # Memory lifecycle. Scope is part of the permission name: "may I do this to my
+    # own records, or to anyone's in the tenant?" are different powers, and an
+    # unscoped `memory:delete` could not express the difference.
     MEMORY_READ_SELF = "memory:read:self"
-    MEMORY_WRITE_SELF = "memory:write:self"
-    # Tenant-wide memory management (any user in the tenant).
     MEMORY_READ_TENANT = "memory:read:tenant"
-    MEMORY_APPROVE = "memory:approve"
-    MEMORY_ARCHIVE = "memory:archive"
-    MEMORY_DELETE = "memory:delete"
+    MEMORY_WRITE_SELF = "memory:write:self"
+    MEMORY_WRITE_TENANT = "memory:write:tenant"
+    MEMORY_ARCHIVE_SELF = "memory:archive:self"
+    MEMORY_ARCHIVE_TENANT = "memory:archive:tenant"
+    MEMORY_DELETE_SELF = "memory:delete:self"
+    MEMORY_DELETE_TENANT = "memory:delete:tenant"
+    # Approval is tenant governance by definition: a user approving their own
+    # pending sensitive memory would defeat the queue that put it there.
+    MEMORY_APPROVE_TENANT = "memory:approve:tenant"
+    MEMORY_REJECT_TENANT = "memory:reject:tenant"
     # Governance and evidence surfaces.
     AUDIT_READ_SELF = "audit:read:self"
     AUDIT_READ_TENANT = "audit:read:tenant"
@@ -62,13 +69,30 @@ class Permission(str, Enum):
 
 
 class Role(str, Enum):
-    """Named bundles of permissions. Kept few on purpose."""
+    """Named bundles of permissions. Kept few on purpose.
 
-    MEMORY_READER = "memory_reader"
-    MEMORY_ADMIN = "memory_admin"
+    These are the *authorization* vocabulary. The web app has its own *persona*
+    vocabulary (viewer / developer / auditor / memory_admin / owner); the two are
+    joined by `contracts/auth-role-map.json`, not by matching strings. Minting a web
+    persona name straight into an API credential left three of the five human roles
+    naming nothing the API recognised.
+    """
+
+    MEMORY_VIEWER = "memory_viewer"
+    MEMORY_USER = "memory_user"
     AUDITOR = "auditor"
+    MEMORY_ADMIN = "memory_admin"
     TENANT_ADMIN = "tenant_admin"
     SERVICE_WORKER = "service_worker"
+
+
+#: Accepted role names that are not `Role` values. `memory_reader` shipped in the
+#: first RBAC release and could already write, so the name was misleading: it is a
+#: self-service memory *user*, not a reader. Kept so existing credentials keep
+#: working while the accurate name becomes canonical.
+ROLE_ALIASES: dict[str, Role] = {
+    "memory_reader": Role.MEMORY_USER,
+}
 
 
 _P = Permission
@@ -76,21 +100,33 @@ _P = Permission
 #: Static role → permission mapping. A role is only a name for a bundle; every
 #: check is against a permission, so adding a role never implicitly grants access
 #: to an endpoint that did not ask for its permission.
+_SELF_MEMORY = frozenset(
+    {
+        _P.MEMORY_READ_SELF,
+        _P.MEMORY_WRITE_SELF,
+        _P.MEMORY_ARCHIVE_SELF,
+        # Self-deletion belongs to an ordinary user. Removing your own memory is a
+        # user-control guarantee; requiring tenant-admin for it would invert that.
+        _P.MEMORY_DELETE_SELF,
+        _P.AUDIT_READ_SELF,
+    }
+)
+
 ROLE_PERMISSIONS: dict[Role, frozenset[Permission]] = {
-    # The default for an authenticated caller with no recognised role claim.
-    # Least privilege: read and write *their own* memory, read *their own* audit.
-    Role.MEMORY_READER: frozenset(
-        {_P.MEMORY_READ_SELF, _P.MEMORY_WRITE_SELF, _P.AUDIT_READ_SELF}
-    ),
-    Role.MEMORY_ADMIN: frozenset(
+    # Read-only persona.
+    Role.MEMORY_VIEWER: frozenset({_P.MEMORY_READ_SELF, _P.AUDIT_READ_SELF}),
+    # The default for an authenticated caller with no role claim, where the
+    # deployment permits that fallback. Full self-service over their own records.
+    Role.MEMORY_USER: _SELF_MEMORY,
+    Role.MEMORY_ADMIN: _SELF_MEMORY
+    | frozenset(
         {
-            _P.MEMORY_READ_SELF,
-            _P.MEMORY_WRITE_SELF,
             _P.MEMORY_READ_TENANT,
-            _P.MEMORY_APPROVE,
-            _P.MEMORY_ARCHIVE,
-            _P.MEMORY_DELETE,
-            _P.AUDIT_READ_SELF,
+            _P.MEMORY_WRITE_TENANT,
+            _P.MEMORY_ARCHIVE_TENANT,
+            _P.MEMORY_DELETE_TENANT,
+            _P.MEMORY_APPROVE_TENANT,
+            _P.MEMORY_REJECT_TENANT,
             _P.RETENTION_MANAGE,
             _P.CONSENT_MANAGE,
         }
@@ -122,7 +158,7 @@ ROLE_PERMISSIONS: dict[Role, frozenset[Permission]] = {
 #: to a mistyped credential: `roles=["service_workre"]` would resolve to
 #: `memory_reader` and receive `memory:read:self` + `memory:write:self`. A typo must
 #: not grant anything.
-DEFAULT_ROLE = Role.MEMORY_READER
+DEFAULT_ROLE = Role.MEMORY_USER
 
 
 def parse_roles(raw: object) -> frozenset[Role]:
@@ -141,7 +177,7 @@ def parse_roles(raw: object) -> frozenset[Role]:
     else:
         return frozenset()
 
-    known = {r.value: r for r in Role}
+    known = {r.value: r for r in Role} | ROLE_ALIASES
     return frozenset(known[c.strip()] for c in candidates if c.strip() in known)
 
 

--- a/services/api/tests/test_api_rbac.py
+++ b/services/api/tests/test_api_rbac.py
@@ -21,6 +21,8 @@ the API directly rather than through the BFF.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from app.auth.roles import (
@@ -57,10 +59,13 @@ def test_an_authenticated_caller_without_roles_gets_least_privilege():
     assert p.effective_roles == frozenset({DEFAULT_ROLE})
     assert p.has(Permission.MEMORY_READ_SELF)
     assert p.has(Permission.MEMORY_WRITE_SELF)
+    # Self-service over their own records, including deleting them.
+    assert p.has(Permission.MEMORY_DELETE_SELF)
     # Never a tenant-wide or administrative default.
     assert not p.has(Permission.AUDIT_READ_TENANT)
     assert not p.has(Permission.RETENTION_MANAGE)
-    assert not p.has(Permission.MEMORY_DELETE)
+    assert not p.has(Permission.MEMORY_DELETE_TENANT)
+    assert not p.has(Permission.MEMORY_APPROVE_TENANT)
 
 
 def test_auditor_can_read_tenant_evidence_but_not_mutate_memory():
@@ -70,8 +75,9 @@ def test_auditor_can_read_tenant_evidence_but_not_mutate_memory():
     assert Permission.EVIDENCE_READ in granted
     assert Permission.METRICS_READ_TENANT in granted
     for denied in (
-        Permission.MEMORY_DELETE,
-        Permission.MEMORY_APPROVE,
+        Permission.MEMORY_DELETE_SELF,
+        Permission.MEMORY_DELETE_TENANT,
+        Permission.MEMORY_APPROVE_TENANT,
         Permission.RETENTION_MANAGE,
         Permission.CONSENT_MANAGE,
         Permission.MEMORY_WRITE_SELF,
@@ -95,6 +101,9 @@ def test_every_role_is_mapped():
 
 
 # ── the audit endpoint ───────────────────────────────────────────────────────
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
 def _hdr(user: str, roles: str | None = None, tenant: str = "acme") -> dict:
     h = {"X-MemoryOps-Tenant": tenant, "X-MemoryOps-User": user}
     if roles:
@@ -411,3 +420,136 @@ def test_a_production_credential_without_roles_gets_nothing():
         require_role_claim=True,
     )
     assert strict.permissions == frozenset()
+
+
+# ── the web↔API role contract ────────────────────────────────────────────────
+# The web and API vocabularies were independent, and the BFF minted the web persona
+# name straight into the API credential. viewer / developer / owner named nothing
+# the API recognised, so three of the five human roles resolved to ZERO permissions
+# — including `owner`, which the demo identity uses.
+#
+# An earlier propagation test asserted only that the claim *shape* was `roles: [...]`.
+# It could not catch this, because the shape was right and the value was wrong.
+def _role_contract() -> dict:
+    import json
+
+    return json.loads((REPO_ROOT / "contracts" / "auth-role-map.json").read_text())
+
+
+def test_every_web_persona_maps_to_a_role_the_api_recognises():
+    from app.auth.roles import parse_roles
+
+    contract = _role_contract()
+    for web_role, api_role in contract["web_to_api"].items():
+        resolved = parse_roles([api_role])
+        assert resolved, (
+            f"web role '{web_role}' maps to '{api_role}', which the API does not "
+            "recognise — that credential would receive zero permissions"
+        )
+
+
+def test_every_mapped_api_role_grants_something():
+    from app.auth.roles import parse_roles, permissions_for
+
+    for api_role in _role_contract()["web_to_api"].values():
+        assert permissions_for(parse_roles([api_role])), f"{api_role} grants nothing"
+
+
+def test_no_human_persona_maps_to_the_service_worker_role():
+    """service_worker is a machine identity scoped to operational permissions."""
+    contract = _role_contract()
+    assert "service_worker" not in contract["web_to_api"].values()
+    assert contract["never_assignable_to_humans"] == ["service_worker"]
+
+
+def test_the_contract_lists_exactly_the_api_roles_that_exist():
+    from app.auth.roles import Role
+
+    assert set(_role_contract()["api_roles"]) == {r.value for r in Role}
+
+
+def test_the_memory_reader_alias_still_resolves():
+    """Existing credentials from the first RBAC release keep working."""
+    from app.auth.roles import Role, parse_roles
+
+    assert parse_roles(["memory_reader"]) == frozenset({Role.MEMORY_USER})
+
+
+@pytest.mark.parametrize(
+    ("web_role", "must_have", "must_not_have"),
+    [
+        ("viewer", [Permission.MEMORY_READ_SELF], [Permission.MEMORY_WRITE_SELF]),
+        (
+            "developer",
+            [Permission.MEMORY_WRITE_SELF, Permission.MEMORY_DELETE_SELF],
+            [Permission.MEMORY_DELETE_TENANT, Permission.AUDIT_READ_TENANT],
+        ),
+        (
+            "auditor",
+            [Permission.AUDIT_READ_TENANT, Permission.EVIDENCE_READ],
+            [Permission.MEMORY_WRITE_SELF, Permission.MEMORY_DELETE_TENANT],
+        ),
+        (
+            "memory_admin",
+            [Permission.MEMORY_APPROVE_TENANT, Permission.RETENTION_MANAGE],
+            [Permission.AUDIT_READ_TENANT],
+        ),
+        (
+            "owner",
+            [Permission.AUDIT_READ_TENANT, Permission.MEMORY_DELETE_TENANT],
+            [],
+        ),
+    ],
+)
+def test_each_web_persona_receives_the_intended_api_permissions(
+    web_role, must_have, must_not_have
+):
+    """Semantics, not shape: mint what the BFF mints, resolve it as the API does."""
+    from app.auth.principal import Principal
+    from app.auth.roles import resolve_roles
+
+    api_role = _role_contract()["web_to_api"][web_role]
+    roles, present = resolve_roles([api_role])
+    principal = Principal(
+        tenant_id="t", user_id="u", provider="jwt",
+        roles=roles, role_claim_present=present,
+    )
+    for permission in must_have:
+        assert principal.has(permission), f"{web_role} lacks {permission.value}"
+    for permission in must_not_have:
+        assert not principal.has(permission), f"{web_role} wrongly holds {permission.value}"
+
+
+def test_self_deletion_belongs_to_an_ordinary_user():
+    """Removing your own memory is a user-control guarantee — it must not require
+    becoming a tenant memory administrator."""
+    from app.auth.roles import Role, permissions_for
+
+    user = permissions_for(frozenset({Role.MEMORY_USER}))
+    assert Permission.MEMORY_DELETE_SELF in user
+    assert Permission.MEMORY_DELETE_TENANT not in user
+
+
+def test_approval_is_tenant_governance_not_self_service():
+    """A user approving their own pending sensitive memory defeats the queue."""
+    from app.auth.roles import Role, permissions_for
+
+    user = permissions_for(frozenset({Role.MEMORY_USER}))
+    assert Permission.MEMORY_APPROVE_TENANT not in user
+    assert Permission.MEMORY_REJECT_TENANT not in user
+    assert Permission.MEMORY_APPROVE_TENANT in permissions_for(frozenset({Role.MEMORY_ADMIN}))
+
+
+def test_an_auditor_cannot_mutate_and_an_admin_is_not_automatically_an_auditor():
+    """These are separate capabilities, not ranks on one ladder."""
+    from app.auth.roles import Role, permissions_for
+
+    auditor = permissions_for(frozenset({Role.AUDITOR}))
+    admin = permissions_for(frozenset({Role.MEMORY_ADMIN}))
+
+    assert Permission.MEMORY_WRITE_SELF not in auditor
+    assert Permission.MEMORY_DELETE_TENANT not in auditor
+    # memory_admin manages lifecycle but does not inherit tenant-wide audit.
+    assert Permission.AUDIT_READ_TENANT not in admin
+    # Only tenant_admin holds both.
+    assert Permission.AUDIT_READ_TENANT in permissions_for(frozenset({Role.TENANT_ADMIN}))

--- a/services/api/tests/test_packaging.py
+++ b/services/api/tests/test_packaging.py
@@ -218,3 +218,24 @@ def test_behaviour_changing_upgrades_are_not_auto_grouped():
     # packaging and test tooling is not a reviewable unit.
     patterns = [p for g in api.get("groups", {}).values() for p in g.get("patterns", [])]
     assert "*" not in patterns, "a catch-all group re-creates the unreviewable bundle"
+
+
+# ── role contract mirror ────────────────────────────────────────────────────
+def test_the_web_role_map_mirror_matches_the_contract():
+    """`contracts/auth-role-map.json` is authoritative;
+    `apps/web/lib/roleMap.generated.ts` is a committed mirror.
+
+    The mirror exists because the web Dockerfile builds with `apps/web` as its
+    context, so importing the repo-root contract is absent from the image — the
+    production build failed on exactly that. Same rule as the dependency mirrors:
+    generated, never hand-edited, drift is a failure.
+    """
+    proc = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "sync_role_contract.py"), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"role contract drift:\n{proc.stdout}\n{proc.stderr}\n"
+        "Run: python scripts/sync_role_contract.py"
+    )


### PR DESCRIPTION
Blocks route coverage. Based directly on `main`.

## Reproduced on merged main

The BFF minted `identity.role` straight into the API credential:

```
viewer        -> (unrecognised)   0 perms
developer     -> (unrecognised)   0 perms
auditor       -> auditor          7 perms
memory_admin  -> memory_admin     9 perms
owner         -> (unrecognised)   0 perms
```

**Three of the five human roles had no API access at all** — including `owner`, which the demo identity uses. Fail-closed since #116, but the authenticated web experience was broken.

My earlier propagation test asserted the claim **shape** (`roles: [...]`) and therefore could not catch this: the shape was right and the value was wrong. That is precisely the weakness in asserting structure rather than semantics.

## One contract, read by both sides

`contracts/auth-role-map.json`. `apiRoleForWebRole()` is used by **both** the JWT and trusted-header paths — no duplicated mapping. An unknown persona raises rather than passing through, since passing through is how the break happened.

| Web persona | API role |
| --- | --- |
| `viewer` | `memory_viewer` |
| `developer` | `memory_user` |
| `auditor` | `auditor` |
| `memory_admin` | `memory_admin` |
| `owner` | `tenant_admin` |

`memory_reader` stays an accepted **alias** for `memory_user` — it shipped in the first RBAC release and could already write, so the name was misleading.

## Scope is part of the permission

`memory:delete:self` vs `memory:delete:tenant` are different powers, so scope is in the name rather than inferred.

**`memory:delete:self` belongs to an ordinary user.** Removing your own memory is a user-control guarantee; requiring tenant-admin for it would invert that. Conversely **approval and rejection are tenant-only** — a user approving their own pending sensitive memory would defeat the queue #103 puts it in.

## Capabilities, not ranks

`memory_admin` no longer implicitly holds tenant-wide audit. An auditor cannot mutate; an administrator is not automatically an auditor. Someone needing both carries both, or is `tenant_admin`.

The web still models an ordinal ladder (`hasAtLeast`); replacing it with capability checks belongs to route coverage, as you noted.

## Tests assert semantics

Every persona maps to a role the API recognises; every mapped role grants the intended permissions **and withholds the others**; no human persona maps to `service_worker`; both BFF paths use the translation and neither passes the raw persona.

Two earlier tests asserted pre-fix behaviour and were updated rather than kept — including one that pinned `identity.role` directly, which *is* the bug.

747 API tests · 49 web tests · ruff + web lint + typecheck clean · evals PASS · benchmark PASS · invariant gate PASS.

## Out of scope

Route enforcement of the new scoped permissions (the vocabulary lands here, enforcement in `feat/api-rbac-route-coverage`), the web `hasAtLeast` → capability replacement, and the router-enumeration guard.