### PR TITLE
feat(auth): enforce authorization on retention and consent mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,32 @@ file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
   correction rather than an additive change; every patch that requests a real
   change is unaffected.
 
+## Unreleased — governance mutations enforced
+
+**28 of 39 routes enforced.** Planned 2 (`POST /api/evals/run`, `GET /api/traces`),
+public 9.
+
+- **Legal hold, pin, protect and consent now require `retention:manage` /
+  `consent:manage`.** `auditor` reads governance state and cannot change it;
+  `memory_admin` and `tenant_admin` manage it within their tenant.
+
+### Fixed
+- **An admin could not govern another user's memory.** `_load()` ran
+  `enforce_scope(request, tenant_id, user_id)` and then looked the record up with
+  `repo.get_memory(tenant_id, user_id, memory_id)` — both halves trusting the
+  request's `user_id`. Naming the real owner was refused (`403`, scope mismatch);
+  naming yourself found nothing (`404`). The stored owner is now authoritative: the
+  request's `user_id` is a compatibility hint about where to look, and the lookup is
+  tenant-scoped and user-spanning.
+
+### Audit evidence
+- **Actor and target are recorded separately.** Once an admin can change someone
+  else's governance state, `audit.user_id = "bob"` cannot say whether Bob acted or was
+  acted upon. `user_id` stays the *target* for query compatibility, and content-free
+  metadata now names `actor_id`, `actor_user_id`, `actor_type` (human /
+  service_account), `target_user_id`, `authorized_permission`, and
+  `acted_on_behalf_of_another_user`. Never the credential, its claims, or memory text.
+
 ## Unreleased — governance and evidence reads enforced
 
 **24 of 39 routes enforced** (was 10). Planned 6, public 9.

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -344,6 +344,23 @@ calls the harness, and it updates what this route serves.
 Results are **deployment-wide**, not per-tenant — the harness runs against its own
 isolated fixtures — which is why this route takes no tenant parameter.
 
+## Retention + consent mutations
+`POST /api/retention/{legal-hold,pin,protect}` require `retention:manage`;
+`POST /api/retention/consent` requires `consent:manage`. Both are held by
+`memory_admin` and `tenant_admin`; `auditor` is deliberately refused — reading
+governance evidence is not permission to change it.
+
+Body: `{ tenant_id, user_id, memory_id, ... }`. **The stored memory's owner is
+authoritative**, not the body's `user_id`, which is only a hint about where to look.
+An administrator therefore sends their own scope and the loaded record decides. A
+memory outside the authenticated tenant answers `404`; naming another tenant outright
+answers `403`.
+
+Each mutation appends one content-free audit event in the same transaction as the
+governance change. `user_id` on that event is the **target**; the actor is recorded
+separately in metadata (`actor_user_id`, `actor_type`, `authorized_permission`,
+`acted_on_behalf_of_another_user`) so "who did this to whom" is unambiguous.
+
 ## Retention reads
 `GET /api/retention/policies`, `/decisions`, `/memory/{memory_id}` require
 `retention:read` — held by **both** `auditor` and `memory_admin`. Retention describes

--- a/docs/security.md
+++ b/docs/security.md
@@ -399,8 +399,8 @@ matters most:
 | --- | --- | --- | --- | --- | --- |
 | `memory_viewer` | – | – | – | – | – |
 | `memory_user` | – | – | – | – | own only |
-| `memory_admin` | – | – | – | ✓ | tenant-wide |
-| `auditor` | ✓ | ✓ | ✓ | ✓ | – |
+| `memory_admin` | – | – | – | ✓ (+ manage) | tenant-wide |
+| `auditor` | ✓ | ✓ | ✓ | ✓ (read only) | – |
 | `tenant_admin` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `service_worker` | – | – | – | – | – |
 
@@ -456,6 +456,36 @@ stays honest until either spans carry a tenant and are filtered by it, or the en
 is reclassified as deployment-level telemetry under an `ops:traces` permission with a
 dedicated observability role. An ordinary tenant auditor should not implicitly become
 a deployment-wide observability operator.
+
+### Governance mutations: the stored owner is the target
+
+Legal hold, pin, protect and consent require `retention:manage` / `consent:manage` —
+held by `memory_admin` and `tenant_admin`, and deliberately **not** by `auditor`, who
+reads governance evidence and must not be able to change it.
+
+Administering another user's record was previously impossible: the handler validated
+the request's `user_id` against the principal and *then* looked the memory up with it,
+so naming the owner was refused as a scope mismatch and naming yourself found nothing.
+The rule is now the same one the memory routes follow — the request's `user_id` is a
+hint about where to look, and the **stored** owner decides everything after that.
+
+#### Actor and target are different facts
+
+Once an admin can change someone else's governance state, an audit row saying
+`user_id: bob` is ambiguous: did Bob act, or was Bob acted upon? `user_id` remains the
+**target** so existing per-user queries keep working, and each mutation additionally
+records, content-free:
+
+| Field | Meaning |
+| --- | --- |
+| `actor_id` / `actor_user_id` | who performed it |
+| `actor_type` | `human` or `service_account` |
+| `target_user_id` | whose record changed |
+| `authorized_permission` | which capability permitted it |
+| `acted_on_behalf_of_another_user` | true when actor ≠ target |
+
+The credential, its claims, and memory content are never written to the audit trail —
+it is read by operators who may not be cleared for the memory itself.
 
 ### What is not claimed
 

--- a/docs/security/endpoint-authorization-matrix.md
+++ b/docs/security/endpoint-authorization-matrix.md
@@ -87,7 +87,7 @@ cannot get ahead of the runtime again.
 
 ### Enforced
 
-The handler checks the permission. 24 of 39 routes.
+The handler checks the permission. 28 of 39 routes.
 
 | Method | Path | Scope | Permission | Note |
 | --- | --- | --- | --- | --- |
@@ -112,9 +112,13 @@ The handler checks the permission. 24 of 39 routes.
 | `GET` | `/api/memories/{memory_id}/audit` | resource | `audit:read:self` (own) / `audit:read:tenant` (tenant) |  |
 | `GET` | `/api/memories/{memory_id}/provenance` | resource | `memory:read:self` (own) / `memory:read:tenant` (tenant) |  |
 | `GET` | `/api/metrics` | tenant | `metrics:read:tenant` |  |
+| `POST` | `/api/retention/consent` | tenant | `consent:manage` |  |
 | `GET` | `/api/retention/decisions` | tenant | `retention:read` |  |
+| `POST` | `/api/retention/legal-hold` | tenant | `retention:manage` |  |
 | `GET` | `/api/retention/memory/{memory_id}` | tenant | `retention:read` |  |
+| `POST` | `/api/retention/pin` | tenant | `retention:manage` |  |
 | `GET` | `/api/retention/policies` | tenant | `retention:read` |  |
+| `POST` | `/api/retention/protect` | tenant | `retention:manage` |  |
 
 ### Planned — declared, **not yet enforced**
 
@@ -125,10 +129,6 @@ control.**
 | Method | Path | Scope | Permission | Note |
 | --- | --- | --- | --- | --- |
 | `POST` | `/api/evals/run` | tenant | `evals:run` | denial-of-wallet vector |
-| `POST` | `/api/retention/consent` | tenant | `consent:manage` |  |
-| `POST` | `/api/retention/legal-hold` | tenant | `retention:manage` |  |
-| `POST` | `/api/retention/pin` | tenant | `retention:manage` |  |
-| `POST` | `/api/retention/protect` | tenant | `retention:manage` |  |
 | `GET` | `/api/traces` | tenant | `traces:read:tenant` | permission-gated but not tenant-isolated; span buffer is process-wide |
 
 ### Public

--- a/services/api/app/auth/authz_spec.py
+++ b/services/api/app/auth/authz_spec.py
@@ -311,16 +311,16 @@ ROUTE_AUTHZ: dict[tuple[str, str], AuthzSpec] = {
         _S.TENANT, _ST.ENFORCED, permission=_P.RETENTION_READ
     ),
     ("POST", "/api/retention/legal-hold"): AuthzSpec(
-        _S.TENANT, _ST.PLANNED, permission=_P.RETENTION_MANAGE
+        _S.TENANT, _ST.ENFORCED, permission=_P.RETENTION_MANAGE
     ),
     ("POST", "/api/retention/pin"): AuthzSpec(
-        _S.TENANT, _ST.PLANNED, permission=_P.RETENTION_MANAGE
+        _S.TENANT, _ST.ENFORCED, permission=_P.RETENTION_MANAGE
     ),
     ("POST", "/api/retention/protect"): AuthzSpec(
-        _S.TENANT, _ST.PLANNED, permission=_P.RETENTION_MANAGE
+        _S.TENANT, _ST.ENFORCED, permission=_P.RETENTION_MANAGE
     ),
     ("POST", "/api/retention/consent"): AuthzSpec(
-        _S.TENANT, _ST.PLANNED, permission=_P.CONSENT_MANAGE
+        _S.TENANT, _ST.ENFORCED, permission=_P.CONSENT_MANAGE
     ),
     # ── loops (operational timelines, tenant-scoped) ────────────────────────
     ("GET", "/api/loops"): AuthzSpec(

--- a/services/api/app/routes/retention.py
+++ b/services/api/app/routes/retention.py
@@ -18,12 +18,14 @@ Endpoints:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 
-from ..auth import Permission, enforce_scope, require_permission
+from ..auth import Permission, require_permission
+from ..auth.principal import Principal
 from ..db import governance as gov
 from ..db.factory import get_repository
 from ..deps import audit_service
@@ -53,13 +55,84 @@ class ConsentRequest(_ScopedRequest):
     expires_at: datetime | None = None
 
 
-def _load(req: _ScopedRequest, request: Request):
-    enforce_scope(request, req.tenant_id, req.user_id)
+@dataclass(frozen=True)
+class GovernedTarget:
+    """The record a governance mutation will act on, and who is acting.
+
+    `target_user_id` comes from the **stored** memory, never from the request. The
+    request's `user_id` is a compatibility hint about where to look, and nothing more:
+    trusting it both broke legitimate administration (an admin naming another user was
+    refused by scope validation, and naming themselves found nothing) and let
+    caller-controlled scope back into the trusted path.
+    """
+
+    repo: object
+    memory: object
+    principal: Principal | None
+    tenant_id: str
+    target_user_id: str
+    permission: Permission
+
+    def audit_metadata(self, **extra) -> dict:
+        """Content-free evidence naming actor *and* target separately.
+
+        `audit.user_id` stays the target for query compatibility, which is ambiguous
+        on its own once an admin can act on someone else's record — "user_id: bob"
+        cannot say whether Bob acted or was acted upon. Never includes the credential,
+        its claims, or any memory content.
+        """
+        principal = self.principal
+        return {
+            **extra,
+            "actor_id": principal.actor if principal else "development-unauthenticated",
+            "actor_user_id": principal.user_id if principal else "development-unauthenticated",
+            "actor_type": (
+                "service_account" if principal and principal.is_service_account else "human"
+            ),
+            "target_user_id": self.target_user_id,
+            "authorized_permission": self.permission.value,
+            "acted_on_behalf_of_another_user": bool(
+                principal and principal.user_id != self.target_user_id
+            ),
+        }
+
+
+def _load_governed_target(
+    req: _ScopedRequest, request: Request, permission: Permission
+) -> GovernedTarget:
+    """Authorize, then load the target inside the authenticated tenant.
+
+    Authorization happens **first** — before any repository read, transaction, or
+    audit append — so a refused caller leaves no trace and does no work.
+    """
+    principal = require_permission(request, permission)
     repo = get_repository()
-    memory = repo.get_memory(req.tenant_id, req.user_id, req.memory_id)
+
+    if principal is None:
+        # Auth disabled: unchanged development behaviour, scoped by the request.
+        tenant_id = req.tenant_id
+        memory = repo.get_memory(req.tenant_id, req.user_id, req.memory_id)
+    else:
+        if req.tenant_id != principal.tenant_id:
+            raise HTTPException(
+                status_code=403, detail="request scope does not match authenticated principal"
+            )
+        tenant_id = principal.tenant_id
+        # Tenant-scoped and user-spanning: an admin manages records they do not own,
+        # and the tenant stays a predicate so another tenant's id is simply not found.
+        memory = repo.get_memory_in_tenant(tenant_id, req.memory_id)
+
     if memory is None:
         raise HTTPException(status_code=404, detail="memory not found")
-    return repo, memory
+
+    return GovernedTarget(
+        repo=repo,
+        memory=memory,
+        principal=principal,
+        tenant_id=tenant_id,
+        target_user_id=memory.user_id,
+        permission=permission,
+    )
 
 
 def _trace(request: Request) -> str:
@@ -73,56 +146,59 @@ def _state(memory) -> dict:
 # ── mutations ─────────────────────────────────────────────────────────────────
 @router.post("/legal-hold")
 def set_legal_hold(req: LegalHoldRequest, request: Request) -> dict:
-    repo, memory = _load(req, request)
+    target = _load_governed_target(req, request, Permission.RETENTION_MANAGE)
+    repo, memory = target.repo, target.memory
     # Governance mutation + audit commit atomically (P0). The mutation runs inside
     # the transaction so a rollback restores the live in-memory row (see ADR-027).
-    with repo.transaction(req.tenant_id, req.user_id):
+    with repo.transaction(target.tenant_id, target.target_user_id):
         gov.set_legal_hold(memory, on=req.on, reason=req.reason)
         repo.update_memory(memory)
         audit_service().record(
-            tenant_id=req.tenant_id,
-            user_id=req.user_id,
+            tenant_id=target.tenant_id,
+            user_id=target.target_user_id,
             memory_id=req.memory_id,
             action="memory_legal_hold_set" if req.on else "memory_legal_hold_released",
             reason=(req.reason or "legal hold updated") if req.on else "legal hold released",
             trace_id=_trace(request),
-            metadata={"legal_hold": req.on},
+            metadata=target.audit_metadata(**{"legal_hold": req.on}),
         )
     return _state(memory)
 
 
 @router.post("/pin")
 def set_pin(req: FlagRequest, request: Request) -> dict:
-    repo, memory = _load(req, request)
-    with repo.transaction(req.tenant_id, req.user_id):
+    target = _load_governed_target(req, request, Permission.RETENTION_MANAGE)
+    repo, memory = target.repo, target.memory
+    with repo.transaction(target.tenant_id, target.target_user_id):
         gov.set_pinned(memory, on=req.on)
         repo.update_memory(memory)
         audit_service().record(
-            tenant_id=req.tenant_id,
-            user_id=req.user_id,
+            tenant_id=target.tenant_id,
+            user_id=target.target_user_id,
             memory_id=req.memory_id,
             action="memory_pinned" if req.on else "memory_unpinned",
             reason="memory pin updated",
             trace_id=_trace(request),
-            metadata={"pinned": req.on},
+            metadata=target.audit_metadata(**{"pinned": req.on}),
         )
     return _state(memory)
 
 
 @router.post("/protect")
 def set_protect(req: FlagRequest, request: Request) -> dict:
-    repo, memory = _load(req, request)
-    with repo.transaction(req.tenant_id, req.user_id):
+    target = _load_governed_target(req, request, Permission.RETENTION_MANAGE)
+    repo, memory = target.repo, target.memory
+    with repo.transaction(target.tenant_id, target.target_user_id):
         gov.set_protected(memory, on=req.on)
         repo.update_memory(memory)
         audit_service().record(
-            tenant_id=req.tenant_id,
-            user_id=req.user_id,
+            tenant_id=target.tenant_id,
+            user_id=target.target_user_id,
             memory_id=req.memory_id,
             action="memory_protected" if req.on else "memory_unprotected",
             reason="memory protection updated",
             trace_id=_trace(request),
-            metadata={"protected": req.on},
+            metadata=target.audit_metadata(**{"protected": req.on}),
         )
     return _state(memory)
 
@@ -131,18 +207,19 @@ def set_protect(req: FlagRequest, request: Request) -> dict:
 def set_consent(req: ConsentRequest, request: Request) -> dict:
     if req.status not in gov.ConsentStatus.ALL:
         raise HTTPException(status_code=422, detail=f"unknown consent status: {req.status}")
-    repo, memory = _load(req, request)
-    with repo.transaction(req.tenant_id, req.user_id):
+    target = _load_governed_target(req, request, Permission.CONSENT_MANAGE)
+    repo, memory = target.repo, target.memory
+    with repo.transaction(target.tenant_id, target.target_user_id):
         gov.set_consent(memory, status=req.status, expires_at=req.expires_at)
         repo.update_memory(memory)
         audit_service().record(
-            tenant_id=req.tenant_id,
-            user_id=req.user_id,
+            tenant_id=target.tenant_id,
+            user_id=target.target_user_id,
             memory_id=req.memory_id,
             action="memory_consent_updated",
             reason=f"consent set to {req.status}",
             trace_id=_trace(request),
-            metadata={"consent_status": req.status},
+            metadata=target.audit_metadata(**{"consent_status": req.status}),
         )
     return _state(memory)
 

--- a/services/api/tests/_authz_domains.py
+++ b/services/api/tests/_authz_domains.py
@@ -4,25 +4,43 @@ Shared so the coverage guard and the gates themselves cannot disagree. A route i
 of these domains must be driven through the real app by that domain's gate; a route in
 none of them has to be named explicitly in the coverage guard, which is the case that
 would otherwise slip through unnoticed.
+
+The predicates take the **method** as well as the path: `/api/retention/*` holds both
+reads and mutations, and they are gated by different files, so a path-only predicate
+would make the read gate responsible for the mutations it does not drive.
 """
 
 from __future__ import annotations
 
+_GOVERNANCE_PREFIXES = ("/api/evidence", "/api/retention", "/api/loops")
+_GOVERNANCE_PATHS = frozenset({"/api/traces", "/api/evals/latest"})
 
-def is_memory_domain(path: str) -> bool:
+
+def is_memory_domain(method: str, path: str) -> bool:
     return path.startswith("/api/memories") or path == "/api/chat"
 
 
-def is_governance_domain(path: str) -> bool:
-    return path.startswith(("/api/evidence", "/api/retention", "/api/loops")) or path in {
-        "/api/traces",
-        "/api/evals/latest",
-    }
+def is_governance_read(method: str, path: str) -> bool:
+    if method != "GET":
+        return False
+    return path.startswith(_GOVERNANCE_PREFIXES) or path in _GOVERNANCE_PATHS
+
+
+def is_governance_mutation(method: str, path: str) -> bool:
+    return method == "POST" and path.startswith("/api/retention/")
+
+
+def is_runtime_gated(method: str, path: str) -> bool:
+    return (
+        is_memory_domain(method, path)
+        or is_governance_read(method, path)
+        or is_governance_mutation(method, path)
+    )
 
 
 def enforced_in(route_authz, status_enforced, predicate) -> set[tuple[str, str]]:
     return {
         (m, p)
         for (m, p), spec in route_authz.items()
-        if spec.status is status_enforced and predicate(p)
+        if spec.status is status_enforced and predicate(m, p)
     }

--- a/services/api/tests/test_governance_mutation_authorization.py
+++ b/services/api/tests/test_governance_mutation_authorization.py
@@ -1,0 +1,433 @@
+"""Authorization on the four governance mutations.
+
+The defect this fixes
+---------------------
+`_load()` called `enforce_scope(request, req.tenant_id, req.user_id)` and then looked
+the memory up with `repo.get_memory(req.tenant_id, req.user_id, ...)`. Both halves
+trusted the request's `user_id`, so a `memory_admin` could not manage another user's
+record by either route:
+
+    names the real owner  -> 403 (scope validation rejects a user that is not you)
+    names themselves      -> 404 (the lookup cannot find someone else's memory)
+
+The fix is the same rule the memory routes already follow: the request's `user_id` is
+a hint about where to look; the **stored** owner is authoritative for the mutation and
+for the audit record.
+
+Which raises a second problem. Once an admin can act on someone else's governance
+state, `audit.user_id = "bob"` no longer says whether Bob acted or was acted upon, so
+actor and target are now recorded separately.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.auth.authz_spec import ROUTE_AUTHZ, Status
+from app.auth.witness import witness_for
+from app.db.entities import StoredMemory
+from app.schemas.memory import MemoryType, Sensitivity, Source
+from app.schemas.memory import Status as MemStatus
+
+from ._authz_domains import enforced_in, is_governance_mutation
+
+TENANT = "acme"
+
+
+def _hdr(user: str, roles: str | None = None, tenant: str = TENANT) -> dict:
+    h = {"X-MemoryOps-Tenant": tenant, "X-MemoryOps-User": user}
+    if roles:
+        h["X-MemoryOps-Roles"] = roles
+    return h
+
+
+@pytest.fixture
+def gov(monkeypatch):
+    from app import deps
+    from app.core import config
+    from app.db import factory
+
+    def _clear():
+        config.get_settings.cache_clear()
+        factory.get_repository.cache_clear()
+        deps.gateway.cache_clear()
+        deps.audit_service.cache_clear()
+
+    monkeypatch.setenv("MEMORYOPS_AUTH_MODE", "trusted_header")
+    monkeypatch.setenv("MEMORYOPS_STORAGE", "memory")
+    _clear()
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    recorded: list = []
+
+    async def _capture(request, call_next):
+        response = await call_next(request)
+        recorded.extend(witness_for(request).decisions)
+        return response
+
+    app.middleware_stack = None
+    app.add_middleware(BaseHTTPMiddleware, dispatch=_capture)
+
+    client = TestClient(app)
+    repo = factory.get_repository()
+
+    class Harness:
+        def __init__(self):
+            self.client = client
+            self.repo = repo
+            self.decisions = recorded
+
+        def seed(self, *, user="bob", tenant=TENANT, content="a governed note"):
+            return repo.create_memory(
+                StoredMemory(
+                    tenant_id=tenant,
+                    user_id=user,
+                    memory_type=MemoryType.preference,
+                    content=content,
+                    importance=5,
+                    confidence=0.8,
+                    sensitivity=Sensitivity.low,
+                    status=MemStatus.active,
+                    source=Source(kind="chat", excerpt=content),
+                )
+            )
+
+        def audit_for(self, memory_id):
+            return repo.list_audit(TENANT, None, memory_id=memory_id, limit=50)
+
+        def last_for(self, method, path):
+            return [d for d in recorded if d.route == (method, path)]
+
+        def clear(self):
+            recorded.clear()
+
+    yield Harness()
+    app.user_middleware = [
+        m for m in app.user_middleware if m.kwargs.get("dispatch") is not _capture
+    ]
+    app.middleware_stack = None
+    _clear()
+
+
+#: (route path, body beyond scope, permission it must require)
+_MUTATIONS = [
+    pytest.param("/api/retention/legal-hold", {"on": True, "reason": "litigation"},
+                 "retention:manage", id="legal-hold"),
+    pytest.param("/api/retention/pin", {"on": True}, "retention:manage", id="pin"),
+    pytest.param("/api/retention/protect", {"on": True}, "retention:manage", id="protect"),
+    pytest.param("/api/retention/consent", {"status": "withdrawn"}, "consent:manage",
+                 id="consent"),
+]
+
+
+def _body(memory_id: str, extra: dict, user: str = "alice") -> dict:
+    return {"tenant_id": TENANT, "user_id": user, "memory_id": memory_id, **extra}
+
+
+# ── the reproduction ─────────────────────────────────────────────────────────
+@pytest.mark.parametrize(("path", "extra", "permission"), _MUTATIONS)
+def test_an_admin_governs_another_users_memory(gov, path, extra, permission):
+    """Neither addressing mode worked before: naming the owner was refused by scope
+    validation, and naming yourself found nothing."""
+    mem = gov.seed(user="bob")
+    r = gov.client.post(
+        path, json=_body(mem.id, extra), headers=_hdr("alice", "memory_admin")
+    )
+    assert r.status_code == 200, r.text
+
+    decision = gov.last_for("POST", path)[-1]
+    assert decision.permission.value == permission
+
+
+@pytest.mark.parametrize(("path", "extra", "permission"), _MUTATIONS)
+def test_the_stored_owner_wins_over_whatever_the_request_claims(gov, path, extra, permission):
+    """A caller-supplied `user_id` must not steer the mutation or the audit target."""
+    mem = gov.seed(user="bob")
+    r = gov.client.post(
+        path,
+        json=_body(mem.id, extra, user="alice"),  # not the owner
+        headers=_hdr("alice", "memory_admin"),
+    )
+    assert r.status_code == 200, r.text
+
+    stored = gov.repo.get_memory_in_tenant(TENANT, mem.id)
+    assert stored.user_id == "bob"
+    row = gov.audit_for(mem.id)[0]
+    assert row.user_id == "bob", "the audit target is the stored owner, not the request"
+
+
+@pytest.mark.parametrize(("path", "extra", "permission"), _MUTATIONS)
+def test_actor_and_target_are_recorded_separately(gov, path, extra, permission):
+    """`user_id: bob` alone cannot say whether Bob acted or was acted upon."""
+    mem = gov.seed(user="bob")
+    assert gov.client.post(
+        path, json=_body(mem.id, extra), headers=_hdr("alice", "memory_admin")
+    ).status_code == 200
+
+    row = gov.audit_for(mem.id)[0]
+    assert row.user_id == "bob"
+    assert row.metadata["actor_user_id"] == "alice"
+    assert row.metadata["target_user_id"] == "bob"
+    assert row.metadata["actor_type"] == "human"
+    assert row.metadata["authorized_permission"] == permission
+    assert row.metadata["acted_on_behalf_of_another_user"] is True
+
+    # Content-free: no credential, no claims, no memory text.
+    blob = str(row.metadata)
+    assert "a governed note" not in blob
+    assert "X-MemoryOps" not in blob and "Bearer" not in blob
+
+
+def test_self_service_is_not_labelled_as_acting_for_someone_else(gov):
+    mem = gov.seed(user="alice")
+    assert gov.client.post(
+        "/api/retention/pin",
+        json=_body(mem.id, {"on": True}),
+        headers=_hdr("alice", "memory_admin"),
+    ).status_code == 200
+    row = gov.audit_for(mem.id)[0]
+    assert row.metadata["acted_on_behalf_of_another_user"] is False
+
+
+# ── role separation ──────────────────────────────────────────────────────────
+@pytest.mark.parametrize(("path", "extra", "permission"), _MUTATIONS)
+@pytest.mark.parametrize(
+    "role", ["auditor", "memory_user", "memory_viewer", "service_worker", None]
+)
+def test_roles_without_the_permission_are_refused(gov, path, extra, permission, role):
+    """An auditor reads governance evidence and must not be able to change it."""
+    mem = gov.seed(user="alice")
+    r = gov.client.post(path, json=_body(mem.id, extra), headers=_hdr("alice", role))
+    assert r.status_code == 403, f"{role}: {r.text}"
+    assert permission in r.json()["detail"]
+
+
+@pytest.mark.parametrize(("path", "extra", "permission"), _MUTATIONS)
+def test_a_tenant_admin_governs_its_own_tenant(gov, path, extra, permission):
+    mem = gov.seed(user="bob")
+    assert gov.client.post(
+        path, json=_body(mem.id, extra), headers=_hdr("alice", "tenant_admin")
+    ).status_code == 200
+
+
+@pytest.mark.parametrize(("path", "extra", "permission"), _MUTATIONS)
+def test_no_role_reaches_another_tenant(gov, path, extra, permission):
+    """Permission is not scope."""
+    theirs = gov.seed(tenant="evilcorp", user="mallory", content="their private note")
+    admin = _hdr("alice", "tenant_admin")
+
+    # Their memory id, our tenant: not found in the authenticated tenant.
+    r = gov.client.post(path, json=_body(theirs.id, extra), headers=admin)
+    assert r.status_code == 404
+    assert "their private note" not in r.text
+
+    # Naming their tenant outright: refused before the record is touched.
+    body = {**_body(theirs.id, extra), "tenant_id": "evilcorp", "user_id": "mallory"}
+    assert gov.client.post(path, json=body, headers=admin).status_code == 403
+
+    untouched = gov.repo.get_memory_in_tenant("evilcorp", theirs.id)
+    from app.db import governance as gov_state
+
+    assert gov_state.public_governance(untouched) == gov_state.public_governance(theirs)
+
+
+# ── a refused mutation does nothing at all ───────────────────────────────────
+class _Counters:
+    def __init__(self, h, monkeypatch):
+        self.h = h
+        self.lookups = 0
+        self.transactions = 0
+        repo = h.repo
+
+        for name in ("get_memory", "get_memory_in_tenant"):
+            original = getattr(repo, name)
+
+            def counting(*a, _o=original, **kw):
+                self.lookups += 1
+                return _o(*a, **kw)
+
+            monkeypatch.setattr(repo, name, counting)
+
+        original_tx = repo.transaction
+
+        def counting_tx(*a, **kw):
+            self.transactions += 1
+            return original_tx(*a, **kw)
+
+        monkeypatch.setattr(repo, "transaction", counting_tx)
+
+    def snapshot(self) -> dict:
+        repo = self.h.repo
+        return {
+            "lookups": self.lookups,
+            "transactions": self.transactions,
+            "audit": len(repo.list_audit(TENANT, limit=2000)),
+            "loop_runs": len(repo.list_loop_runs(tenant_id=TENANT, limit=1000)),
+            "loop_events": len(repo.list_loop_events(tenant_id=TENANT, limit=1000)),
+        }
+
+
+@pytest.fixture
+def counters(gov, monkeypatch):
+    return _Counters(gov, monkeypatch)
+
+
+@pytest.mark.parametrize(("path", "extra", "permission"), _MUTATIONS)
+def test_a_refused_mutation_reaches_nothing(gov, counters, path, extra, permission):
+    """Authorization runs before the repository lookup, so a refused caller cannot
+    even probe which memory ids exist, let alone open a transaction."""
+    from app.db import governance as gov_state
+
+    mem = gov.seed(user="bob")
+    before_state = gov_state.public_governance(gov.repo.get_memory_in_tenant(TENANT, mem.id))
+    before = counters.snapshot()
+
+    r = gov.client.post(path, json=_body(mem.id, extra), headers=_hdr("alice", "auditor"))
+    assert r.status_code == 403
+
+    after = counters.snapshot()
+    moved = {k: (before[k], after[k]) for k in before if before[k] != after[k]}
+    assert not moved, f"refused mutation left side effects: {moved}"
+
+    stored = gov.repo.get_memory_in_tenant(TENANT, mem.id)
+    assert gov_state.public_governance(stored) == before_state
+
+
+def test_the_side_effect_counters_move_on_an_authorized_mutation(gov, counters):
+    """Positive control — the assertions above are worthless if nothing is wired."""
+    mem = gov.seed(user="bob")
+    before = counters.snapshot()
+    assert gov.client.post(
+        "/api/retention/pin",
+        json=_body(mem.id, {"on": True}),
+        headers=_hdr("alice", "memory_admin"),
+    ).status_code == 200
+    after = counters.snapshot()
+    for key in ("lookups", "transactions", "audit"):
+        assert after[key] > before[key], f"{key} did not move on an authorized mutation"
+
+
+def test_an_unauthorized_request_for_a_nonexistent_memory_is_still_403(gov):
+    """403 before 404: the refusal must not double as an existence oracle."""
+    r = gov.client.post(
+        "/api/retention/pin",
+        json=_body("no-such-memory", {"on": True}),
+        headers=_hdr("alice", "auditor"),
+    )
+    assert r.status_code == 403
+
+
+def test_consent_validation_does_not_leak_record_existence(gov):
+    """The status vocabulary check runs before authorization, which is safe only
+    because it inspects nothing but the request body. Pinned so it stays that way."""
+    r = gov.client.post(
+        "/api/retention/consent",
+        json=_body("no-such-memory", {"status": "not-a-status"}),
+        headers=_hdr("alice", "auditor"),
+    )
+    assert r.status_code == 422
+    assert "unknown consent status" in r.json()["detail"]
+
+    # A *valid* status with no permission is refused without touching the record.
+    r = gov.client.post(
+        "/api/retention/consent",
+        json=_body("no-such-memory", {"status": "withdrawn"}),
+        headers=_hdr("alice", "auditor"),
+    )
+    assert r.status_code == 403
+
+
+# ── atomicity ────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(("path", "extra", "permission"), _MUTATIONS)
+def test_the_mutation_rolls_back_when_its_audit_fails(gov, monkeypatch, path, extra, permission):
+    """Invariant #7 across the newly authorized paths: governance state and its
+    evidence commit together or not at all."""
+    from app.db import governance as gov_state
+
+    mem = gov.seed(user="bob")
+    before = gov_state.public_governance(gov.repo.get_memory_in_tenant(TENANT, mem.id))
+
+    from app import deps
+
+    service = deps.audit_service()
+    monkeypatch.setattr(
+        service, "record", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("audit down"))
+    )
+
+    with pytest.raises(RuntimeError):
+        gov.client.post(path, json=_body(mem.id, extra), headers=_hdr("alice", "memory_admin"))
+
+    stored = gov.repo.get_memory_in_tenant(TENANT, mem.id)
+    assert gov_state.public_governance(stored) == before, (
+        "the governance mutation survived a failed audit"
+    )
+
+
+# ── the runtime witness gate ─────────────────────────────────────────────────
+def test_every_enforced_mutation_records_a_decision(gov):
+    mem = gov.seed(user="bob")
+    gov.clear()
+    driven = set()
+    for path, extra, _perm in [(p.values[0], p.values[1], p.values[2]) for p in _MUTATIONS]:
+        r = gov.client.post(
+            path, json=_body(mem.id, extra), headers=_hdr("alice", "tenant_admin")
+        )
+        assert r.status_code == 200, f"{path}: {r.text}"
+        driven.add(("POST", path))
+
+    expected = enforced_in(ROUTE_AUTHZ, Status.ENFORCED, is_governance_mutation)
+    assert driven == expected, f"gate does not drive every enforced mutation: {driven ^ expected}"
+
+    witnessed = {d.route for d in gov.decisions}
+    assert not expected - witnessed, f"no decision recorded for {sorted(expected - witnessed)}"
+
+
+def test_the_mutation_witness_gate_is_not_vacuous(gov, monkeypatch):
+    """Remove the permission check; the request still succeeds and the gate must
+    notice the missing witness."""
+    import app.routes.retention as retention_route
+
+    monkeypatch.setattr(retention_route, "require_permission", lambda request, permission: None)
+    mem = gov.seed(user="alice")
+    gov.clear()
+
+    r = gov.client.post(
+        "/api/retention/pin",
+        json=_body(mem.id, {"on": True}),
+        headers=_hdr("alice", "auditor"),
+    )
+    assert r.status_code == 200, "the unchecked handler still answers normally"
+    assert not gov.last_for("POST", "/api/retention/pin"), (
+        "no decision recorded — the gate cannot detect a handler that stopped checking"
+    )
+
+
+def test_governance_mutations_are_unchanged_with_auth_disabled(api_client):
+    """Development default: no principal, so the request scope stands."""
+    from app.db.entities import StoredMemory
+
+    client, repo = api_client
+    mem = repo.create_memory(
+        StoredMemory(
+            tenant_id="t1",
+            user_id="u1",
+            memory_type=MemoryType.preference,
+            content="a note",
+            importance=5,
+            confidence=0.8,
+            sensitivity=Sensitivity.low,
+            status=MemStatus.active,
+            source=Source(kind="chat", excerpt="a note"),
+        )
+    )
+    body = {"tenant_id": "t1", "user_id": "u1", "memory_id": mem.id}
+    for path, extra in (
+        ("/api/retention/legal-hold", {"on": True, "reason": "x"}),
+        ("/api/retention/pin", {"on": True}),
+        ("/api/retention/protect", {"on": True}),
+        ("/api/retention/consent", {"status": "granted"}),
+    ):
+        assert client.post(path, json={**body, **extra}).status_code == 200, path

--- a/services/api/tests/test_governance_read_authorization.py
+++ b/services/api/tests/test_governance_read_authorization.py
@@ -22,7 +22,7 @@ from app.db.entities import StoredMemory
 from app.schemas.memory import MemoryType, Sensitivity, Source
 from app.schemas.memory import Status as MemStatus
 
-from ._authz_domains import enforced_in, is_governance_domain
+from ._authz_domains import enforced_in, is_governance_read
 from ._secret_fixtures import FAKE_JWT_SIGNING_KEY
 
 TENANT = "acme"
@@ -148,7 +148,7 @@ def test_every_enforced_governance_read_records_a_decision(gov):
     )
     urls = _paths(gov, mem.id, trace)
 
-    expected = enforced_in(ROUTE_AUTHZ, Status.ENFORCED, is_governance_domain)
+    expected = enforced_in(ROUTE_AUTHZ, Status.ENFORCED, is_governance_read)
     assert set(urls) == expected, (
         "the gate does not drive every enforced governance route: "
         f"{sorted(set(urls) ^ expected)}"

--- a/services/api/tests/test_route_authorization_coverage.py
+++ b/services/api/tests/test_route_authorization_coverage.py
@@ -21,7 +21,7 @@ import pytest
 from app.auth.authz_spec import ROUTE_AUTHZ, AuthzSpec, Scope, Status, iter_routes
 from app.auth.roles import Permission, Role, permissions_for
 
-from ._authz_domains import is_governance_domain, is_memory_domain
+from ._authz_domains import is_runtime_gated
 
 
 @pytest.fixture(scope="module")
@@ -230,6 +230,10 @@ def test_the_currently_enforced_set_is_exactly_what_ships():
         "GET /api/retention/policies",
         "PATCH /api/memories/{memory_id}",
         "POST /api/chat",
+        "POST /api/retention/consent",
+        "POST /api/retention/legal-hold",
+        "POST /api/retention/pin",
+        "POST /api/retention/protect",
     ], f"enforced set changed: {enforced}"
 
 
@@ -370,8 +374,7 @@ def test_every_enforced_route_has_a_witness_test():
     runtime_gated = {
         f"{m} {p}"
         for (m, p), spec in ROUTE_AUTHZ.items()
-        if spec.status is Status.ENFORCED
-        and (is_memory_domain(p) or is_governance_domain(p))
+        if spec.status is Status.ENFORCED and is_runtime_gated(m, p)
     }
     uncovered = enforced - _WITNESSED_HERE - runtime_gated
     assert not uncovered, (


### PR DESCRIPTION
Fifth step of the API trust boundary. **28 of 39 routes enforced**; 2 planned, 9 public.

Enforces the four retention/consent mutations. `POST /api/evals/run` is deliberately
**excluded** — see the last section.

| Route | Permission |
| --- | --- |
| `POST /api/retention/legal-hold` | `retention:manage` |
| `POST /api/retention/pin` | `retention:manage` |
| `POST /api/retention/protect` | `retention:manage` |
| `POST /api/retention/consent` | `consent:manage` |

`auditor` reads governance state and is refused all four — reading the evidence is not
permission to change it. `memory_admin` and `tenant_admin` manage within their tenant.

## The reproduced flaw

Enforcement exposed that **an admin could not govern another user's memory at all**.
`_load()` ran `enforce_scope(request, tenant_id, user_id)` and then looked the record
up with `repo.get_memory(tenant_id, user_id, memory_id)` — both halves trusting the
request's `user_id`. Neither addressing mode worked:

```
memory_admin names bob (the real owner) -> 403 request scope does not match authenticated principal
memory_admin names self                 -> 404 memory not found
```

The stored owner is now authoritative. The request's `user_id` is a compatibility hint
about where to look; the lookup is tenant-scoped and user-spanning, and the
transaction, the mutation and the audit target all come from the loaded record. That
also keeps caller-controlled scope out of the trusted path — the same rule the memory
routes already follow.

## Actor and target are different facts

This is the part worth reviewing carefully. Once an admin can change someone else's
governance state, an audit row saying `user_id: bob` cannot say whether Bob **acted**
or **was acted upon**.

`user_id` stays the *target*, so existing per-user audit queries keep working. Each
mutation additionally records, content-free:

| Field | Meaning |
| --- | --- |
| `actor_id` / `actor_user_id` | who performed it |
| `actor_type` | `human` or `service_account` |
| `target_user_id` | whose record changed |
| `authorized_permission` | which capability permitted it |
| `acted_on_behalf_of_another_user` | true when actor ≠ target |

Never the credential, its claims, or memory text — the trail is read by operators who
may not be cleared for the memory itself, and a test asserts that.

## Ordering

Authorization runs **before** the repository lookup, so a refused caller cannot probe
which memory ids exist, open a transaction, or append evidence.

The consent status-vocabulary check deliberately stays *ahead* of authorization: it
inspects nothing but the request body, so it leaks nothing. A test pins that a valid
status with no permission is still refused without touching the record, so the
ordering is a decision rather than an accident.

## Tests

988 pass, up from 933 on `main`. New file: 55 tests.

- admin legal-holds / pins / protects / updates consent on another user's memory → 200
- auditor, memory_user, memory_viewer, service_worker, no-role → **403** on all four
- tenant_admin same-tenant → 200; another tenant → 404 (id) / 403 (named outright),
  with the target's governance state asserted unchanged
- a wrong `user_id` with a valid `memory_id` → the stored owner still wins, for the
  mutation *and* the audit row
- refused mutation → zero repository lookups, transactions, audit rows, loop records —
  with a positive control proving those counters move on an authorized mutation
- unauthorized request for a nonexistent memory → still 403, not 404 (not an
  existence oracle)
- injected audit failure → governance mutation rolled back, all four routes
  (invariant #7 on the newly authorized paths)
- runtime witness gate extended to the mutations, plus a negative test that removes
  the permission check, confirms the request still succeeds, and asserts the gate
  notices the missing witness
- auth-disabled development behaviour unchanged

Domain membership moved to **method-aware** predicates: `/api/retention` holds both
reads and mutations gated by different files, so a path-only predicate made the read
gate responsible for POSTs it does not drive.

Gate green: pytest 988, ruff, evals, benchmark, matrix drift check, PR invariant gate,
gitleaks over the commit range.

## Why `POST /api/evals/run` is not here

#129 established that evaluation execution and results are **deployment-wide**: the
harness runs against its own isolated fixtures, and the result store is process-wide.
But the route is still classified `tenant`, and `tenant_admin` currently receives
every permission via `frozenset(set(Permission))`.

Enforcing it unchanged would mean a tenant admin for tenant A can execute the
deployment-wide harness and replace the result every other tenant reads. That is
platform operation, not tenant administration — so it stays `planned` rather than
getting a truthful-looking label.

It belongs with `GET /api/traces` in a `feat/api-rbac-operational-boundary` PR that
introduces a `platform_operator` role and `ops:*` permissions, reclassifies
`GET /api/evals/latest` from `tenant` to a deployment-level scope, and **replaces
`frozenset(set(Permission))` with an explicit tenant bundle first** — otherwise every
future `ops:*` permission silently becomes tenant-admin authority.

## Out of scope

Eval execution; tracing storage; the operator role and `ops:*` permissions; web
capability generation; stable error envelopes; `operation_id` correlation.
