### PR TITLE
fix(auth): honour an explicit null JWT roles claim as zero permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,16 @@ Ten of 39 routes now enforce their declared permission (was three): `POST /api/c
   `memory_user` — read, write and delete over its own memory — for a credential the
   issuer said should carry none. Roles are now read with a new `claim_node`; scalar
   claims are unchanged. Trusted-header mode was never affected.
+- **A JWT `roles` claim of explicit `null` was read as an omitted claim.** The array
+  fix above left one state wrong: `claim_node` returned `None` for both an absent key
+  and a JSON `null`, so `{"roles": null}` still took the compatibility fallback to
+  `DEFAULT_ROLE`. Presence cannot be recovered from a value — the two are different
+  statements (an issuer granting no roles, versus a credential predating roles), and
+  only the second may fall back. `claim_node` now returns `(present, value)` and
+  `resolve_roles` accepts an explicit `claim_present`. All six claim states are
+  pinned: omitted → fallback; `null`, `[]`, `""`, unrecognised → zero permissions;
+  valid → those roles. Identity claims are unchanged, where absent and `null` are
+  correctly identical because there is no fallback to reach.
 
 ## Unreleased — worker mutation atomicity
 Additive; completes invariant #7 across the whole system.

--- a/docs/security.md
+++ b/docs/security.md
@@ -325,10 +325,33 @@ and authorize against its **stored** owner. Two consequences worth stating:
 
 Authorization depends on the resolved `Principal`, never on how it arrived. Trusted-
 header and JWT modes are asserted to produce identical decisions for the same roles,
-including the four-state role resolution (omitted / valid / present-invalid /
-present-empty). This test found a real divergence: a JWT `roles` claim in array form
-— the shape almost every issuer emits — was discarded, so every JWT caller fell back
-to the default role. See the v2.4 entry in `CHANGELOG.md`.
+including role resolution. This test found a real divergence: a JWT `roles` claim in
+array form — the shape almost every issuer emits — was discarded, so every JWT caller
+fell back to the default role.
+
+Role claims have **six** states, and only the first may fall back:
+
+| Claim | Result |
+| --- | --- |
+| omitted | `DEFAULT_ROLE` where the deployment permits it (`auth_require_role_claim`) |
+| `null` | zero permissions |
+| `[]` | zero permissions |
+| `""` | zero permissions |
+| `["unrecognised"]` | zero permissions |
+| `["auditor"]` | those roles |
+
+The distinction that makes this work is that **presence is not inferred from the
+value**. An absent key and a JSON `null` both read as `None`, but they are opposite
+statements: an issuer saying *this identity has no roles*, versus a credential that
+predates roles entirely. `claim_node` therefore returns `(present, value)`. Collapsing
+them is what let an explicit `null` keep receiving the fallback even after array
+claims were fixed.
+
+Identity claims (`tenant_id`, `sub`) are the opposite case: absent and `null` are
+correctly identical, because there is no fallback to reach — both refuse
+authentication rather than invent an identifier.
+
+See the v2.4 entries in `CHANGELOG.md`.
 
 ### What is not claimed
 

--- a/docs/security/api-rbac.md
+++ b/docs/security/api-rbac.md
@@ -46,7 +46,33 @@ MemoryOps stays identity-neutral — roles are claims from your existing issuer.
 | `jwt` | a claim in the verified token | `MEMORYOPS_AUTH_JWT_ROLES_CLAIM` (default `roles`, dotted paths allowed) |
 | `trusted_header` | a header from the trusted proxy | `MEMORYOPS_AUTH_ROLES_HEADER` (default `X-MemoryOps-Roles`) |
 
-Accepts a list, or a space/comma-separated string.
+Accepts a list, or a space/comma-separated string. A list is the common shape and is
+read as-is — under JWT it was previously stringified and discarded, which silently
+handed every token the fallback role below.
+
+### The six claim states
+
+Only an **omitted** claim may fall back. Everything else is an authorization decision
+the issuer already made, and is honoured:
+
+| Claim | Roles granted |
+| --- | --- |
+| omitted entirely | `MEMORYOPS_AUTH_REQUIRE_ROLE_CLAIM` decides: the default role, or nothing |
+| `null` | **none** |
+| `[]` | **none** |
+| `""` | **none** |
+| `["not_a_role"]` | **none** |
+| `["auditor"]` | `auditor` |
+
+Presence is taken from whether the claim *exists*, never from whether its value is
+non-null — `{"roles": null}` and a token with no `roles` key both carry `None`, but
+the first is an issuer saying "this identity has no roles" and must not be given the
+fallback.
+
+If you issue tokens where an unprivileged identity gets `"roles": null`, that
+identity receives **zero** permissions and every governed route will refuse it. That
+is intended; set `MEMORYOPS_AUTH_REQUIRE_ROLE_CLAIM=false` and omit the claim if you
+want the compatibility fallback instead.
 
 > **Trusted-header mode inherits its trust from the network.** The role header is as
 > authoritative as the tenant/user headers already were: only safe when the API is
@@ -56,12 +82,15 @@ Accepts a list, or a space/comma-separated string.
 
 ## Defaults are least-privilege
 
-An authenticated caller with no recognised role gets `memory_reader`: read and write
-their **own** memory, read their **own** audit. Never a tenant-wide or administrative
-default.
+An authenticated caller whose credential carries **no role claim at all** gets
+`memory_user` (formerly named `memory_reader`, which was misleading — it could always
+write): read, write, archive and delete their **own** memory, read their **own**
+audit. Never a tenant-wide or administrative default.
 
-Unrecognised role names are dropped rather than trusted — an issuer sending `"admin"`
-must not accidentally match `tenant_admin`.
+A caller whose claim is *present but names nothing recognised* gets **nothing**, not
+this fallback. Unrecognised names are dropped rather than trusted — an issuer sending
+`"admin"` must not accidentally match `tenant_admin`, and a typo
+(`["service_workre"]`) must not quietly grant self-service memory permissions.
 
 ## Behaviour change
 

--- a/services/api/app/auth/jwt.py
+++ b/services/api/app/auth/jwt.py
@@ -87,33 +87,40 @@ def decode_jwt(
         raise JWTError(str(exc)) from exc
 
 
-def claim_node(payload: dict, dotted: str) -> object | None:
-    """Read a possibly nested claim **without** coercing it to a string.
+def claim_node(payload: dict, dotted: str) -> tuple[bool, object | None]:
+    """Read a possibly nested claim as `(present, value)`, uncoerced.
 
     For claims whose legitimate shape is a container. `roles` is the case that
     matters: virtually every issuer emits it as a JSON array, and reading it through
-    `claim_path` returned `None` — which `resolve_roles` cannot distinguish from an
-    omitted claim, so the credential silently fell back to `DEFAULT_ROLE`.
+    `claim_path` returned `None` — which cannot be distinguished from an omitted
+    claim, so the credential silently fell back to `DEFAULT_ROLE`.
 
-    Returns `None` for an absent claim and for an explicit JSON `null`; both mean
-    "the issuer said nothing", which is the compatibility case.
+    Presence is returned separately because it cannot be recovered from the value.
+    `{"roles": null}` and a payload with no `roles` key both yield a value of `None`,
+    but they are different statements: the first is an issuer saying *this identity
+    has no roles*, the second is a credential that predates roles entirely. Only the
+    second may take the compatibility fallback. Inferring presence from
+    `value is not None` collapses them, which is how an explicit `null` kept
+    receiving `DEFAULT_ROLE` after the array fix.
     """
     node: object = payload
     for part in dotted.split("."):
         if not isinstance(node, dict) or part not in node:
-            return None
+            return False, None
         node = node[part]
-    return node
+    return True, node
 
 
 def claim_path(payload: dict, dotted: str) -> str | None:
     """Read a possibly nested **scalar** claim (e.g. `app_metadata.tenant_id`).
 
     Containers are rejected on purpose: a tenant or subject that arrived as a list
-    or object is malformed, and `str()`-ing it would invent an identifier. Use
-    `claim_node` for claims that are legitimately containers.
+    or object is malformed, and `str()`-ing it would invent an identifier. An explicit
+    `null` is rejected the same way — for identity claims there is nothing to fall
+    back to, so absent and null are correctly identical here. Use `claim_node` where
+    that distinction carries meaning.
     """
-    node = claim_node(payload, dotted)
+    _present, node = claim_node(payload, dotted)
     if node is None or isinstance(node, dict | list):
         return None
     return str(node)

--- a/services/api/app/auth/providers.py
+++ b/services/api/app/auth/providers.py
@@ -120,8 +120,11 @@ class JWTProvider:
         if not tenant or not user:
             return None
         # `claim_node`, not `claim_path`: a roles claim is normally a JSON array, and
-        # stringifying containers turned `["auditor"]` into "no claim at all".
-        roles, claim_present = resolve_roles(claim_node(payload, self._roles_claim))
+        # stringifying containers turned `["auditor"]` into "no claim at all". Presence
+        # comes from the claim's *existence*, never from its value — `{"roles": null}`
+        # is an issuer saying "no roles", not a credential that predates roles.
+        roles_present, raw_roles = claim_node(payload, self._roles_claim)
+        roles, claim_present = resolve_roles(raw_roles, claim_present=roles_present)
         return Principal(
             tenant_id=tenant,
             user_id=user,

--- a/services/api/app/auth/roles.py
+++ b/services/api/app/auth/roles.py
@@ -165,7 +165,7 @@ ROLE_PERMISSIONS: dict[Role, frozenset[Permission]] = {
 #: A claim that is *present but contains no recognised role* gets **nothing**, not
 #: this. Collapsing those two states would silently grant human memory permissions
 #: to a mistyped credential: `roles=["service_workre"]` would resolve to
-#: `memory_reader` and receive `memory:read:self` + `memory:write:self`. A typo must
+#: `memory_user` and receive `memory:read:self` + `memory:write:self`. A typo must
 #: not grant anything.
 DEFAULT_ROLE = Role.MEMORY_USER
 
@@ -190,7 +190,9 @@ def parse_roles(raw: object) -> frozenset[Role]:
     return frozenset(known[c.strip()] for c in candidates if c.strip() in known)
 
 
-def resolve_roles(raw: object) -> tuple[frozenset[Role], bool]:
+def resolve_roles(
+    raw: object, *, claim_present: bool | None = None
+) -> tuple[frozenset[Role], bool]:
     """Return `(roles, claim_present)` so callers can tell the four states apart.
 
     * claim omitted           -> `(frozenset(), False)`  — compatibility fallback
@@ -198,18 +200,24 @@ def resolve_roles(raw: object) -> tuple[frozenset[Role], bool]:
     * claim present, invalid  -> `(frozenset(), True)`   — zero permissions
     * claim present, empty    -> `(frozenset(), True)`   — zero permissions
 
-    Presence is `raw is not None` and nothing more. Treating `[]` and `""` as
-    absent conflated two different statements: an issuer that deliberately grants a
-    credential **no roles** was indistinguishable from an older credential that
-    predates roles entirely, so an explicitly empty role set silently received the
-    `memory_reader` fallback — `memory:read:self` and `memory:write:self` for an
-    identity the issuer said should have nothing.
+    Treating `[]` and `""` as absent conflated two different statements: an issuer
+    that deliberately grants a credential **no roles** was indistinguishable from an
+    older credential that predates roles entirely, so an explicitly empty role set
+    silently received the `memory_user` fallback — `memory:read:self` and
+    `memory:write:self` for an identity the issuer said should have nothing.
 
     An omitted claim is a *compatibility* question the deployment answers
     (`auth_require_role_claim`). An empty claim is an *authorization decision the
     issuer already made*, and must be honoured.
+
+    `claim_present` lets a caller state presence it knows independently of the value.
+    A JSON `null` is a *present* claim whose value is `None`, and no inspection of
+    the value can reveal that — the default `raw is not None` would read it as
+    omitted and hand back the fallback. Header-based callers omit the argument: for
+    them an absent header really is `None`, and an empty header is `""`.
     """
-    return parse_roles(raw), raw is not None
+    present = (raw is not None) if claim_present is None else claim_present
+    return parse_roles(raw), present
 
 
 def permissions_for(roles: frozenset[Role]) -> frozenset[Permission]:

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -19,6 +19,9 @@ import pytest
 from app.auth import build_provider, decode_jwt
 from app.auth.jwt import JWTError
 from app.auth.providers import JWTProvider, TrustedHeaderProvider
+from app.auth.roles import Role
+
+from ._secret_fixtures import FAKE_JWT_SIGNING_KEY
 
 
 # ── token minting (independent of app.auth internals, to prove interop) ──────────
@@ -234,16 +237,17 @@ def test_a_list_roles_claim_is_read_not_discarded():
     that was meant to carry none.
     """
     from app.auth.jwt import claim_node, claim_path
-    from app.auth.roles import Role, resolve_roles
+    from app.auth.roles import resolve_roles
 
     payload = {"roles": ["auditor", "memory_admin"], "tenant_id": "t1"}
 
     assert claim_path(payload, "roles") is None, "unchanged: scalars only"
-    assert claim_node(payload, "roles") == ["auditor", "memory_admin"]
+    assert claim_node(payload, "roles") == (True, ["auditor", "memory_admin"])
 
-    roles, present = resolve_roles(claim_node(payload, "roles"))
+    present, raw = claim_node(payload, "roles")
+    roles, claim_present = resolve_roles(raw, claim_present=present)
     assert roles == frozenset({Role.AUDITOR, Role.MEMORY_ADMIN})
-    assert present is True
+    assert claim_present is True
 
 
 def test_an_explicitly_empty_roles_claim_grants_nothing_over_jwt(auth_client):
@@ -271,10 +275,10 @@ def test_a_nested_list_roles_claim_is_read(auth_client):
     from app.auth.jwt import claim_node
     from app.auth.roles import Role, resolve_roles
 
-    payload = {"app_metadata": {"roles": ["tenant_admin"]}}
-    roles, present = resolve_roles(claim_node(payload, "app_metadata.roles"))
+    present, raw = claim_node({"app_metadata": {"roles": ["tenant_admin"]}}, "app_metadata.roles")
+    roles, claim_present = resolve_roles(raw, claim_present=present)
     assert roles == frozenset({Role.TENANT_ADMIN})
-    assert present is True
+    assert claim_present is True
 
 
 def test_a_scalar_claim_still_refuses_a_container():
@@ -284,3 +288,95 @@ def test_a_scalar_claim_still_refuses_a_container():
     assert claim_path({"tenant_id": ["t1", "t2"]}, "tenant_id") is None
     assert claim_path({"tenant_id": {"id": "t1"}}, "tenant_id") is None
     assert claim_path({"tenant_id": "t1"}, "tenant_id") == "t1"
+
+
+# ── presence is not the value ────────────────────────────────────────────────
+def test_claim_node_separates_presence_from_value():
+    """`{"roles": null}` and no `roles` key both hold `None`, and mean opposite things.
+
+    The first is an issuer saying *this identity has no roles*. The second is a
+    credential that predates roles entirely. Only the second may take the
+    compatibility fallback, and no inspection of the value can tell them apart — which
+    is why an explicit `null` kept receiving `DEFAULT_ROLE` even after array claims
+    were fixed.
+    """
+    from app.auth.jwt import claim_node
+
+    assert claim_node({"roles": None}, "roles") == (True, None)
+    assert claim_node({}, "roles") == (False, None)
+    assert claim_node({"roles": []}, "roles") == (True, [])
+    assert claim_node({"app_metadata": {"roles": None}}, "app_metadata.roles") == (True, None)
+    assert claim_node({"app_metadata": {}}, "app_metadata.roles") == (False, None)
+
+
+@pytest.mark.parametrize(
+    ("claim", "expected_roles", "expected_present"),
+    [
+        ({}, frozenset({Role.MEMORY_USER}), False),  # omitted -> fallback
+        ({"roles": None}, frozenset(), True),  # explicit null -> nothing
+        ({"roles": []}, frozenset(), True),
+        ({"roles": ""}, frozenset(), True),
+        ({"roles": ["unknown_role"]}, frozenset(), True),
+        ({"roles": ["auditor"]}, frozenset({Role.AUDITOR}), True),
+    ],
+)
+def test_every_jwt_role_claim_state_resolves_correctly(claim, expected_roles, expected_present):
+    from app.auth.principal import Principal
+    from app.auth.providers import JWTProvider
+
+    provider = JWTProvider(
+        key=FAKE_JWT_SIGNING_KEY,
+        algorithms=["HS256"],
+        tenant_claim="tenant_id",
+        user_claim="sub",
+    )
+    tok = make_jwt(
+        {"sub": "u1", "tenant_id": "t1", "exp": time.time() + 60, **claim},
+        secret=FAKE_JWT_SIGNING_KEY,
+    )
+    principal = provider.resolve({"authorization": f"Bearer {tok}"})
+    assert isinstance(principal, Principal)
+    assert principal.role_claim_present is expected_present
+    assert principal.effective_roles == expected_roles
+
+
+def test_a_null_identity_claim_is_rejected_outright():
+    """Absent and null are correctly identical for identity claims — there is no
+    fallback to reach, so both must refuse authentication rather than invent one."""
+    from app.auth.providers import JWTProvider
+
+    provider = JWTProvider(
+        key=FAKE_JWT_SIGNING_KEY,
+        algorithms=["HS256"],
+        tenant_claim="tenant_id",
+        user_claim="sub",
+    )
+    for claims in (
+        {"sub": "u1", "tenant_id": None},
+        {"sub": None, "tenant_id": "t1"},
+        {"tenant_id": "t1"},
+        {"sub": "u1"},
+    ):
+        tok = make_jwt({**claims, "exp": time.time() + 60}, secret=FAKE_JWT_SIGNING_KEY)
+        assert provider.resolve({"authorization": f"Bearer {tok}"}) is None, claims
+
+
+def test_a_trusted_header_still_infers_presence_from_the_header(auth_client):
+    """The header provider must keep its own reading: an absent header is `None`,
+    an empty header is `""`, and that distinction is already exact."""
+    from app.auth.providers import TrustedHeaderProvider
+
+    provider = TrustedHeaderProvider(
+        tenant_header="X-MemoryOps-Tenant",
+        user_header="X-MemoryOps-User",
+        roles_header="X-MemoryOps-Roles",
+    )
+    base = {"x-memoryops-tenant": "t1", "x-memoryops-user": "u1"}
+
+    absent = provider.resolve(base)
+    assert absent.role_claim_present is False
+    assert absent.effective_roles == frozenset({Role.MEMORY_USER})
+
+    empty = provider.resolve({**base, "x-memoryops-roles": ""})
+    assert empty.role_claim_present is True
+    assert empty.effective_roles == frozenset()

--- a/services/api/tests/test_memory_route_authorization.py
+++ b/services/api/tests/test_memory_route_authorization.py
@@ -775,3 +775,54 @@ def test_jwt_self_approval_is_refused_exactly_as_under_trusted_header(monkeypatc
     assert r.status_code == 403
     assert "memory:approve:tenant" in r.json()["detail"]
     assert repo.get_memory(TENANT, "alice", pending.id).status is MemStatus.pending
+
+
+def test_a_null_roles_claim_is_refused_at_the_route_with_no_side_effects(monkeypatch):
+    """The end-to-end shape of the claim-state fix.
+
+    `{"roles": null}` is an issuer stating this identity has no roles. Read as an
+    omitted claim it took the compatibility fallback to `memory_user` — which carries
+    `memory:write:self`, so the chat write path ran for a credential meant to carry
+    nothing. The refusal must also land before any of it: no loop run, no audit event,
+    no policy-broker call, no memory.
+    """
+    import time
+
+    from app.services import policy_broker
+
+    from .test_auth import make_jwt
+
+    client, repo = _jwt_client(monkeypatch)
+
+    calls = {"policy": 0}
+    original = policy_broker.PolicyBroker.evaluate
+
+    def counting(inner_self, *a, **kw):
+        calls["policy"] += 1
+        return original(inner_self, *a, **kw)
+
+    monkeypatch.setattr(policy_broker.PolicyBroker, "evaluate", counting)
+
+    def _token(claims: dict) -> dict:
+        payload = {"sub": "alice", "tenant_id": TENANT, "exp": time.time() + 60, **claims}
+        return {"Authorization": f"Bearer {make_jwt(payload, secret=FAKE_JWT_SIGNING_KEY)}"}
+
+    body = {"tenant_id": TENANT, "user_id": "alice", "message": "remember I prefer dark mode"}
+
+    runs_before = len(repo.list_loop_runs(tenant_id=TENANT, user_id="alice", limit=1000))
+    audit_before = len(repo.list_audit(TENANT, "alice", limit=1000))
+
+    refused = client.post("/api/chat", json=body, headers=_token({"roles": None}))
+    assert refused.status_code == 403
+    assert "memory:write:self" in refused.json()["detail"]
+
+    assert len(repo.list_loop_runs(tenant_id=TENANT, user_id="alice", limit=1000)) == runs_before
+    assert len(repo.list_audit(TENANT, "alice", limit=1000)) == audit_before
+    assert calls["policy"] == 0
+    assert repo.list_memories(TENANT, "alice") == []
+
+    # The same request with the claim genuinely omitted still works, so the refusal
+    # is the null claim being honoured — not chat being broken for everyone.
+    allowed = client.post("/api/chat", json=body, headers=_token({}))
+    assert allowed.status_code == 200
+    assert calls["policy"] > 0


### PR DESCRIPTION
Follow-up to #127, which had already been squash-merged as `5f8a724` before this
defect was identified — so this lands as its own PR rather than a revision of that one.

## The defect

#127 fixed JWT `roles` claims arriving as arrays. One state was still wrong.

`claim_node` returned `None` for both an absent key **and** an explicit JSON `null`,
and its docstring said both meant "the issuer said nothing". `resolve_roles` then
inferred presence as `raw is not None`, so `{"roles": null}` read as *omitted* and
took the compatibility fallback to `DEFAULT_ROLE` — `memory_user`, which carries
read, write, archive and delete over the caller's own memory.

Reproduced against `main` before changing anything:

```
omitted       present=False effective=['memory_user']
null          present=False effective=['memory_user']   <- wrong
empty list    present=True  effective=[]
empty string  present=True  effective=[]
unknown       present=True  effective=[]
auditor       present=True  effective=['auditor']
```

This is the same class of bug as the array one and violates the same principle from
#116: an omitted claim is a **deployment compatibility** question; an explicitly empty
or invalid claim is an **authorization decision the issuer already made** and must be
honoured.

## The fix

Presence is no longer inferred from the value.

```python
def claim_node(payload: dict, dotted: str) -> tuple[bool, object | None]: ...

roles_present, raw_roles = claim_node(payload, self._roles_claim)
roles, claim_present = resolve_roles(raw_roles, claim_present=roles_present)
```

An absent key and a JSON `null` both hold `None`, but they are opposite statements —
a credential that predates roles entirely, versus an issuer deciding this identity
gets nothing. Only the first may fall back, and no inspection of the value can
distinguish them.

`resolve_roles` keeps its old inference as the default, so the **trusted-header
provider is unchanged**: for it an absent header really is `None` and an empty header
is `""`, which is already an exact distinction.

**Identity claims are deliberately untouched.** For `tenant_id` and `sub` there is no
fallback to reach, so absent and `null` are correctly identical — both refuse
authentication rather than invent an identifier. There is a test asserting the
narrowing does not leak there.

## Tests

857 pass, up from 847.

All six claim states pinned in one parametrized test through the real provider:

| Claim | Result |
| --- | --- |
| omitted | fallback where compatibility permits |
| `null` | zero permissions |
| `[]` | zero permissions |
| `""` | zero permissions |
| `["unknown_role"]` | zero permissions |
| `["auditor"]` | auditor |

Plus:

- `claim_node` returns `(True, None)` for `null` and `(False, None)` for absent —
  including through a nested dotted path, so the Auth0/Okta-style namespaced shape is
  covered.
- `tenant_id: null` and `sub: null` both refuse authentication.
- The trusted-header provider still distinguishes absent from empty.
- **HTTP-level:** a `roles: null` JWT posting to `/api/chat` gets `403` with **no**
  loop run, audit event, policy-broker call, or stored memory — and the same request
  with the claim genuinely omitted still returns `200`, so the refusal is the null
  being honoured rather than chat being broken for everyone.

Gate green: pytest 857, ruff, evals, benchmark, matrix drift check, PR invariant gate,
gitleaks over the commit range.

## Also corrected

`docs/security/api-rbac.md` was stale in two ways this change touches, both
predating it:

- it named `memory_reader`, renamed to `memory_user` in #116;
- it said a caller with "no recognised role" gets the fallback, when a
  present-but-invalid claim has granted nothing since #116.

Both fixed, with the six-state table added and an explicit operator note: if you issue
tokens where an unprivileged identity gets `"roles": null`, that identity now receives
zero permissions and every governed route will refuse it. Omit the claim instead if
you want the fallback.

## Out of scope

No route statuses change (still 10 enforced / 20 planned / 9 public) and no
authorization logic moves. This is the claim-state reader only.
