### PR TITLE
feat(auth): centralize authorization decisions and ownership lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable releases. Git tags + GitHub Releases are the source of truth; this
 file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
 
+## Unreleased — API authorization boundary
+
+- **Every route is classified, and the classification is enforced in CI.**
+  `app/auth/authz_spec.py` states each route's scope (public / authenticated /
+  self / subject / tenant / resource / operator), its required permission, and
+  whether it is enforced or still planned. A route added without a spec fails the
+  build, and `docs/security/endpoint-authorization-matrix.md` is generated from
+  the spec rather than maintained by hand, so the published matrix cannot drift
+  from the code.
+- **Four authorization helpers** (`app/auth/decisions.py`) replace ad-hoc checks:
+  a fixed capability, a requested subject, a loaded record, and an
+  action-determined permission are four different questions. Ownership-based
+  checks decide from the **stored** record, never from request values, and each
+  records a content-free witness so a route cannot be called enforced without
+  runtime evidence the check ran.
+- **A tenant-only action stays tenant-only on your own record.** `approve` /
+  `reject` declare no self permission, so owning a memory does not let you approve
+  it — self-approval would defeat the review queue that held it.
+- **`GET /api/audit`** now resolves its subject through the shared helper; only
+  the resolved tenant/user reach the repository.
+
+### Behaviour changes
+- **`PATCH /api/memories/{id}` with no changed field now returns 422** (was 200
+  with the unchanged record). Such a body requests no action, so there is no
+  permission it could be authorized against, and it wrote a governance loop run
+  and a `memory_updated` audit event for a mutation that never happened. Refused
+  before any evidence is written. `MemoryOpsClient.update_memory()` raises
+  `ValueError` locally for the same case. No web caller sends an empty patch.
+  This narrows a previously-accepted request shape, so it is a behavioural
+  correction rather than an additive change; every patch that requests a real
+  change is unaffected.
+
 ## Unreleased — worker mutation atomicity
 Additive; completes invariant #7 across the whole system.
 

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -151,6 +151,28 @@ per-memory `AuditEvent[]`, newest first.
 Body: `{ tenant_id, user_id, content?, importance?, confidence?, status?, expected_revision? }`.
 Returns the updated `MemoryRecord`. Emits an audit event.
 
+At least one of `content`, `importance`, `confidence`, `status` is **required**. A
+body carrying only scope (and optionally `expected_revision`) returns `422`.
+
+> **Behaviour change (v2.4).** This previously returned `200` with the unchanged
+> record. Such a request asks for no action, so there is no permission it could be
+> authorized against — yet it opened a governance loop run and wrote a
+> `memory_updated` audit event for a mutation that never happened, making a no-op
+> indistinguishable from a real edit in the trail. It is now refused before any
+> evidence is written, and before the memory is looked up, so it cannot be used to
+> probe which ids exist. Every patch that requests a real change is unaffected.
+> `MemoryOpsClient.update_memory()` raises `ValueError` locally for the same case.
+
+### One patch can request several actions
+
+`{ "content": ..., "status": "active" }` is an **edit and an approval**. The two are
+governed differently — `edit` has a self permission, `approve` deliberately does not,
+because approving your own pending memory defeats the review queue that held it.
+Authorization therefore derives the full set of requested actions and requires *every*
+applicable permission, rather than keying off the status transition alone. Otherwise
+`memory:approve:tenant` would implicitly grant a content edit, letting an approver
+rewrite the text in the same request that approves it.
+
 ### Content edits are governed
 
 A `content` change runs through the **governed update service**, not a direct
@@ -236,9 +258,17 @@ audit `memory_deleted`. The memory is never retrievable again.
 Query: `tenant_id` (req), `user_id` (opt), `memory_id` (opt), `limit` (opt, ≤1000).
 Returns `AuditEvent[]` (append-only), newest first.
 
-**Authorization.** A tenant-wide read — omitting `user_id`, or naming another user —
-requires the `audit:read:tenant` permission. Without it the query is forced to the
-caller's own `user_id`; a request naming another user returns `403`.
+**Authorization.** A tenant-wide read — omitting `user_id`, **or** naming another
+user — requires the `audit:read:tenant` permission. Without it both forms return
+`403`; only a request that names the caller's own `user_id` succeeds.
+
+Omitting `user_id` is a tenant-wide request, not an implicit "my own". Reinterpreting
+it as self-scoped would succeed with narrower data than the caller asked for, quietly
+changing the meaning of the request — and omission is exactly how this endpoint
+leaked in the first place. Callers wanting their own rows name themselves.
+
+Only the resolved tenant/user reach the repository; the request's own values are
+never passed through after validation (`authorize_subject_scope`).
 
 `user_id` was previously optional *and unauthorized*, and the scope-validation
 middleware only checks a `user_id` that is **present** — so omitting it skipped

--- a/docs/memory-control-plane.md
+++ b/docs/memory-control-plane.md
@@ -62,6 +62,28 @@ Newest-first lifecycle history scoped to one memory.
 gains the `memory_id` filter, implemented in both the in-memory and Postgres
 backends. No other repository contract changed.
 
+### Authorization lookup (v2.4)
+
+`Repository.get_memory_in_tenant(tenant_id, memory_id)` loads a memory by id within a
+tenant, **across users**, so ownership can be decided before the owner is known — a
+per-user lookup cannot distinguish "not yours" from "does not exist", and the route
+needs the owner to pick which permission applies. The tenant is a predicate in the
+query, never a check applied to a globally loaded row. See
+[security.md](security.md#authorization-decisions-are-centralized-v24).
+
+## PATCH is not one action (v2.4)
+
+`{ "content": ..., "status": "active" }` edits the memory **and** approves it. The
+control plane treats these as one call, but they are governed differently: `edit` has
+a self permission, `approve` deliberately does not. Authorization requires every
+action the body requests, so an approver cannot rewrite what they are approving in the
+request that approves it.
+
+A patch that changes nothing now returns `422` instead of `200` — it requests no
+action, so there is no permission to check it against, and it was writing a loop run
+and a `memory_updated` event for a mutation that never happened. The web UI always
+sends a field, so no control-plane surface changes.
+
 ## Explainability: "why a memory was used"
 
 v0.5 explains retrieval through signals already in the system:

--- a/docs/security.md
+++ b/docs/security.md
@@ -201,6 +201,93 @@ The most dangerous failures for an AI memory system are:
   [worker-runtime.md](worker-runtime.md) and
   [ADR-012](../infra/adr/ADR-012-worker-runtime-orchestration.md).
 
+## Authorization decisions are centralized (v2.4)
+
+Authentication answers *who are you*. Authorization answers *may you do this on
+this record*, and until v2.4 each route answered it in its own way — which is how
+`GET /api/audit` came to return tenant-wide rows to any authenticated caller.
+
+### The route contract
+
+`app/auth/authz_spec.py` states, for every route, its **scope**, the permission it
+requires, and whether that requirement is `enforced` or still `planned`:
+
+| Scope | Meaning |
+| --- | --- |
+| `public` | no credential (health, readiness) |
+| `authenticated` | any verified principal |
+| `self` | acts only on the caller |
+| `subject` | resolves a *requested* subject; no stored record exists to inspect |
+| `tenant` | tenant-wide data; needs a `:tenant` permission |
+| `resource` | loads a stored record first, then decides from its owner |
+| `operator` | operational surface, not memory content |
+
+A route added without a spec fails the build, and
+[security/endpoint-authorization-matrix.md](security/endpoint-authorization-matrix.md)
+is **generated** from the spec — the published matrix cannot drift from the code.
+
+`planned` is stated deliberately. A route listed as enforced that is not would be
+worse than an unlisted one, because the matrix is what a reader trusts.
+
+### The four helpers
+
+`app/auth/decisions.py` — separate helpers, not one with optional arguments. A fixed
+capability, a requested subject, a loaded record, and an action-determined permission
+are four different questions; one signature covering all four makes every call site
+look plausible while doing something subtly different.
+
+- `require_permission` — a fixed capability.
+- `authorize_subject_scope` — resolves which subject may be queried and **forces the
+  query to it**. The returned tenant/user are the only values that may reach the
+  repository; echoing back the caller's values after validating them leaves untrusted
+  input in the query path, which is not authorization.
+- `authorize_loaded_resource` — decides from the **stored** record's owner. Never from
+  `tenant_id` / `user_id` in the body, which the caller controls.
+- `authorize_transition` — picks the permission from the action the server already
+  validated, never from a client-supplied action string. An action the route never
+  declared fails closed (500) rather than falling back to a route-level permission.
+
+### Two rules that are easy to get wrong
+
+**Ownership does not grant a tenant-only action.** `approve` and `reject` declare no
+self permission, so owning a memory does not let you approve it — self-approval
+defeats the review queue that held it. A missing self branch means *tenant-only*, not
+*own record, therefore allowed*.
+
+**Concealment over refusal.** A cross-tenant record, or another user's record you may
+not touch, answers `404`, not `403`. A `403` confirms the record exists, which is
+itself a disclosure — an attacker can enumerate ids by status code alone.
+
+### Enforcement evidence
+
+Each helper records a content-free **witness** (`app/auth/witness.py`): the route, the
+helper, the permission, the action, and whether the check was tenant-scoped. A pinned
+list of enforced routes is only a claim; the witness is runtime evidence that a check
+actually ran, so a handler that silently stopped checking — and would still return the
+right answer for an authorized caller — is detectable.
+
+### Cross-tenant lookup for ownership
+
+Deciding ownership needs the record *before* the owner is known, so it cannot filter
+by `user_id`. `Repository.get_memory_in_tenant(tenant_id, memory_id)` provides this
+with the tenant as a **predicate in the query** — not a global lookup by id with the
+tenant compared afterward, which is one dropped condition away from a cross-tenant
+read while reading as safe because the comparison is right there. RLS
+(`004_rls_policies.sql`) remains the outer guarantee; neither layer is alone
+load-bearing.
+
+It deliberately returns soft-deleted rows, so the deletion guarantee is re-proved
+against it in `tests/test_deletion.py`: the lookup is not a retrieval path, and
+nothing downstream re-enters retrieval or context.
+
+### What is not claimed
+
+This is an authorization boundary, not an authorization product. Roles are coarse
+named bundles, not per-record ACLs; there is no delegation, no attribute-based policy,
+and no per-field redaction by role. Route statuses are moving from `planned` to
+`enforced` incrementally — read the generated matrix for the current state rather than
+assuming the whole surface is covered.
+
 ## Production hardening roadmap
 
 - Encryption at rest (pgcrypto / disk) + field-level encryption for high-sensitivity content.

--- a/docs/security/endpoint-authorization-matrix.md
+++ b/docs/security/endpoint-authorization-matrix.md
@@ -92,7 +92,7 @@ The handler checks the permission. 3 of 39 routes.
 | Method | Path | Scope | Permission | Note |
 | --- | --- | --- | --- | --- |
 | `GET` | `/api/admin/workers/health` | operator | `worker:read` |  |
-| `GET` | `/api/audit` | resource | `audit:read:self` (own) / `audit:read:tenant` (tenant) | tenant-wide requires audit:read:tenant; otherwise forced to own user |
+| `GET` | `/api/audit` | subject | `audit:read:self` (own) / `audit:read:tenant` (tenant) | tenant-wide requires audit:read:tenant; otherwise forced to own user |
 | `GET` | `/api/metrics` | tenant | `metrics:read:tenant` |  |
 
 ### Planned — declared, **not yet enforced**
@@ -119,7 +119,7 @@ control.**
 | `GET` | `/api/memories` | subject | `memory:read:self` (own) / `memory:read:tenant` (tenant) |  |
 | `DELETE` | `/api/memories/{memory_id}` | resource | `memory:delete:self` (own) / `memory:delete:tenant` (tenant) | a user may delete their own pending memory; legal hold still overrides |
 | `GET` | `/api/memories/{memory_id}` | resource | `memory:read:self` (own) / `memory:read:tenant` (tenant) |  |
-| `PATCH` | `/api/memories/{memory_id}` | resource | `memory:write:self` (own) / `memory:write:tenant` (tenant) | The action comes from the validated transition, never a client-supplied string. Legal hold and the revision check still apply — authorization does not bypass them. |
+| `PATCH` | `/api/memories/{memory_id}` | resource | — *(any authenticated principal)* | The action comes from the validated transition, never a client-supplied string. Legal hold and the revision check still apply — authorization does not bypass them. |
 | `GET` | `/api/memories/{memory_id}/audit` | resource | `audit:read:self` (own) / `audit:read:tenant` (tenant) |  |
 | `GET` | `/api/memories/{memory_id}/provenance` | resource | `memory:read:self` (own) / `memory:read:tenant` (tenant) |  |
 | `POST` | `/api/retention/consent` | tenant | `consent:manage` |  |

--- a/packages/memoryops-sdk/memoryops/client.py
+++ b/packages/memoryops-sdk/memoryops/client.py
@@ -200,6 +200,14 @@ class MemoryOpsClient:
         ):
             if val is not None:
                 body[key] = val
+        if len(body) == len(self._scope()):
+            # The server refuses this with 422: a patch requesting no change has no
+            # action, so there is no permission it could be authorized against.
+            # Fail here instead, where the caller can see which argument they missed.
+            raise ValueError(
+                "update_memory() requires at least one of "
+                "content, importance, confidence, status"
+            )
         return Memory.from_dict(self._request("PATCH", f"/api/memories/{memory_id}", json=body))
 
     def delete_memory(self, memory_id: str) -> dict:

--- a/packages/memoryops-sdk/tests/test_client_unit.py
+++ b/packages/memoryops-sdk/tests/test_client_unit.py
@@ -196,3 +196,35 @@ def test_no_auth_sends_no_authorization_header() -> None:
     with _client(handler) as mo:
         mo.list_memories()
     assert seen["auth"] is None
+
+
+def test_update_memory_with_no_fields_never_reaches_the_network() -> None:
+    """The server refuses an empty patch with 422 — a body with no action has no
+    permission to authorize it against. The SDK should say which argument is
+    missing rather than surface a status code from a request it should not send."""
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(200, json={})
+
+    client = _client(handler)
+    with pytest.raises(ValueError, match="at least one of"):
+        client.update_memory("m1")
+    assert calls == [], "no request should have been sent"
+
+
+def test_update_memory_still_accepts_a_single_field() -> None:
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.update(json.loads(request.content))
+        return httpx.Response(200, json={
+            "id": "m1", "content": "x", "memory_type": "preference",
+            "status": "active", "importance": 5, "confidence": 0.8,
+            "sensitivity": "low",
+        })
+
+    client = _client(handler)
+    client.update_memory("m1", status="active")
+    assert seen["status"] == "active"

--- a/services/api/app/auth/authz_spec.py
+++ b/services/api/app/auth/authz_spec.py
@@ -102,13 +102,20 @@ class AuthzSpec:
     status: Status
     #: Required for SELF / TENANT / OPERATOR scopes.
     permission: Permission | None = None
-    #: Required for RESOURCE scope — which permission applies depends on whether the
-    #: loaded record belongs to the caller.
+    #: Required for RESOURCE/SUBJECT scope *without* variants — which permission
+    #: applies depends on whether the record (or requested subject) is the caller's.
+    #: A route that declares variants must leave these unset, so there is no generic
+    #: fallback path alongside the per-action ones.
     self_permission: Permission | None = None
     tenant_permission: Permission | None = None
     #: Set when one method/path performs several distinct actions.
     variants: tuple[AuthzVariant, ...] = ()
     note: str = ""
+
+    @property
+    def is_variant_driven(self) -> bool:
+        """True when authorization is decided per action rather than per route."""
+        return bool(self.variants)
 
     def variant(self, action: str) -> AuthzVariant | None:
         for candidate in self.variants:
@@ -186,10 +193,13 @@ ROUTE_AUTHZ: dict[tuple[str, str], AuthzSpec] = {
         tenant_permission=_P.MEMORY_READ_TENANT,
     ),
     ("PATCH", "/api/memories/{memory_id}"): AuthzSpec(
+        # Deliberately no top-level self/tenant pair. Carrying both a generic
+        # route-level check and per-variant checks leaves two authorization paths,
+        # and a handler could take the generic one and silently skip
+        # archive/approve/reject. With variants only, the safe path is the only
+        # representable path.
         _S.RESOURCE,
         _ST.PLANNED,
-        self_permission=_P.MEMORY_WRITE_SELF,
-        tenant_permission=_P.MEMORY_WRITE_TENANT,
         variants=(
             AuthzVariant(
                 "edit",
@@ -247,7 +257,10 @@ ROUTE_AUTHZ: dict[tuple[str, str], AuthzSpec] = {
     ),
     # ── governance + evidence ───────────────────────────────────────────────
     ("GET", "/api/audit"): AuthzSpec(
-        _S.RESOURCE,
+        # Resolves an optional requested user and forces the query to the caller
+        # when tenant-wide access is unavailable — a subject decision, not a loaded
+        # record. It was RESOURCE, which contradicted the registry's own definition.
+        _S.SUBJECT,
         _ST.ENFORCED,
         self_permission=_P.AUDIT_READ_SELF,
         tenant_permission=_P.AUDIT_READ_TENANT,

--- a/services/api/app/auth/decisions.py
+++ b/services/api/app/auth/decisions.py
@@ -1,0 +1,234 @@
+"""The four authorization helpers every governed route uses.
+
+Separate helpers rather than one with many optional arguments: a route that needs a
+fixed capability, a route that resolves a requested subject, a route that loads a
+record first, and a route whose action decides the permission are four different
+questions. Collapsing them into one signature makes every call site look plausible
+while doing something subtly different.
+
+Each helper returns the **trusted** values the handler must use from that point on,
+and records a content-free witness so a route cannot be called enforced without
+evidence the check ran.
+
+The rule that makes this work
+-----------------------------
+When a variant declares no self permission — `approve`, `reject` — the tenant
+permission is required *even on the caller's own record*. Ownership must not convert
+tenant governance into self-service: a user approving their own pending sensitive
+memory would defeat the queue that put it there. `authorize_loaded_resource` treats
+a missing self branch as "tenant-only", never as "own record, therefore allowed".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import HTTPException, Request
+
+from .dependencies import current_principal
+from .principal import Principal
+from .roles import Permission
+from .witness import AuthzDecision, record_decision, route_of
+
+
+@dataclass(frozen=True)
+class AuthorizedSubject:
+    """The tenant/user a handler is permitted to query.
+
+    These are the *only* values that may reach the repository. Returning the
+    caller's requested values after validating them would leave untrusted input in
+    the query path, which is not authorization.
+    """
+
+    tenant_id: str
+    user_id: str | None
+    tenant_scoped: bool
+
+
+@dataclass(frozen=True)
+class AuthorizationDecision:
+    """The outcome of an ownership-based check."""
+
+    permission: Permission
+    tenant_scoped: bool
+    action: str | None = None
+
+
+def _witness(
+    request: Request,
+    *,
+    helper: str,
+    permission: Permission | None,
+    action: str | None = None,
+    tenant_scoped: bool = False,
+) -> None:
+    route = route_of(request)
+    if route is None:
+        return
+    record_decision(
+        request,
+        AuthzDecision(
+            route=route,
+            helper=helper,
+            permission=permission,
+            action=action,
+            tenant_scoped=tenant_scoped,
+        ),
+    )
+
+
+def _require(principal: Principal, permission: Permission) -> None:
+    if not principal.has(permission):
+        raise HTTPException(
+            status_code=403,
+            detail=f"missing required permission '{permission.value}'",
+        )
+
+
+def authorize_subject_scope(
+    request: Request,
+    *,
+    requested_tenant_id: str,
+    requested_user_id: str | None,
+    self_permission: Permission,
+    tenant_permission: Permission,
+) -> AuthorizedSubject:
+    """Resolve which subject the caller may query, and force the query to it.
+
+    Used by collection routes, where no stored record exists to inspect ownership
+    on. Omitting the user is how `/api/audit` silently returned tenant-wide records:
+    the scope middleware only validates a `user_id` that is *present*.
+    """
+    principal = current_principal(request)
+    if principal is None:
+        # Auth disabled: unchanged development behaviour. Production refuses to start
+        # with auth_mode=none, so this path cannot reach it.
+        return AuthorizedSubject(requested_tenant_id, requested_user_id, tenant_scoped=False)
+
+    if requested_tenant_id != principal.tenant_id:
+        raise HTTPException(
+            status_code=403,
+            detail="request scope does not match authenticated principal",
+        )
+
+    # An *omitted* subject is treated as a tenant-wide request, not as an implicit
+    # "my own". Omitting it is precisely how /api/audit silently returned
+    # tenant-wide records — the scope middleware only validates a `user_id` that is
+    # present. Reinterpreting an unscoped request as self-scoped would succeed with
+    # narrower data instead of failing, silently changing what the caller asked for
+    # and reversing the 403 established in #115. Callers wanting their own rows name
+    # themselves.
+    wants_tenant_wide = requested_user_id is None or requested_user_id != principal.user_id
+    if wants_tenant_wide:
+        _require(principal, tenant_permission)
+        _witness(
+            request,
+            helper="subject",
+            permission=tenant_permission,
+            tenant_scoped=True,
+        )
+        return AuthorizedSubject(principal.tenant_id, requested_user_id, tenant_scoped=True)
+
+    _require(principal, self_permission)
+    _witness(request, helper="subject", permission=self_permission)
+    # Forced to the principal, not echoed back from the request.
+    return AuthorizedSubject(principal.tenant_id, principal.user_id, tenant_scoped=False)
+
+
+def authorize_loaded_resource(
+    request: Request,
+    *,
+    resource_tenant_id: str,
+    resource_user_id: str,
+    self_permission: Permission | None,
+    tenant_permission: Permission | None,
+    action: str | None = None,
+) -> AuthorizationDecision:
+    """Decide from the *stored* record's ownership, never from request values.
+
+    `self_permission=None` marks a tenant-only action. Ownership then does not
+    grant it: `approve` on your own pending memory still requires
+    `memory:approve:tenant`.
+    """
+    principal = current_principal(request)
+    if principal is None:
+        return AuthorizationDecision(
+            permission=self_permission or tenant_permission,  # type: ignore[arg-type]
+            tenant_scoped=False,
+            action=action,
+        )
+
+    if resource_tenant_id != principal.tenant_id:
+        # Conceal existence across tenants — 403 would confirm the record is real.
+        raise HTTPException(status_code=404, detail="memory not found")
+
+    owns_it = resource_user_id == principal.user_id
+
+    if owns_it and self_permission is not None:
+        required, tenant_scoped = self_permission, False
+    else:
+        if tenant_permission is None:
+            raise HTTPException(
+                status_code=403,
+                detail=f"action '{action or 'operation'}' is not permitted",
+            )
+        required, tenant_scoped = tenant_permission, True
+
+    if not principal.has(required):
+        # Another user's record: hide it rather than confirm it exists.
+        if not owns_it:
+            raise HTTPException(status_code=404, detail="memory not found")
+        raise HTTPException(
+            status_code=403,
+            detail=f"missing required permission '{required.value}'",
+        )
+
+    _witness(
+        request,
+        helper="resource",
+        permission=required,
+        action=action,
+        tenant_scoped=tenant_scoped,
+    )
+    return AuthorizationDecision(permission=required, tenant_scoped=tenant_scoped, action=action)
+
+
+def authorize_transition(
+    request: Request,
+    *,
+    spec,
+    validated_action: str,
+    resource_tenant_id: str,
+    resource_user_id: str,
+) -> AuthorizationDecision:
+    """Authorize one validated action on a loaded record.
+
+    `validated_action` comes from the transition the server already validated, never
+    from a client-supplied action string.
+    """
+    variant = spec.variant(validated_action)
+    if variant is None:
+        # A contract error, not a caller error: the handler derived an action the
+        # route never declared. Fail closed rather than fall back to a route-level
+        # permission — that fallback is what commit 1b removed.
+        raise HTTPException(
+            status_code=500,
+            detail=f"no authorization contract for action '{validated_action}'",
+        )
+
+    decision = authorize_loaded_resource(
+        request,
+        resource_tenant_id=resource_tenant_id,
+        resource_user_id=resource_user_id,
+        self_permission=variant.self_permission,
+        tenant_permission=variant.tenant_permission,
+        action=validated_action,
+    )
+    _witness(
+        request,
+        helper="transition",
+        permission=decision.permission,
+        action=validated_action,
+        tenant_scoped=decision.tenant_scoped,
+    )
+    return decision

--- a/services/api/app/db/memory_repo.py
+++ b/services/api/app/db/memory_repo.py
@@ -173,6 +173,13 @@ class InMemoryRepository(Repository):
         return sorted(rows, key=lambda m: m.created_at, reverse=True)
 
     @_locked
+    def get_memory_in_tenant(self, tenant_id: str, memory_id: str) -> StoredMemory | None:
+        memory = self._memories.get(memory_id)
+        if memory is None or memory.tenant_id != tenant_id:
+            return None
+        return memory
+
+    @_locked
     def update_memory(self, memory: StoredMemory) -> StoredMemory:
         memory.updated_at = datetime.now(UTC)
         memory.revision = getattr(memory, "revision", 1) + 1

--- a/services/api/app/db/postgres_repo.py
+++ b/services/api/app/db/postgres_repo.py
@@ -295,6 +295,14 @@ class PostgresRepository(Repository):
             stmt = stmt.order_by(MemoryRecordORM.created_at.desc())
             return [_to_stored(r) for r in s.scalars(stmt)]
 
+    def get_memory_in_tenant(self, tenant_id: str, memory_id: str) -> StoredMemory | None:
+        # Tenant is part of the query, never a check applied after a global load.
+        with self._scoped(tenant_id, "") as s:
+            row = s.get(MemoryRecordORM, memory_id)
+            if not row or row.tenant_id != tenant_id:
+                return None
+            return _to_stored(row)
+
     def _apply_memory_fields(self, row: MemoryRecordORM, memory: StoredMemory) -> None:
         # `normalized_content` and `embedding` were previously NOT persisted at all,
         # so a content edit changed `content` while the keyword form and the vector

--- a/services/api/app/db/postgres_repo.py
+++ b/services/api/app/db/postgres_repo.py
@@ -296,12 +296,24 @@ class PostgresRepository(Repository):
             return [_to_stored(r) for r in s.scalars(stmt)]
 
     def get_memory_in_tenant(self, tenant_id: str, memory_id: str) -> StoredMemory | None:
-        # Tenant is part of the query, never a check applied after a global load.
+        """Load a memory by id *within* a tenant, for ownership authorization.
+
+        The tenant is a predicate in the query, not a check applied to a globally
+        loaded row. `Session.get()` is a primary-key lookup: it would fetch another
+        tenant's row into the session and rely on a Python comparison to reject it —
+        one dropped condition away from a cross-tenant read, and a shape that reads
+        as safe because the comparison is right there. Filtering in SQL means the
+        row never leaves the database. RLS (`004_rls_policies.sql`) is the outer
+        guarantee; this is the inner one, so neither alone is load-bearing.
+        """
         with self._scoped(tenant_id, "") as s:
-            row = s.get(MemoryRecordORM, memory_id)
-            if not row or row.tenant_id != tenant_id:
-                return None
-            return _to_stored(row)
+            row = s.execute(
+                select(MemoryRecordORM).where(
+                    MemoryRecordORM.id == memory_id,
+                    MemoryRecordORM.tenant_id == tenant_id,
+                )
+            ).scalar_one_or_none()
+            return _to_stored(row) if row else None
 
     def _apply_memory_fields(self, row: MemoryRecordORM, memory: StoredMemory) -> None:
         # `normalized_content` and `embedding` were previously NOT persisted at all,

--- a/services/api/app/db/repository.py
+++ b/services/api/app/db/repository.py
@@ -46,6 +46,19 @@ class Repository(ABC):
     ) -> list[StoredMemory]: ...
 
     @abstractmethod
+    def get_memory_in_tenant(self, tenant_id: str, memory_id: str) -> StoredMemory | None:
+        """Load a memory by id within one tenant, whatever user owns it.
+
+        Needed because ownership is what authorization inspects: a tenant
+        administrator acting on another user's record cannot be made to supply that
+        user's id first. The alternative — an unscoped `get_memory_by_id` with the
+        tenant checked afterwards — would put a global lookup in the codebase and
+        make tenant isolation depend on every caller remembering the follow-up
+        check. The tenant is part of the query, always.
+        """
+        ...
+
+    @abstractmethod
     def update_memory(self, memory: StoredMemory) -> StoredMemory:
         """Persist a mutated memory and bump its ``revision``.
 

--- a/services/api/app/routes/audit.py
+++ b/services/api/app/routes/audit.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Query, Request
 
-from ..auth import Permission, authorize_audit_scope, require_permission
+from ..auth import Permission, require_permission
+from ..auth.decisions import authorize_subject_scope
 from ..db.factory import get_repository
 from ..schemas.memory import AuditEvent
 
@@ -29,10 +30,17 @@ def get_audit(
     A tenant-wide read now requires `audit:read:tenant`; without it the query is
     forced to the caller's own `user_id`.
     """
-    effective_user = authorize_audit_scope(request, tenant_id, user_id)
+    subject = authorize_subject_scope(
+        request,
+        requested_tenant_id=tenant_id,
+        requested_user_id=user_id,
+        self_permission=Permission.AUDIT_READ_SELF,
+        tenant_permission=Permission.AUDIT_READ_TENANT,
+    )
     repo = get_repository()
+    # Only the authorized scope reaches the repository — never the request values.
     rows = repo.list_audit(
-        tenant_id, user_id=effective_user, memory_id=memory_id, limit=limit
+        subject.tenant_id, user_id=subject.user_id, memory_id=memory_id, limit=limit
     )
     return [
         AuditEvent(

--- a/services/api/app/routes/memories.py
+++ b/services/api/app/routes/memories.py
@@ -22,6 +22,7 @@ from ..schemas.memory import (
 )
 from ..services.policy_broker import PolicyBroker
 from ..services.status_transitions import (
+    EDIT_FIELDS,
     TRANSITION_AUDIT,
     UNSUPPORTED_PATCH_STATUSES,
     InvalidTransition,
@@ -216,6 +217,16 @@ def patch_memory(memory_id: str, patch: MemoryPatch, request: Request) -> Memory
     # Scope lives in the body, so the query-string middleware can't guard it —
     # enforce it here (invariant #1). No-op when auth is disabled.
     enforce_scope(request, patch.tenant_id, patch.user_id)
+    # Refuse a no-op patch before it opens a loop run and an audit trail. It asks
+    # for no action, so there is no permission it could be checked against.
+    if patch.changes_nothing:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "patch requests no change: provide at least one of "
+                f"{', '.join(EDIT_FIELDS)}, status"
+            ),
+        )
     repo = get_repository()
     trace_id = getattr(request.state, "trace_id", "-")
     loop = start_loop_run_sync(

--- a/services/api/app/schemas/memory.py
+++ b/services/api/app/schemas/memory.py
@@ -251,6 +251,21 @@ class MemoryPatch(BaseModel):
     #: previous last-write-wins behaviour, so existing clients are unaffected.
     expected_revision: int | None = Field(default=None, ge=1)
 
+    @property
+    def changes_nothing(self) -> bool:
+        """True when the body carries scope but requests no change.
+
+        Such a patch has no action, and therefore no permission to check. Letting
+        it succeed would mean a request that nothing authorized returned 200 —
+        cheap to send, and indistinguishable in a log from a real edit.
+        """
+        return (
+            self.content is None
+            and self.importance is None
+            and self.confidence is None
+            and self.status is None
+        )
+
 
 class DeleteRequest(BaseModel):
     tenant_id: str

--- a/services/api/app/services/status_transitions.py
+++ b/services/api/app/services/status_transitions.py
@@ -63,6 +63,10 @@ TRANSITION_AUDIT: dict[str, tuple[str, str]] = {
 }
 
 
+class EmptyPatch(ValueError):
+    """The patch requests no change at all (→ 422)."""
+
+
 class UnsupportedStatus(ValueError):
     """The requested status is never settable via PATCH (→ 422)."""
 
@@ -90,3 +94,44 @@ def validate_transition(current: Status, requested: Status) -> str:
             f"cannot change status from '{current.value}' to '{requested.value}'"
         )
     return action
+
+
+#: Fields whose presence means the caller is editing the memory's own substance,
+#: as opposed to moving it through the governance state machine.
+EDIT_FIELDS: tuple[str, ...] = ("content", "importance", "confidence")
+
+
+def derive_patch_actions(
+    *,
+    has_content: bool,
+    has_importance: bool,
+    has_confidence: bool,
+    transition: str | None,
+) -> frozenset[str]:
+    """Every governance action one PATCH body requests.
+
+    A PATCH is not one action. ``{"content": ..., "status": "active"}`` edits the
+    memory *and* approves it, and the two are governed differently: `edit` has a
+    self permission, `approve` deliberately does not. Authorizing only the
+    transition would let ``memory:approve:tenant`` implicitly grant a content edit
+    — the approver could rewrite what they are approving, in the same request that
+    approves it, and the audit trail would record only the approval.
+
+    So the caller must hold *every* applicable permission, not any one of them.
+
+    Raises:
+        EmptyPatch: the body changes nothing (→ 422). A patch that requests no
+            action has no permission to check, and a request with nothing to
+            authorize must not be treated as authorized.
+    """
+    actions: set[str] = set()
+    if has_content or has_importance or has_confidence:
+        actions.add("edit")
+    if transition is not None:
+        actions.add(transition)
+    if not actions:
+        raise EmptyPatch(
+            "patch requests no change: provide at least one of "
+            f"{', '.join(EDIT_FIELDS)}, status"
+        )
+    return frozenset(actions)

--- a/services/api/tests/test_authz_helpers.py
+++ b/services/api/tests/test_authz_helpers.py
@@ -1,0 +1,323 @@
+"""The four authorization helpers, and the witness each records.
+
+Separate helpers rather than one with many optional arguments: a fixed capability,
+a requested subject, a loaded record, and an action-determined permission are four
+different questions. One signature covering all four makes every call site look
+plausible while doing something subtly different.
+
+Each test asserts both the *decision* and the *evidence* — a handler that stopped
+checking would still return the right answer for an authorized caller, so the
+witness is what distinguishes "allowed" from "actually checked".
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.auth.authz_spec import ROUTE_AUTHZ
+from app.auth.decisions import (
+    authorize_loaded_resource,
+    authorize_subject_scope,
+    authorize_transition,
+)
+from app.auth.principal import Principal
+from app.auth.roles import Permission, Role
+from app.auth.witness import witness_for
+
+_PATCH_SPEC = ROUTE_AUTHZ[("PATCH", "/api/memories/{memory_id}")]
+
+
+def _request(principal: Principal | None, path: str = "/api/memories/{memory_id}", method="PATCH"):
+    class _Route:
+        pass
+
+    _Route.path = path
+    return SimpleNamespace(
+        method=method,
+        state=SimpleNamespace(principal=principal),
+        scope={"route": _Route()},
+    )
+
+
+def _principal(user: str = "alice", roles: set[Role] | None = None) -> Principal:
+    return Principal(
+        tenant_id="acme",
+        user_id=user,
+        provider="jwt",
+        roles=frozenset(roles or {Role.MEMORY_USER}),
+        role_claim_present=True,
+    )
+
+
+# ── authorize_subject_scope ──────────────────────────────────────────────────
+def test_subject_scope_forces_the_query_to_the_caller():
+    """Returning the caller's own requested values would leave untrusted input in
+    the query path — validating a value is not the same as trusting it."""
+    request = _request(_principal(), path="/api/audit", method="GET")
+    subject = authorize_subject_scope(
+        request,
+        requested_tenant_id="acme",
+        requested_user_id="alice",
+        self_permission=Permission.AUDIT_READ_SELF,
+        tenant_permission=Permission.AUDIT_READ_TENANT,
+    )
+    assert subject.user_id == "alice"
+    assert subject.tenant_scoped is False
+
+    decision = witness_for(request).decisions[0]
+    assert decision.helper == "subject"
+    assert decision.permission is Permission.AUDIT_READ_SELF
+    assert decision.tenant_scoped is False
+
+
+def test_an_omitted_subject_is_a_tenant_wide_request_not_an_implicit_self_scope():
+    """A deliberate choice, and the one place this helper diverges from the
+    obvious reading of "omitted -> force principal.user_id".
+
+    Omitting the subject is how /api/audit silently returned tenant-wide records:
+    the scope middleware only validates a `user_id` that is *present*. Treating an
+    omitted subject as "my own" would make the request succeed with narrower data
+    instead of failing — friendlier, but it silently reinterprets what the caller
+    asked for, and it would change the shipped 403 that #115 established.
+
+    Fail closed: an unscoped request is a tenant-wide request and needs the
+    tenant permission. Callers wanting their own rows name themselves.
+    """
+    request = _request(_principal(), path="/api/audit", method="GET")
+    with pytest.raises(HTTPException) as exc:
+        authorize_subject_scope(
+            request,
+            requested_tenant_id="acme",
+            requested_user_id=None,
+            self_permission=Permission.AUDIT_READ_SELF,
+            tenant_permission=Permission.AUDIT_READ_TENANT,
+        )
+    assert exc.value.status_code == 403
+    assert "audit:read:tenant" in exc.value.detail
+
+
+def test_subject_scope_requires_the_tenant_permission_for_another_user():
+    request = _request(_principal(roles={Role.AUDITOR}), path="/api/audit", method="GET")
+    subject = authorize_subject_scope(
+        request,
+        requested_tenant_id="acme",
+        requested_user_id="bob",
+        self_permission=Permission.AUDIT_READ_SELF,
+        tenant_permission=Permission.AUDIT_READ_TENANT,
+    )
+    assert subject.user_id == "bob"
+    assert subject.tenant_scoped is True
+
+    decision = witness_for(request).decisions[0]
+    assert decision.permission is Permission.AUDIT_READ_TENANT
+    assert decision.tenant_scoped is True
+
+
+def test_subject_scope_refuses_another_user_without_the_tenant_permission():
+    request = _request(_principal(), path="/api/audit", method="GET")
+    with pytest.raises(HTTPException) as exc:
+        authorize_subject_scope(
+            request,
+            requested_tenant_id="acme",
+            requested_user_id="bob",
+            self_permission=Permission.AUDIT_READ_SELF,
+            tenant_permission=Permission.AUDIT_READ_TENANT,
+        )
+    assert exc.value.status_code == 403
+    assert not witness_for(request), "a refused check must not record a success"
+
+
+def test_subject_scope_refuses_another_tenant():
+    request = _request(_principal(roles={Role.TENANT_ADMIN}), path="/api/audit", method="GET")
+    with pytest.raises(HTTPException) as exc:
+        authorize_subject_scope(
+            request,
+            requested_tenant_id="evilcorp",
+            requested_user_id=None,
+            self_permission=Permission.AUDIT_READ_SELF,
+            tenant_permission=Permission.AUDIT_READ_TENANT,
+        )
+    assert exc.value.status_code == 403
+
+
+# ── authorize_loaded_resource ────────────────────────────────────────────────
+def test_loaded_resource_uses_the_self_permission_for_an_owned_record():
+    request = _request(_principal())
+    decision = authorize_loaded_resource(
+        request,
+        resource_tenant_id="acme",
+        resource_user_id="alice",
+        self_permission=Permission.MEMORY_WRITE_SELF,
+        tenant_permission=Permission.MEMORY_WRITE_TENANT,
+    )
+    assert decision.permission is Permission.MEMORY_WRITE_SELF
+    assert decision.tenant_scoped is False
+    assert witness_for(request).decisions[0].helper == "resource"
+
+
+def test_loaded_resource_uses_the_tenant_permission_for_another_users_record():
+    request = _request(_principal(roles={Role.MEMORY_ADMIN}))
+    decision = authorize_loaded_resource(
+        request,
+        resource_tenant_id="acme",
+        resource_user_id="bob",
+        self_permission=Permission.MEMORY_WRITE_SELF,
+        tenant_permission=Permission.MEMORY_WRITE_TENANT,
+    )
+    assert decision.permission is Permission.MEMORY_WRITE_TENANT
+    assert decision.tenant_scoped is True
+
+
+def test_another_users_record_is_concealed_rather_than_refused():
+    """403 confirms the record exists. For an individual resource that is a leak."""
+    request = _request(_principal())
+    with pytest.raises(HTTPException) as exc:
+        authorize_loaded_resource(
+            request,
+            resource_tenant_id="acme",
+            resource_user_id="bob",
+            self_permission=Permission.MEMORY_WRITE_SELF,
+            tenant_permission=Permission.MEMORY_WRITE_TENANT,
+        )
+    assert exc.value.status_code == 404
+
+
+def test_a_cross_tenant_record_is_concealed():
+    request = _request(_principal(roles={Role.TENANT_ADMIN}))
+    with pytest.raises(HTTPException) as exc:
+        authorize_loaded_resource(
+            request,
+            resource_tenant_id="evilcorp",
+            resource_user_id="alice",
+            self_permission=Permission.MEMORY_WRITE_SELF,
+            tenant_permission=Permission.MEMORY_WRITE_TENANT,
+        )
+    assert exc.value.status_code == 404
+
+
+def test_ownership_does_not_grant_a_tenant_only_action():
+    """The rule that makes the contract work.
+
+    `approve` declares no self permission. Owning the record must not be read as
+    "own record, therefore allowed" — a user approving their own pending sensitive
+    memory would defeat the queue that put it there.
+    """
+    request = _request(_principal())  # memory_user, owns the record
+    with pytest.raises(HTTPException) as exc:
+        authorize_loaded_resource(
+            request,
+            resource_tenant_id="acme",
+            resource_user_id="alice",
+            self_permission=None,
+            tenant_permission=Permission.MEMORY_APPROVE_TENANT,
+            action="approve",
+        )
+    assert exc.value.status_code == 403
+    assert not witness_for(request)
+
+
+def test_a_tenant_only_action_succeeds_with_the_tenant_permission():
+    request = _request(_principal(roles={Role.MEMORY_ADMIN}))
+    decision = authorize_loaded_resource(
+        request,
+        resource_tenant_id="acme",
+        resource_user_id="alice",
+        self_permission=None,
+        tenant_permission=Permission.MEMORY_APPROVE_TENANT,
+        action="approve",
+    )
+    assert decision.permission is Permission.MEMORY_APPROVE_TENANT
+    # Recorded as tenant-scoped even though the record is the caller's own.
+    assert decision.tenant_scoped is True
+
+
+# ── authorize_transition ─────────────────────────────────────────────────────
+def test_transition_selects_the_variant_and_records_the_action():
+    request = _request(_principal(roles={Role.MEMORY_ADMIN}))
+    decision = authorize_transition(
+        request,
+        spec=_PATCH_SPEC,
+        validated_action="archive",
+        resource_tenant_id="acme",
+        resource_user_id="alice",
+    )
+    assert decision.permission is Permission.MEMORY_ARCHIVE_SELF
+    actions = {d.action for d in witness_for(request).decisions}
+    assert "archive" in actions
+    assert any(d.helper == "transition" for d in witness_for(request).decisions)
+
+
+def test_self_approval_is_refused_through_the_transition_helper():
+    request = _request(_principal())
+    with pytest.raises(HTTPException) as exc:
+        authorize_transition(
+            request,
+            spec=_PATCH_SPEC,
+            validated_action="approve",
+            resource_tenant_id="acme",
+            resource_user_id="alice",
+        )
+    assert exc.value.status_code == 403
+
+
+def test_an_undeclared_action_fails_closed_as_a_contract_error():
+    """A handler deriving an action the route never declared is a bug in us, not a
+    caller error — and must not fall back to a route-level permission."""
+    request = _request(_principal(roles={Role.TENANT_ADMIN}))
+    with pytest.raises(HTTPException) as exc:
+        authorize_transition(
+            request,
+            spec=_PATCH_SPEC,
+            validated_action="obliterate",
+            resource_tenant_id="acme",
+            resource_user_id="alice",
+        )
+    assert exc.value.status_code == 500
+
+
+def test_a_mixed_patch_records_one_decision_per_action():
+    """`{"content": ..., "status": "active"}` is edit + approve, not one action.
+
+    Authorizing only the transition would let an approve permission implicitly grant
+    the content edit.
+    """
+    request = _request(_principal(roles={Role.MEMORY_ADMIN}))
+    for action in ("edit", "approve"):
+        authorize_transition(
+            request,
+            spec=_PATCH_SPEC,
+            validated_action=action,
+            resource_tenant_id="acme",
+            resource_user_id="alice",
+        )
+    recorded = {d.action for d in witness_for(request).decisions if d.helper == "transition"}
+    assert recorded == {"edit", "approve"}
+
+
+def test_a_mixed_patch_is_refused_when_only_one_permission_is_held():
+    """memory_user may edit its own record but may not approve it."""
+    request = _request(_principal())
+    authorize_transition(
+        request,
+        spec=_PATCH_SPEC,
+        validated_action="edit",
+        resource_tenant_id="acme",
+        resource_user_id="alice",
+    )
+    with pytest.raises(HTTPException):
+        authorize_transition(
+            request,
+            spec=_PATCH_SPEC,
+            validated_action="approve",
+            resource_tenant_id="acme",
+            resource_user_id="alice",
+        )
+
+
+# ── no evidence before a decision ────────────────────────────────────────────
+def test_no_witness_exists_before_any_helper_runs():
+    request = _request(_principal())
+    assert not witness_for(request)

--- a/services/api/tests/test_deletion.py
+++ b/services/api/tests/test_deletion.py
@@ -382,3 +382,56 @@ def test_a_content_edit_never_resurrects_or_hides_a_memory(api_client):
     )
     assert edit.status_code == 404
     assert repo.get_memory("t1", "u1", gone.id).content == "already deleted"
+
+
+def test_the_authorization_lookup_is_not_a_retrieval_path(api_client):
+    """`get_memory_in_tenant` (v2.4) is new reach across a tenant, so the deletion
+    guarantee has to be re-proved against it.
+
+    Ownership authorization has to inspect a record *before* it knows the owner, so
+    this lookup spans users and returns soft-deleted rows — otherwise "not yours"
+    and "does not exist" would be indistinguishable. That makes it the one place a
+    deleted memory is legitimately readable inside the process, and therefore the
+    one place a careless caller could turn it back into a retrieval path.
+
+    The invariant is that nothing downstream of it re-enters retrieval or context.
+    """
+    from app.db.entities import StoredMemory
+    from app.schemas.memory import MemoryType, Sensitivity, Source, Status
+
+    client, repo = api_client
+    secret = "renews the enterprise contract in March"
+    mem = repo.create_memory(
+        StoredMemory(
+            tenant_id="t1",
+            user_id="u1",
+            memory_type=MemoryType.semantic,
+            content=secret,
+            importance=8,
+            confidence=0.95,
+            sensitivity=Sensitivity.low,
+            status=Status.active,
+            source=Source(kind="chat", excerpt=secret),
+        )
+    )
+    assert client.request(
+        "DELETE", f"/api/memories/{mem.id}", json={"tenant_id": "t1", "user_id": "u1"}
+    ).status_code == 200
+
+    # The lookup still sees it — deliberately, and it is the only thing that does.
+    assert repo.get_memory_in_tenant("t1", mem.id) is not None
+
+    # None of the retrieval surfaces do.
+    assert repo.retrieve_active("t1", "u1") == []
+    assert repo.search_candidates("t1", "u1", [0.1] * 8, limit=10) == []
+    assert [m.id for m in repo.list_memories("t1", "u1")] == []
+
+    # And a chat response neither uses it nor repeats it.
+    chat = client.post(
+        "/api/chat",
+        json={"tenant_id": "t1", "user_id": "u1", "message": "when does the contract renew?"},
+    )
+    assert chat.status_code == 200, chat.text
+    body = chat.json()
+    assert secret not in chat.text
+    assert mem.id not in {u["memory_id"] for u in body.get("used_memories", [])}

--- a/services/api/tests/test_governance_api.py
+++ b/services/api/tests/test_governance_api.py
@@ -12,6 +12,7 @@ import pytest
 
 from app.db.entities import StoredMemory
 from app.schemas.memory import MemoryType, Sensitivity, Source, Status
+from app.services.status_transitions import derive_patch_actions
 
 from ._secret_fixtures import FAKE_PROVIDER_KEY
 
@@ -345,3 +346,68 @@ def test_content_edit_goes_through_governance(api_client):
     assert ok.status_code == 200
     assert ok.json()["content"] == "prefers light mode"
     assert ok.json()["revision"] == 2
+
+
+# ── one patch, every action it requests (v2.4) ───────────────────────────────
+def test_approving_and_editing_in_one_patch_is_two_governance_actions(api_client):
+    """`{"content": ..., "status": "active"}` approves *and* rewrites.
+
+    The route resolves it to a single audit action today, which is the reason
+    authorization cannot key off the status transition alone: whoever may approve
+    would implicitly be allowed to rewrite the text they are approving, in the
+    request that approves it, leaving only the approval in the trail. Pinned here
+    so the coupling is visible while the route is still `planned`.
+    """
+    client, repo = api_client
+    m = _seed(repo, status=Status.pending, content="original claim")
+
+    r = client.patch(
+        f"/api/memories/{m.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "content": "rewritten claim", "status": "active"},
+    )
+    assert r.status_code == 200, r.text
+
+    stored = repo.get_memory("t1", "u1", m.id)
+    assert stored.status is Status.active
+    assert stored.content == "rewritten claim"
+
+    actions = derive_patch_actions(
+        has_content=True,
+        has_importance=False,
+        has_confidence=False,
+        transition="approve",
+    )
+    assert actions == {"edit", "approve"}, (
+        "both permissions must be required once this route is enforced"
+    )
+
+
+def test_a_patch_requesting_no_change_is_refused(api_client):
+    """It returned 200 with the record and wrote a `memory_updated` audit event
+    for a mutation that never happened — a no-op indistinguishable from an edit."""
+    client, repo = api_client
+    m = _seed(repo)
+    audit_before = len(client.get(f"/api/audit{_q()}").json())
+
+    r = client.patch(f"/api/memories/{m.id}", json={"tenant_id": "t1", "user_id": "u1"})
+    assert r.status_code == 422
+    assert "no change" in r.json()["detail"]
+    assert len(client.get(f"/api/audit{_q()}").json()) == audit_before
+
+
+def test_every_single_field_patch_still_works(api_client):
+    """The 422 must catch only genuinely empty bodies."""
+    client, repo = api_client
+    for field, value in (("content", "new text"), ("importance", 9), ("confidence", 0.4)):
+        m = _seed(repo)
+        r = client.patch(
+            f"/api/memories/{m.id}", json={"tenant_id": "t1", "user_id": "u1", field: value}
+        )
+        assert r.status_code == 200, f"{field}: {r.text}"
+
+    pending = _seed(repo, status=Status.pending)
+    r = client.patch(
+        f"/api/memories/{pending.id}",
+        json={"tenant_id": "t1", "user_id": "u1", "status": "active"},
+    )
+    assert r.status_code == 200, r.text

--- a/services/api/tests/test_route_authorization_coverage.py
+++ b/services/api/tests/test_route_authorization_coverage.py
@@ -96,14 +96,51 @@ def test_tenant_scoped_routes_declare_a_tenant_permission(routes):
         assert spec.permission is not None, f"{method} {path} is tenant-scoped with no permission"
 
 
-def test_resource_scoped_routes_declare_both_permissions(routes):
-    """Resource scope exists precisely because self and tenant differ."""
+def test_ownership_scoped_routes_declare_both_permissions(routes):
+    """RESOURCE and SUBJECT exist precisely because self and tenant differ.
+
+    Two valid shapes:
+      * without variants — a top-level self/tenant pair decides the route;
+      * with variants — each action decides itself, and the top-level pair must be
+        ABSENT so there is no second authorization path a handler could take
+        instead, silently skipping archive/approve/reject.
+    """
     for method, path in routes:
         spec = ROUTE_AUTHZ[(method, path)]
-        if spec.scope is not Scope.RESOURCE:
+        if spec.scope not in (Scope.RESOURCE, Scope.SUBJECT):
+            continue
+        if spec.is_variant_driven:
+            assert spec.self_permission is None and spec.tenant_permission is None, (
+                f"{method} {path} declares variants *and* a generic fallback pair — "
+                "remove the fallback so the safe path is the only representable one"
+            )
+            for variant in spec.variants:
+                assert variant.permissions(), (
+                    f"{method} {path} variant '{variant.action}' names no permission"
+                )
             continue
         assert spec.self_permission is not None, f"{method} {path} lacks a self permission"
         assert spec.tenant_permission is not None, f"{method} {path} lacks a tenant permission"
+
+
+def test_subject_and_resource_scopes_are_assigned_deliberately(routes):
+    """RESOURCE means a stored record is loaded before ownership is decided.
+    SUBJECT means a requested user is resolved before querying.
+
+    /api/audit was RESOURCE while resolving an optional `user_id` — contradicting
+    the registry's own definition, and it would have modelled the first real
+    subject-scope helper as a special case.
+    """
+    subject = {p for (m, p) in routes if ROUTE_AUTHZ[(m, p)].scope is Scope.SUBJECT}
+    assert "/api/audit" in subject
+    assert "/api/memories" in subject
+
+    resource = {p for (m, p) in routes if ROUTE_AUTHZ[(m, p)].scope is Scope.RESOURCE}
+    for path in resource:
+        assert "{" in path, (
+            f"{path} is RESOURCE-scoped but takes no identifier — a route with no "
+            "record to load cannot decide ownership from one"
+        )
 
 
 def test_public_routes_are_a_short_explicit_list(routes):

--- a/services/api/tests/test_status_transition_bypass.py
+++ b/services/api/tests/test_status_transition_bypass.py
@@ -236,3 +236,54 @@ def test_content_only_patch_is_unaffected(api_client):
     assert r.status_code == 200
     assert r.json()["content"] == "prefers light mode"
     assert repo.get_memory("t1", "u1", m.id).status is Status.active
+
+
+# ── a patch that asks for nothing ────────────────────────────────────────────
+def test_a_patch_with_no_changed_field_is_refused(api_client):
+    """It returned 200 and a full memory record while requesting no change.
+
+    That matters once the route is authorized: a body with no action has no
+    permission to check against, so it would be a request nothing authorized that
+    still succeeded — and in the audit trail it is indistinguishable from a real
+    edit, because it opens a governance loop run and writes a `memory_updated`
+    event for a mutation that never happened.
+    """
+    client, repo = api_client
+    m = _seed(repo)
+    before = repo.get_memory("t1", "u1", m.id)
+    revision_before = before.revision
+
+    r = _patch(client, m.id)
+    assert r.status_code == 422
+    assert "no change" in r.json()["detail"]
+
+    after = repo.get_memory("t1", "u1", m.id)
+    assert after.revision == revision_before, "a refused patch must not bump revision"
+
+
+def test_a_revision_guard_alone_is_still_no_change(api_client):
+    client, repo = api_client
+    m = _seed(repo)
+    r = _patch(client, m.id, expected_revision=repo.get_memory("t1", "u1", m.id).revision)
+    assert r.status_code == 422
+
+
+def test_the_refusal_happens_before_any_governance_evidence_is_written(api_client):
+    """No loop run, no audit event. A rejected request must leave no trace that
+    reads like a completed governance action."""
+    client, repo = api_client
+    m = _seed(repo)
+    audit_before = len(client.get(f"/api/audit{_Q}").json())
+    runs_before = len(client.get(f"/api/loops/runs{_Q}").json())
+
+    assert _patch(client, m.id).status_code == 422
+
+    assert len(client.get(f"/api/audit{_Q}").json()) == audit_before
+    assert len(client.get(f"/api/loops/runs{_Q}").json()) == runs_before
+
+
+def test_a_nonexistent_memory_still_reports_the_empty_patch(api_client):
+    """The emptiness check runs before the lookup, so it cannot be used to probe
+    which memory ids exist."""
+    client, _repo = api_client
+    assert _patch(client, "does-not-exist").status_code == 422

--- a/services/api/tests/test_status_transition_matrix.py
+++ b/services/api/tests/test_status_transition_matrix.py
@@ -10,13 +10,16 @@ import itertools
 
 import pytest
 
-from app.schemas.memory import Status
+from app.schemas.memory import MemoryPatch, Status
 from app.services.status_transitions import (
     ALLOWED_TRANSITIONS,
+    EDIT_FIELDS,
     TRANSITION_AUDIT,
     UNSUPPORTED_PATCH_STATUSES,
+    EmptyPatch,
     InvalidTransition,
     UnsupportedStatus,
+    derive_patch_actions,
     validate_transition,
 )
 
@@ -91,3 +94,79 @@ def test_every_allowed_transition_has_a_distinct_audit_action():
 
 def test_audit_table_covers_every_allowed_action():
     assert set(TRANSITION_AUDIT) >= set(ALLOWED_TRANSITIONS.values())
+
+
+# ── one PATCH, many actions ──────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({"has_content": True}, {"edit"}),
+        ({"has_importance": True}, {"edit"}),
+        ({"has_confidence": True}, {"edit"}),
+        # Every edit field collapses to the same single action.
+        ({"has_content": True, "has_importance": True, "has_confidence": True}, {"edit"}),
+        ({"transition": "approve"}, {"approve"}),
+        ({"transition": "archive"}, {"archive"}),
+        # The case the conjunctive rule exists for.
+        ({"has_content": True, "transition": "approve"}, {"edit", "approve"}),
+        ({"has_importance": True, "transition": "restore"}, {"edit", "restore"}),
+    ],
+)
+def test_derived_actions_cover_everything_the_body_requests(kwargs, expected):
+    call = {
+        "has_content": False,
+        "has_importance": False,
+        "has_confidence": False,
+        "transition": None,
+        **kwargs,
+    }
+    assert derive_patch_actions(**call) == expected
+
+
+def test_an_edit_plus_transition_is_two_actions_not_one():
+    """The reason authorization cannot key off the transition alone.
+
+    `approve` has no self permission by design; `edit` does. If one PATCH resolved
+    to a single action, a tenant approver could rewrite a memory's content in the
+    same request that approves it, and the audit would record only the approval.
+    Both permissions must be held.
+    """
+    actions = derive_patch_actions(
+        has_content=True,
+        has_importance=False,
+        has_confidence=False,
+        transition="approve",
+    )
+    assert actions == {"edit", "approve"}
+    assert len(actions) == 2, "an edit must not be absorbed into the transition"
+
+
+def test_a_patch_that_changes_nothing_is_refused():
+    """No action means no permission to check — it must not resolve to 'allowed'."""
+    with pytest.raises(EmptyPatch):
+        derive_patch_actions(
+            has_content=False,
+            has_importance=False,
+            has_confidence=False,
+            transition=None,
+        )
+
+
+def test_edit_fields_matches_the_schema_fields_that_produce_an_edit():
+    """Adding an editable field without adding it here would let it through
+    unauthorized — the field would mutate the memory but contribute no action."""
+    schema_fields = set(MemoryPatch.model_fields)
+    governance_fields = {"tenant_id", "user_id", "status", "expected_revision"}
+    assert set(EDIT_FIELDS) == schema_fields - governance_fields
+
+
+def test_changes_nothing_agrees_with_the_derivation():
+    scoped = {"tenant_id": "acme", "user_id": "alice"}
+    assert MemoryPatch(**scoped).changes_nothing is True
+    assert MemoryPatch(**scoped, expected_revision=3).changes_nothing is True, (
+        "a revision guard alone still requests no change"
+    )
+    for field in EDIT_FIELDS:
+        value = {"content": "x", "importance": 5, "confidence": 0.5}[field]
+        assert MemoryPatch(**scoped, **{field: value}).changes_nothing is False
+    assert MemoryPatch(**scoped, status=Status.active).changes_nothing is False

--- a/services/api/tests/test_tenant_isolation.py
+++ b/services/api/tests/test_tenant_isolation.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from app.schemas.memory import ChatRequest
+from app.db.entities import StoredMemory
+from app.schemas.memory import ChatRequest, MemoryType, Sensitivity, Source, Status
 
 
 def _chat(gateway, tenant, user, message):
@@ -263,3 +264,86 @@ def test_revision_is_not_a_cross_tenant_oracle(api_client):
     # 404 (not 409): scope is checked before the revision, so the response is
     # identical whether or not the revision would have matched.
     assert r.status_code == 404
+
+
+# ── the authorization lookup (v2.4) ──────────────────────────────────────────
+def test_get_memory_in_tenant_never_crosses_a_tenant(gateway, repo):
+    """Ownership authorization needs a record it can inspect *before* it knows the
+    owner — so it cannot pass `user_id` as a filter, and a naive implementation
+    reaches for a global lookup by id with the tenant checked afterward.
+
+    That shape is one dropped condition away from a cross-tenant read, and it reads
+    as safe because the comparison is right there. The tenant stays a predicate.
+    """
+    _chat(gateway, "tenant_acme", "user_acme", "Remember Acme's roadmap is confidential.")
+    mem_id = repo.list_memories("tenant_acme", "user_acme")[0].id
+
+    assert repo.get_memory_in_tenant("tenant_acme", mem_id) is not None
+    assert repo.get_memory_in_tenant("tenant_demo", mem_id) is None
+    assert repo.get_memory_in_tenant("", mem_id) is None
+
+
+def test_get_memory_in_tenant_spans_users_but_only_inside_the_tenant(gateway, repo):
+    """It must see another user's record — that is the point; a per-user lookup
+    could not tell "not yours" apart from "does not exist", and the route needs the
+    owner to decide which permission applies. The tenant boundary still holds.
+    """
+    _chat(gateway, "t1", "alice", "Remember Alice likes dark mode.")
+    mem_id = repo.list_memories("t1", "alice")[0].id
+
+    found = repo.get_memory_in_tenant("t1", mem_id)
+    assert found is not None and found.user_id == "alice"
+    # Same id, other tenant: nothing.
+    assert repo.get_memory_in_tenant("t2", mem_id) is None
+
+
+def test_a_deleted_memory_is_not_exposed_through_the_authorization_lookup(api_client):
+    """The lookup deliberately returns a soft-deleted row so authorization can run
+    on it, so the deletion guarantee (invariant #2) has to be re-proved at the
+    route: nothing about a deleted memory may reach a response through this path.
+    """
+    client, repo = api_client
+    content = "the quarterly rotation date is the 3rd"
+    mem_id = repo.create_memory(
+        StoredMemory(
+            tenant_id="t1",
+            user_id="u1",
+            memory_type=MemoryType.preference,
+            content=content,
+            importance=6,
+            confidence=0.9,
+            sensitivity=Sensitivity.low,
+            status=Status.active,
+            source=Source(kind="manual", excerpt=content),
+        )
+    ).id
+    deleted = client.request(
+        "DELETE",
+        f"/api/memories/{mem_id}",
+        json={"tenant_id": "t1", "user_id": "u1"},
+    )
+    assert deleted.status_code == 200, deleted.text
+
+    # The repository still hands it to the authorization layer...
+    stored = repo.get_memory_in_tenant("t1", mem_id)
+    assert stored is not None and stored.status is Status.deleted
+
+    # ...and the mutation route must not act on it.
+    patched = client.patch(
+        f"/api/memories/{mem_id}",
+        json={"tenant_id": "t1", "user_id": "u1", "content": "rewritten"},
+    )
+    assert patched.status_code == 404
+    assert content not in patched.text
+    assert repo.get_memory_in_tenant("t1", mem_id).content != "rewritten"
+
+    # It is still absent from retrieval, which is what invariant #2 governs.
+    assert repo.retrieve_active("t1", "u1") == []
+    assert [m.id for m in repo.list_memories("t1", "u1")] == []
+
+    # The control-plane detail route is a deliberate exception: it returns
+    # soft-deleted rows for governance/forensics, carrying the true `status`
+    # rather than concealing them. Pinned so the exception stays explicit.
+    detail = client.get(f"/api/memories/{mem_id}?tenant_id=t1&user_id=u1")
+    assert detail.status_code == 200
+    assert detail.json()["status"] == "deleted"


### PR DESCRIPTION
Follow-up to #125. Those commits merged as `5302fcc` **without** this work — it was
finished afterward, and #125's description was briefly edited to claim it. That
description has been restored to what actually merged; this PR carries the rest.

Branched fresh from `main` rather than continuing `feat/api-rbac-route-coverage`,
since that branch was squash-merged and would re-present its commits alongside these.

## What #125 left unfinished

#125 made every route's requirement *stated and checkable*. It did not centralize the
checks themselves, so the answer to "may you do this on this record" was still
re-derived per handler — which is how `GET /api/audit` came to return tenant-wide rows
to any authenticated caller in the first place.

It also shipped two contract defects, corrected here:

1. **`/api/audit` was classified `resource`.** It has no stored record to inspect; it
   resolves a *requested* subject. The wrong scope is what made the original leak look
   acceptable — `resource` implies ownership was checked against something loaded, and
   nothing was loaded. Now `subject`, and rewired onto the shared helper so only the
   resolved tenant/user reach the repository.

2. **`PATCH` declared a top-level permission pair alongside its variants.** A single
   pair must be either the weakest (anyone who may edit may approve) or the strongest
   (self-edits blocked). Both are wrong. The route is variant-only, and a test fails
   if a top-level pair is added back.

## What changed

**`app/auth/decisions.py`** — four helpers, deliberately not one with optional
arguments. A fixed capability, a requested subject, a loaded record, and an
action-determined permission are four different questions; one signature covering all
four makes every call site look plausible while doing something subtly different.

Two rules that are easy to get wrong, now enforced in one place:

- **Ownership does not grant a tenant-only action.** `approve` / `reject` declare no
  self permission, so owning a memory does not let you approve it — self-approval
  defeats the review queue that held it. A missing self branch means *tenant-only*,
  never *own record, therefore allowed*.
- **Conceal rather than refuse.** A cross-tenant record, or another user's record you
  may not touch, answers `404`. A `403` confirms the record exists, letting an
  attacker enumerate ids by status code alone.

**`Repository.get_memory_in_tenant`** — ownership must be decided *before* the owner is
known, so the lookup cannot filter by `user_id`; a per-user lookup cannot tell "not
yours" from "does not exist". The Postgres implementation I first wrote was
`Session.get()` by primary key with the tenant compared in Python afterward: it pulled
another tenant's row into the session before rejecting it, one dropped condition away
from a cross-tenant read, and it read as safe because the comparison was right there.
The tenant is now a predicate in the query. RLS stays the outer guarantee; neither
layer is alone load-bearing.

**Route statuses are unchanged — still 3 enforced / 27 planned / 9 public.** Enforcing
the memory routes is the next PR (`feat/api-rbac-memory-routes`).

## Behaviour change

**`PATCH /api/memories/{id}` with no changed field: `200` → `422`.**

It returned the unchanged record while requesting no action — so there is no
permission it could be authorized against, and it opened a governance loop run and
wrote a `memory_updated` audit event for a mutation that never happened, making a
no-op indistinguishable from a real edit in the trail. Refused before any evidence is
written, and before the memory lookup, so it cannot probe which ids exist.

Every patch requesting a real change is unaffected. All five web call sites verified
to send a field. `MemoryOpsClient.update_memory()` raises `ValueError` locally rather
than surfacing a status code from a request it should not send. This narrows a
previously-accepted request shape, so it is a behavioural correction, not an additive
change — called out in `CHANGELOG.md` and `docs/api-contracts.md`.

**A documentation correction:** `docs/api-contracts.md` claimed a tenant-wide audit
read without the permission was "forced to the caller's own `user_id`". It returns
`403`, and has since #115. Documenting a fallback that does not exist is worse than
documenting nothing.

## Tests with teeth

809 pass, up from 768 on `main`.

- **Ownership does not grant approve** — a `memory_user` is refused `approve` on their
  *own* record. The rule the whole contract rests on.
- **Cross-tenant and unauthorized records answer 404, not 403**, asserted per helper.
- **Witness per helper**, including a mixed `edit` + `approve` patch recording two
  decisions, and no witness recorded before a resource is loaded and classified.
- **An undeclared action fails closed (500)** rather than falling back to a
  route-level permission.
- **`get_memory_in_tenant` crosses users but never tenants**, and is proved *not* to be
  a retrieval path: a deleted memory stays absent from retrieval, search, listing, and
  chat responses. It deliberately returns soft-deleted rows so authorization can run on
  them, which is exactly why the deletion guarantee is re-proved against it.
- **The empty patch writes no audit event and no loop run**, and returns `422` for a
  nonexistent id too, so it is not an existence oracle.
- **`EDIT_FIELDS` is derived against the schema's own fields** — adding an editable
  field without adding it to the action derivation fails, since the new field would
  otherwise mutate memory while contributing no action to authorize.

Gate green: pytest (809), ruff, evals, benchmark, matrix drift check, PR invariant gate
(8 armed rules), gitleaks over the commit range.

## Known remaining limitation

The helpers exist and are tested; **no memory handler calls them yet**. Route statuses
are unchanged, so this PR does not change what any caller can do — apart from the empty
PATCH above.

One deliberate divergence, confirmed as correct: `authorize_subject_scope` treats an
**omitted** subject as a tenant-wide request needing the tenant permission, not as an
implicit "my own". Reinterpreting omission as self-scoped would silently execute a
narrower request than the caller made, and omission was the exact shape of the original
leak. A future `GET /api/audit/self` can be the explicit convenience form.

`PATCH` still resolves a mixed edit-plus-transition to a single **audit** action. The
action derivation is in place and tested (`derive_patch_actions` → `{edit, approve}`)
and the coupling is pinned, but both the conjunctive permission requirement and the
durable mixed-action evidence land with enforcement in the next PR.

## Out of scope

Per-record ACLs, delegation, attribute-based policy, per-field redaction by role, role
management UI, the operational-surface split (`ops:readiness` / `ops:metrics`), and
replacing the web's `hasAtLeast` with generated capabilities.

An authorization boundary, not an authorization product — and not a claim that the API
is enterprise production-ready.
