### PR TITLE
chore: harden Railway deployment reproducibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,18 +87,33 @@ One project (`memoryops-ai`), four services: `memoryops-web`, `memoryops-api`,
 `memoryops-worker`, Railway Postgres (+pgvector). Redis was removed — it was
 declared and health-gated but no runtime code ever read `REDIS_URL`.
 
-- Config-as-code lives in `railway/{api,web,worker}.railway.json`; point each
-  Railway service at its file. Builder is `DOCKERFILE`.
+- Config-as-code lives in `railway/{api,web,worker,playground}.railway.json` —
+  **canonical**; point each Railway service at its file. Builder is `DOCKERFILE`.
+  The Dockerfile `CMD` owns the start command; configs must **not** set
+  `startCommand`, and must never contain a literal `$PORT` (it does not expand in
+  exec form — this broke the v2.4 API deploy). Enforced by the
+  `railway-deployment-config` trust guard.
+  ⚠️ `services/api/railway.toml` still exists as a **temporary** production
+  compatibility file; see the Phase B checkpoint in `docs/deployment/railway.md`.
 - Per-service Root Directory: api → `services/api`, web → `apps/web`, worker →
-  repo root. Full settings + deploy order: `docs/deployment/railway.md`.
+  repo root. Root Directory and Config File are dashboard-only settings.
+  Web health check is `/architecture`, **not** `/` (authenticated `/` 307s to
+  `/signin`). Full settings + deploy order: `docs/deployment/railway.md`.
 - Env var contract per service: `docs/deployment/railway-env.md`. The system runs
   with **no provider keys** (heuristic LLM + stub embeddings); set
   `MEMORYOPS_PROFILE=production`, `MEMORYOPS_STORAGE=postgres`, `DATABASE_URL`,
-  `MEMORYOPS_AUTH_MODE`, `MEMORYOPS_CORS_ALLOW_ORIGINS` for production, and
+  `MEMORYOPS_AUTH_MODE`, `MEMORYOPS_AUTH_JWT_KEY` (**same value on api and web**),
+  `MEMORYOPS_AUTH_REQUIRE_ROLE_CLAIM=true`, `MEMORYOPS_PROTECT_METRICS_ENDPOINT=true`,
+  `MEMORYOPS_CORS_ALLOW_ORIGINS`, `OPERATIONAL_DATABASE_URL` for production, plus
+  `MEMORYOPS_WORKER_SCOPES` for the worker and `AUTH_SECRET` / `AUTH_TRUST_HOST` /
   build-time `NEXT_PUBLIC_API_URL` for web. The production profile is fail-closed:
   missing/unsafe values stop startup rather than degrading silently.
-- After deploy, run `scripts/railway_smoke_test.py` (see
-  `docs/deployment/railway-smoke-test.md`).
+- **Release gate after deploy: `scripts/release_smoke_v24.py`** (`FAILED 0`,
+  `SKIPPED 0`, `RESULT: PASS`). `scripts/railway_smoke_test.py` is a quick
+  liveness-only smoke — it predates authenticated route enforcement and is **not**
+  proof of authorization correctness. See `docs/deployment/railway-smoke-test.md`.
+- Release evidence/tagging rules — including why post-deployment results go in the
+  GitHub Release body rather than the tagged tree: `docs/releases/RELEASE-PROCESS.md`.
 - When changing deployment, update `railway/`, the three `docs/deployment/*`
   files, and `docs/phase-gates/phase-13-infrastructure.md` together.
 

--- a/docs/background-lifecycle-workers.md
+++ b/docs/background-lifecycle-workers.md
@@ -119,8 +119,8 @@ scheduling, locking, retries, and durable history around it. See
 
 ## How this fits the Railway worker service
 
-Deployment is Railway-only (one project, five services: web/api/worker + Postgres
-+ Redis — see [deployment/railway.md](deployment/railway.md)). The `worker`
+Deployment is Railway-only (one project, four services: web/api/worker + Postgres —
+Redis was removed, see [deployment/railway.md](deployment/railway.md)). The `worker`
 service runs the v0.8 scheduler (`services/worker/main.py`), which calls the
 orchestrator once per interval for each configured `"tenant:user"` scope.
 **Scope enumeration stays explicit** (`worker_scopes`), and workers are

--- a/docs/deployment/railway-env.md
+++ b/docs/deployment/railway-env.md
@@ -20,9 +20,12 @@ plugin — use Railway's **variable references** rather than copying values.
 | `DATABASE_URL` | ✅ (postgres) | local dsn | `postgresql+psycopg://…`. Reference the Postgres plugin. |
 | `MEMORYOPS_PROFILE` | ✅ (prod) | `dev` | Set to `production`; fail-closed startup checks. |
 | `MEMORYOPS_AUTH_MODE` | ✅ (prod) | `none` | `jwt` or `trusted_header`; `none` is rejected in production. |
-| `MEMORYOPS_CORS_ALLOW_ORIGINS` | ✅ (prod) | `*` | Explicit origin list; `*` is rejected in production. |
+| `MEMORYOPS_AUTH_JWT_KEY` | ✅ (prod, **secret**) | *(empty)* | HS\* signing key (or RS\* public key). **Must be byte-identical to the web service's value** — the web BFF signs tokens the API verifies. Not validated at startup: with `auth_mode=jwt` and no key the API boots and then rejects every credential with 401. |
+| `MEMORYOPS_AUTH_REQUIRE_ROLE_CLAIM` | ✅ (prod) | `false` | Set `true`. A credential with no roles claim then gets **no** permissions instead of falling back to `memory_user`. The production profile **refuses to start** without it. |
+| `MEMORYOPS_PROTECT_METRICS_ENDPOINT` | ✅ (prod) | `false` | Set `true` on any deployment where `/metrics` is reachable from the public internet; requires `ops:metrics`. The default is safe only behind private networking — a Railway public hostname is not that. |
+| `MEMORYOPS_CORS_ALLOW_ORIGINS` | ✅ (prod) | `*` | Explicit origin list; `*` is rejected in production. Note the name: `MEMORYOPS_CORS_ORIGINS` is **not** read. |
 | `MEMORYOPS_PUBLIC_EVALS` | ✅ (prod) | `false` | Must stay `false` (denial-of-wallet vector). |
-| `OPERATIONAL_DATABASE_URL` | — | *(unset)* | Restricted monitoring role; enables `/healthz/workers`. Fails closed when unset. |
+| `OPERATIONAL_DATABASE_URL` | ✅ (prod, **secret**) | *(unset)* | Restricted monitoring role — see [Operational monitoring role](#operational-monitoring-role). Required for MemoryOps' production profile: without it `/healthz/workers` reports `{"healthy": false}` and the release smoke gate fails C1. |
 | `LLM_PROVIDER` | — | `heuristic` | `heuristic` needs no keys (v0.3.x). `openai`/`anthropic`/`gemini` land in v0.4. |
 | `MEMORYOPS_EMBEDDING_PROVIDER` | — | `stub` | `stub` is deterministic/offline; `openai` needs a key. |
 | `EMBEDDING_DIM` | — | `1536` | Must match the pgvector column dimension. |
@@ -58,11 +61,61 @@ plugin — use Railway's **variable references** rather than copying values.
 
 ## `memoryops-web`
 
-| Variable | Required | Notes |
-|----------|----------|-------|
-| `PORT` | auto | Injected by Railway. |
-| `NEXT_PUBLIC_API_URL` | ✅ | Public URL of `memoryops-api`. **Build-time** — inlined by Next.js; a change requires a rebuild. |
-| `NODE_ENV` | — | `production` (set in the image). |
+The authenticated control plane. The browser never holds an API credential: the
+Next.js BFF resolves identity server-side and mints a short-lived HS256 token per
+request (`apps/web/lib/memoryopsToken.ts`).
+
+**Classification:** 🔒 secret · ✅ required in production · ○ optional · 🌐 public/build-time
+
+| Variable | Class | Default | Notes |
+|----------|-------|---------|-------|
+| `PORT` | auto | — | Injected by Railway. |
+| `MEMORYOPS_WEB_MODE` | ✅ | `demo` | Must be `authenticated` in production. Deliberately **not** `NEXT_PUBLIC_*` — authorization must never be decided by a value the browser can read. Unset throws at request time in production. |
+| `AUTH_SECRET` | 🔒 ✅ | — | Auth.js (NextAuth v5) session-signing secret, read implicitly by the framework. **Not the same value as `MEMORYOPS_AUTH_JWT_KEY`** — generate it separately. |
+| `AUTH_TRUST_HOST` | ✅ | — | Set `true`. Railway terminates TLS at a reverse proxy, and Auth.js will not trust the forwarded host without it, so callback URLs break. |
+| `MEMORYOPS_WEB_OPERATORS` | 🔒 ✅ | *(empty)* | Sign-in records for the built-in Credentials provider — see [format](#memoryops_web_operators-format). Replace this provider with a real IdP for anything beyond a controlled deployment. |
+| `MEMORYOPS_AUTH_MODE` | ✅ | `none` | Mirror the API: `jwt`. Demo web mode combined with an authenticating API mode fails closed rather than minting a shared admin credential. |
+| `MEMORYOPS_AUTH_JWT_KEY` | 🔒 ✅ | *(empty)* | **Byte-identical to the API's value.** The BFF signs with it; the API verifies with it. If they differ the API rejects every BFF call while both services look healthy. |
+| `MEMORYOPS_API_URL` | ✅ | `http://localhost:8000` | Server-only upstream API base URL. Preferred over `NEXT_PUBLIC_API_URL` for the BFF hop so no API address needs to be public. |
+| `NEXT_PUBLIC_API_URL` | 🌐 ✅ | — | Public URL of `memoryops-api`. **Build-time** — inlined by Next.js; a change requires a rebuild, not a restart. |
+| `MEMORYOPS_API_TOKEN_TTL_SECONDS` | ○ | `120` | Lifetime of the minted API token. Short by design: it only has to survive one server-to-server hop. |
+| `MEMORYOPS_AUTH_JWT_AUDIENCE` / `..._ISSUER` | ○ | *(empty)* | Set only if the API also sets them; the values must match. |
+| `NODE_ENV` | — | `production` | Set in the image. |
+
+### Sharing the JWT key between API and web
+
+Define it **once** as a Railway project-level shared variable and reference it from
+both services, so the two cannot drift:
+
+```
+MEMORYOPS_AUTH_JWT_KEY=${{ shared.MEMORYOPS_AUTH_JWT_KEY }}
+```
+
+### `MEMORYOPS_WEB_OPERATORS` format
+
+Comma-separated `tenant:user:role:password` records, parsed in `apps/web/auth.ts`:
+
+```
+MEMORYOPS_WEB_OPERATORS=<tenant>:<user>:<web-role>:<password>,<tenant>:<user>:<web-role>:<password>
+```
+
+`<web-role>` is a **web persona**, not an API role. The five valid personas and the
+API role each maps to (`contracts/auth-role-map.json`):
+
+| Web persona | API role |
+|-------------|----------|
+| `viewer` | `memory_viewer` |
+| `developer` | `memory_user` |
+| `auditor` | `auditor` |
+| `memory_admin` | `memory_admin` |
+| `owner` | `tenant_admin` |
+
+`service_worker` and `platform_operator` are in `never_web_assignable` — no UI
+session may become deployment authority.
+
+> Passwords here are credentials. Keep them in Railway's variable store (sealed if
+> you can, having saved the value elsewhere first — a sealed variable cannot be read
+> back), never in the repository, a ticket, or a chat.
 
 ## `memoryops-worker`
 
@@ -72,6 +125,60 @@ plugin — use Railway's **variable references** rather than copying values.
 | `DATABASE_URL` | ✅ (postgres) | local dsn | Reference the Postgres plugin. |
 | `MEMORYOPS_WORKER_SCOPES` | ✅ | `tenant_demo:user_demo` | `"tenant:user,…"` scopes to process. |
 | `WORKER_INTERVAL_SECONDS` | — | `60` | Scheduler tick interval. |
+
+## Operational monitoring role
+
+Global worker health has to be observable **without** granting access to tenant
+memory. The request-scoped connection is RLS-enforced and deliberately cannot see
+across tenants, so aggregating worker runs through it is impossible by design.
+`OPERATIONAL_DATABASE_URL` is a second, separately authorized connection used only
+for operator views.
+
+It is **fail-closed**: unset, MemoryOps does not silently fall back to the
+application connection. It reports that operational access is unavailable.
+
+### Expected behaviour when it is unset
+
+| Endpoint | Response |
+|----------|----------|
+| `GET /healthz/workers` (public) | `{"healthy": false}` — liveness only, never scope keys |
+| `GET /api/admin/workers/health` (`worker:read`) | `{"healthy": null, "detail": "operational access not configured", "hint": "set OPERATIONAL_DATABASE_URL to a monitoring role"}` |
+
+`healthy: false` here means *"worker health is not observable"*, which is not the
+same as *"the worker is broken"* — but the release gate cannot tell those apart, and
+neither can an operator. `scripts/release_smoke_v24.py` requires `healthy` to be
+exactly `true`, so a deployment without this role fails C1.
+
+### Creating `memoryops_monitor`
+
+Least privilege: it may read worker run history and nothing else. `BYPASSRLS` is
+required because the whole point is a cross-tenant aggregate; the `SELECT` grants are
+what keep that from becoming cross-tenant *memory* access.
+
+```sql
+-- Replace the placeholder before running. Do not commit the real value.
+CREATE ROLE memoryops_monitor LOGIN PASSWORD '<REPLACE_WITH_GENERATED_PASSWORD>' BYPASSRLS;
+
+GRANT CONNECT ON DATABASE memoryops TO memoryops_monitor;
+GRANT USAGE   ON SCHEMA public      TO memoryops_monitor;
+
+-- Worker run history only.
+GRANT SELECT ON worker_runs TO memoryops_monitor;
+
+-- Explicitly NOT granted: memory_records, audit_events, or any tenant-content table.
+-- Verify the boundary holds (both should error):
+--   SET ROLE memoryops_monitor; SELECT count(*) FROM memory_records;
+```
+
+Then point the variable at that role — **not** at the application role:
+
+```
+OPERATIONAL_DATABASE_URL=postgresql+psycopg://memoryops_monitor:<password>@${{Postgres.PGHOST}}:${{Postgres.PGPORT}}/${{Postgres.PGDATABASE}}
+```
+
+> Do not widen these grants to make a dashboard easier. A monitoring role that can
+> read `memory_records` is a cross-tenant read path that bypasses RLS by design, which
+> is precisely what the split connection exists to prevent.
 
 ## Railway Postgres plugin
 
@@ -102,20 +209,43 @@ CORS, and evals variables that the profile itself requires.
 MEMORYOPS_PROFILE=production
 MEMORYOPS_STORAGE=postgres
 MEMORYOPS_AUTH_MODE=jwt                       # or trusted_header
+MEMORYOPS_AUTH_JWT_KEY=${{ shared.MEMORYOPS_AUTH_JWT_KEY }}
+MEMORYOPS_AUTH_REQUIRE_ROLE_CLAIM=true        # profile refuses to start without it
+MEMORYOPS_PROTECT_METRICS_ENDPOINT=true       # /metrics is public on Railway otherwise
 MEMORYOPS_CORS_ALLOW_ORIGINS=https://memoryops-web.up.railway.app
 MEMORYOPS_PUBLIC_EVALS=false
 DATABASE_URL=<reference Postgres plugin, +psycopg prefix>
-OPERATIONAL_DATABASE_URL=<restricted monitoring role>
+OPERATIONAL_DATABASE_URL=<memoryops_monitor role, +psycopg prefix>
 
 # worker
 MEMORYOPS_PROFILE=production
 MEMORYOPS_STORAGE=postgres
 DATABASE_URL=<reference Postgres plugin, +psycopg prefix>
-MEMORYOPS_WORKER_SCOPES=<tenant:user,…>
+MEMORYOPS_WORKER_SCOPES=<tenant:user,…>       # without it the worker idles, healthily
 
 # web
-NEXT_PUBLIC_API_URL=https://memoryops-api.up.railway.app
+MEMORYOPS_WEB_MODE=authenticated
+AUTH_SECRET=<generated; NOT the JWT key>
+AUTH_TRUST_HOST=true                          # Railway terminates TLS at a proxy
+MEMORYOPS_WEB_OPERATORS=<tenant:user:role:password,…>
+MEMORYOPS_AUTH_MODE=jwt
+MEMORYOPS_AUTH_JWT_KEY=${{ shared.MEMORYOPS_AUTH_JWT_KEY }}   # same value as the API
+MEMORYOPS_API_URL=https://memoryops-api.up.railway.app
+NEXT_PUBLIC_API_URL=https://memoryops-api.up.railway.app      # build-time
 ```
+
+The four most common ways this configuration fails, none of which announce
+themselves:
+
+1. **JWT key differs between API and web** — the API rejects every BFF call while
+   both services report healthy.
+2. **`MEMORYOPS_AUTH_JWT_KEY` unset on the API** — boots fine, then 401s everything;
+   nothing validates it at startup.
+3. **`MEMORYOPS_WORKER_SCOPES` unset** — the worker starts, reports healthy, and
+   processes nothing.
+4. **`MEMORYOPS_CORS_ORIGINS` used instead of `MEMORYOPS_CORS_ALLOW_ORIGINS`** — the
+   real setting stays `*`, and the production profile refuses to boot (this one at
+   least fails loudly).
 
 Everything else has a safe default, and the system stays fully functional with
 **no provider API keys** (heuristic LLM + stub embeddings, invariant #4).

--- a/docs/deployment/railway-smoke-test.md
+++ b/docs/deployment/railway-smoke-test.md
@@ -1,7 +1,46 @@
-# Railway smoke test
+# Railway smoke tests
 
-Post-deploy verification for a live MemoryOps AI stack on Railway. Run it after
-all five services are up (see [railway.md](railway.md)).
+There are **two** smoke tests, and they answer different questions. Using the wrong
+one as release evidence is the mistake this page exists to prevent.
+
+| Script | Question it answers | Release gate? |
+|--------|---------------------|---------------|
+| [`scripts/railway_smoke_test.py`](../../scripts/railway_smoke_test.py) | Is the stack up and serving? | **No** |
+| [`scripts/release_smoke_v24.py`](../../scripts/release_smoke_v24.py) | Does the deployed authorization boundary match the release claim? | **Yes** |
+
+## Release gate — `release_smoke_v24.py`
+
+The production release gate since v2.4. It drives seven principals, the four JWT
+role-claim states, cross-tenant isolation, a full write→delete→evidence lifecycle,
+and the web/BFF boundary against a live deployment. See
+[`docs/releases/RELEASE-PROCESS.md`](../releases/RELEASE-PROCESS.md).
+
+```bash
+python scripts/release_smoke_v24.py \
+  --api-url https://<api>.up.railway.app \
+  --web-url https://<web>.up.railway.app \
+  --jwt-key "$MEMORYOPS_AUTH_JWT_KEY" \
+  --production
+```
+
+Gate: `FAILED 0`, `SKIPPED 0`, `RESULT: PASS`. Exit codes are `0` pass, `1` fail,
+`2` incomplete (something was skipped), `3` environment fault (e.g. no local CA
+bundle — see below).
+
+## Quick deployment / liveness smoke — `railway_smoke_test.py`
+
+**This is not the release gate.** It predates authenticated route enforcement: it
+makes unauthenticated `POST /api/chat` calls and cannot exercise the authorization
+boundary at all. Treat a green run as *"the stack is up"* and nothing more.
+
+In particular, **do not cite it as evidence of authorization correctness.** Against
+a production-profile deployment (`MEMORYOPS_AUTH_MODE=jwt`) its write/read checks
+will fail on 401 — which is the API behaving correctly, not a defect.
+
+It is kept because a dependency-free liveness check that runs from any shell is
+genuinely useful during a deploy, before there is any reason to reach for the gate.
+
+Run it after the four services are up (see [railway.md](railway.md)).
 
 ## Automated
 

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -34,34 +34,74 @@ See [railway-env.md](railway-env.md) for the full variable matrix.
 
 ## Config-as-code
 
-Each service ships a checked-in config file under [`railway/`](../../railway/):
+`railway/*.railway.json` is the **canonical** configuration source:
 
 - `railway/api.railway.json`
 - `railway/web.railway.json`
 - `railway/worker.railway.json`
+- `railway/playground.railway.json`
 
 Point each Railway service at its config file via **Service → Settings → Config
-File** (config-as-code). Builder is `DOCKERFILE` for all three.
+File**. Builder is `DOCKERFILE` for all of them.
+
+Explicit per-service config paths are used rather than a `railway.toml` at each
+service root because Railway auto-detects `railway.toml` relative to a service's
+**Root Directory**, and both the worker and the playground are rooted at the
+repository root — they would collide on a single top-level file.
+
+### The Dockerfile owns the start command
+
+None of `api`, `web`, or `worker` sets `deploy.startCommand`. Their Dockerfile `CMD`
+is authoritative. Declaring the launch in two places is how the two drift, and it is
+what broke the v2.4 deployment (below). `scripts/repo_trust_guards.py` enforces this.
+
+### ⚠️ Transitional: the API has two config sources
+
+`services/api/railway.toml` **still exists** and is what the Railway API service
+currently reads. It is a temporary production-compatibility file, not a second
+opinion.
+
+**Migration checkpoint — Phase B, not yet done:**
+
+1. Point the API service's **Config File** at `railway/api.railway.json`
+2. Redeploy the API; confirm `/healthz` and `/readyz`
+3. Run `scripts/release_smoke_v24.py` and require `FAILED 0 / SKIPPED 0`
+4. **Then** delete `services/api/railway.toml`
+5. Remove `TRANSITIONAL_DUPLICATE_CONFIGS` from `scripts/repo_trust_guards.py`, which
+   tightens the guard to "exactly one config source per service" automatically
+
+Until step 5, the guard permits this one duplicate **by name**. Any other service
+gaining a second config source is a finding today.
 
 ## Per-service settings
 
 Set these in **Service → Settings** for each service. `dockerfilePath` in the
 config files is resolved relative to the service **Root Directory**.
 
+> **Root Directory** and **Config File** are Railway *service-level* settings. They
+> cannot be expressed in config-as-code — a config file cannot say where it lives.
+> They must be set deliberately in the dashboard, and they are the two settings most
+> likely to be wrong on a rebuilt project. Record them here whenever they change.
+
 ### 1. `memoryops-api`
 - **Root Directory:** `services/api`
-- **Config File:** `railway/api.railway.json`
+- **Config File:** `railway/api.railway.json` *(currently `services/api/railway.toml`; see the transitional note above)*
 - **Dockerfile path:** `Dockerfile` (relative to root)
-- **Start command:** `uvicorn app.main:app --host 0.0.0.0 --port $PORT` (from config)
+- **Start command:** owned by the **Dockerfile `CMD`** —
+  `uvicorn app.main:app --host 0.0.0.0 --port 8000`. Not set in config.
 - **Health check path:** `/healthz`
-- Bind to `$PORT` — Railway injects it. Do **not** hardcode `8000` in production.
+- **Port 8000 is deliberate.** The image declares `EXPOSE 8000` and binds it, and
+  Railway routes to the detected listening port. Do **not** "fix" this by putting
+  `$PORT` in a config `startCommand` — see the rule below.
 
 ### 2. `memoryops-web`
 - **Root Directory:** `apps/web`
 - **Config File:** `railway/web.railway.json`
 - **Dockerfile path:** `Dockerfile` (relative to root)
-- **Start command:** `npm run start -- --port $PORT --hostname 0.0.0.0` (from config)
-- **Health check path:** `/`
+- **Start command:** owned by the **Dockerfile `CMD`** — `npm run start`. Not set in config.
+- **Health check path:** `/architecture`
+- **Not `/`.** In `authenticated` mode `/` answers **307 → `/signin`**, so a health
+  check pointed at it can never succeed. `/architecture` renders without a session.
 - `NEXT_PUBLIC_API_URL` must be set at **build time** to the public `memoryops-api`
   URL (Next.js inlines `NEXT_PUBLIC_*` at build).
 
@@ -70,14 +110,21 @@ config files is resolved relative to the service **Root Directory**.
   into the build, so its build context must be the repository root.
 - **Config File:** `railway/worker.railway.json`
 - **Dockerfile path:** `services/worker/Dockerfile` (relative to repo root)
-- **Start command:** `python main.py` (from config)
-- **No HTTP health check on the worker itself** — it is an interval scheduler, not
-  a web server. As of v0.8 it runs the orchestrator + scheduler over the real
-  lifecycle workers (leased, retried, dead-lettered); set
-  `MEMORYOPS_WORKER_SCOPES="tenant:user,…"` and optionally
-  `MEMORYOPS_WORKER_INTERVAL_SECONDS`. **Worker health is observable via the API**
-  at `GET /healthz/workers` (run history, dead-letter / failure counts, last run
-  per scope). See [worker-runtime.md](../worker-runtime.md).
+- **Start command:** owned by the **Dockerfile `CMD`** — `memoryops-worker` (the
+  packaged console script). Not set in config.
+- **No HTTP health check, deliberately.** The worker is an interval scheduler, not a
+  web server — it binds no port, so there is nothing for Railway to probe. Adding a
+  health check would require inventing an HTTP surface purely to satisfy the
+  platform, and a fake endpoint that returns 200 while the scheduler is wedged is
+  worse than no endpoint. Railway restarts on process exit
+  (`restartPolicyType: ON_FAILURE`); liveness is process liveness.
+- Set `MEMORYOPS_WORKER_SCOPES="tenant:user,…"` and optionally
+  `MEMORYOPS_WORKER_INTERVAL_SECONDS`. **Without scopes the worker starts, reports
+  healthy, and processes nothing.**
+- **Worker health is observable via the API** at `GET /healthz/workers` — which
+  requires `OPERATIONAL_DATABASE_URL` on the *API* service, not on the worker. See
+  [railway-env.md](railway-env.md#operational-monitoring-role) and
+  [worker-runtime.md](../worker-runtime.md).
 
 ## Deployment order
 
@@ -160,12 +207,16 @@ host. Its Dockerfile copies `services/api`, so the Docker build context must be 
 
 ## Health checks
 
-- `memoryops-api`: Railway hits `healthcheckPath=/healthz` on the assigned `$PORT`.
-  `/readyz` additionally touches the repository so a misconfigured DB surfaces as
-  not-ready (useful for manual verification).
-- `memoryops-web`: `/` returns 200 once Next.js is serving.
+- `memoryops-api`: Railway hits `healthcheckPath=/healthz` on the detected listening
+  port. `/readyz` additionally touches the repository so a misconfigured DB surfaces
+  as not-ready (useful for manual verification).
+- `memoryops-web`: `healthcheckPath=/architecture`. **Not `/`** — in `authenticated`
+  mode the root answers 307 to `/signin`, so a check pointed there never passes. It
+  works in demo mode, which is exactly why the mistake survives review.
 - `memoryops-worker`: no HTTP probe; Railway restarts on process exit
-  (`restartPolicyType: ON_FAILURE`).
+  (`restartPolicyType: ON_FAILURE`). Health is read from the API's
+  `GET /healthz/workers`, which needs `OPERATIONAL_DATABASE_URL` and must report
+  `{"healthy": true}` — the release smoke gate requires exactly that.
 
 ## Rollback
 
@@ -179,9 +230,31 @@ host. Its Dockerfile copies `services/api`, so the Docker build context must be 
 
 ## Known limitations
 
-- The API `Dockerfile` `HEALTHCHECK` hardcodes port `8000`; on Railway the
-  platform health check uses `healthcheckPath` against `$PORT`, so the in-image
-  `HEALTHCHECK` is cosmetic in production.
+- The API binds a fixed port `8000` (Dockerfile `CMD` + `EXPOSE 8000`) and relies on
+  Railway detecting it, rather than binding the injected `$PORT`. This is a
+  deliberate, working arrangement, not an oversight. Making the API bind `$PORT`
+  would require a Dockerfile change (`sh -c` so the variable expands) plus a deploy
+  window, and is out of scope for v2.4.1. The in-image `HEALTHCHECK` is cosmetic in
+  production; Railway uses `healthcheckPath`.
+
+### The `$PORT` rule
+
+**Never place an unexpanded literal `$PORT` inside a Railway config-as-code
+`startCommand` for a Dockerfile service.**
+
+A config `startCommand` on a Dockerfile service runs in **exec form, without shell
+expansion** — the process receives the four characters `$PORT`, not a port number.
+This broke the v2.4 API deployment. The playground had already hit and documented the
+same failure; that precedent did not prevent the second occurrence, so it is now a
+guard (`railway-deployment-config` in `scripts/repo_trust_guards.py`) rather than a
+paragraph.
+
+If a service genuinely needs dynamic port binding, expand it in the **Dockerfile
+`CMD` through a shell**, the way the playground does:
+
+```dockerfile
+CMD ["sh", "-c", "streamlit run streamlit_app.py --server.port ${PORT:-8501} ..."]
+```
 - `NEXT_PUBLIC_API_URL` is build-time; changing the API domain requires a **web
   rebuild**, not just a restart.
 - The worker is an interval scheduler (no Celery/Temporal yet); it is idempotent

--- a/docs/phase-gates/phase-13-infrastructure.md
+++ b/docs/phase-gates/phase-13-infrastructure.md
@@ -4,33 +4,76 @@
 
 ## MemoryOps mapping
 A single **Railway** project hosts the whole stack — no Vercel, no split host.
-Five services in one project: `memoryops-web` (Next.js), `memoryops-api`
-(FastAPI), `memoryops-worker` (background loops), Railway Postgres (+pgvector),
-Railway Redis. Build is Dockerfile-per-service; deploy/build settings are
+**Four** services in one project: `memoryops-web` (Next.js), `memoryops-api`
+(FastAPI), `memoryops-worker` (background loops), and Railway Postgres (+pgvector).
+Redis was removed: it was declared, health-gated and paid for while no runtime code
+ever read `REDIS_URL`. Build is Dockerfile-per-service; deploy/build settings are
 config-as-code under `railway/`.
 
 ## Gate (must be true to pass)
 - Deployment target is **Railway only**; Vercel is not a recommended path.
-- Each service has a checked-in config (`railway/{api,web,worker}.railway.json`).
-- API binds `$PORT` and exposes `/healthz` (liveness) + `/readyz` (readiness).
-- Env contract is documented per service, with safe no-key defaults.
-- A repeatable post-deploy smoke test exists and is runnable from any shell.
+- Each service has a checked-in **canonical** config
+  (`railway/{api,web,worker,playground}.railway.json`), and **exactly one** config
+  source per service.
+- The **Dockerfile `CMD` owns the start command**. Configs do not set
+  `startCommand`, and no config contains a literal `$PORT` — it does not expand in
+  exec form.
+- API exposes `/healthz` (liveness) + `/readyz` (readiness). It binds a fixed port
+  `8000` with `EXPOSE 8000`; Railway routes to the detected port.
+- Web health check is `/architecture`. **Not `/`** — in `authenticated` mode the root
+  answers 307 to `/signin`, so a check there can never pass.
+- Worker has **no** HTTP health check (it binds no port). Its health is read from the
+  API's `GET /healthz/workers`, which must report `{"healthy": true}` — requiring
+  `OPERATIONAL_DATABASE_URL` and the restricted `memoryops_monitor` role.
+- Env contract is documented per service, with safe no-key defaults, and covers the
+  web authentication variables (`AUTH_SECRET`, `AUTH_TRUST_HOST`,
+  `MEMORYOPS_WEB_MODE`, `MEMORYOPS_WEB_OPERATORS`).
+- A repeatable post-deploy **release gate** exists and is runnable from any shell:
+  `scripts/release_smoke_v24.py` (`FAILED 0 / SKIPPED 0 / RESULT: PASS`).
 - Migrations are forward-only and additive (older API runs on newer schema).
 
 ## Evidence
-- [docs/deployment/railway.md](../deployment/railway.md) — topology, order, rollback.
-- [docs/deployment/railway-env.md](../deployment/railway-env.md) — env matrix.
-- [docs/deployment/railway-smoke-test.md](../deployment/railway-smoke-test.md).
+- [docs/deployment/railway.md](../deployment/railway.md) — topology, per-service
+  settings, deploy order, the `$PORT` rule, rollback.
+- [docs/deployment/railway-env.md](../deployment/railway-env.md) — env matrix incl.
+  web auth variables and the `memoryops_monitor` operational role.
+- [docs/deployment/railway-smoke-test.md](../deployment/railway-smoke-test.md) —
+  which smoke test is the release gate and which is liveness-only.
+- [docs/releases/RELEASE-PROCESS.md](../releases/RELEASE-PROCESS.md) — release
+  evidence model, SHA identity, tagging rules.
 - [railway/api.railway.json](../../railway/api.railway.json),
   [web.railway.json](../../railway/web.railway.json),
-  [worker.railway.json](../../railway/worker.railway.json).
-- [scripts/railway_smoke_test.py](../../scripts/railway_smoke_test.py).
+  [worker.railway.json](../../railway/worker.railway.json),
+  [playground.railway.json](../../railway/playground.railway.json).
+- [scripts/release_smoke_v24.py](../../scripts/release_smoke_v24.py) — release gate.
+- [scripts/railway_smoke_test.py](../../scripts/railway_smoke_test.py) — quick
+  liveness smoke; **not** proof of authorization correctness.
+- [scripts/repo_trust_guards.py](../../scripts/repo_trust_guards.py) —
+  `railway-deployment-config` guard enforces the config rules above.
 - [services/api/app/routes/health.py](../../services/api/app/routes/health.py)
-  (`/healthz`, `/readyz`).
+  (`/healthz`, `/readyz`, `/healthz/workers`).
+
+## Config-source migration status (v2.4.1)
+`railway/*.railway.json` is canonical. `services/api/railway.toml` **still exists**
+as a temporary production-compatibility file, because the Railway API service
+currently reads it. The trust guard permits this one duplicate by name
+(`TRANSITIONAL_DUPLICATE_CONFIGS`); any other service gaining a second source is a
+finding today.
+
+**Phase B — not yet done:** point the API service's Config File at
+`railway/api.railway.json` → redeploy → run the release gate → delete the TOML →
+remove the guard exception, which tightens enforcement to exactly one source per
+service. Checkpoint lives in
+[docs/deployment/railway.md](../deployment/railway.md#config-as-code).
 
 ## Gaps to close (→ later)
+- Complete the Phase B config-source switchover (above).
 - CI auto-deploy hook on tag (currently manual redeploy on Railway).
+- API binds a fixed `8000` rather than the injected `$PORT`; making it dynamic needs
+  a Dockerfile `sh -c` change plus a deploy window.
+- `MEMORYOPS_AUTH_JWT_KEY` is not validated at startup — with `auth_mode=jwt` and no
+  key the API boots and then rejects every credential.
 - Multi-replica API + worker on Celery/Temporal with retries/DLQ.
 - Build-time `NEXT_PUBLIC_API_URL` requires a web rebuild on API domain change.
 
-## Status: ✅ Implemented (Railway-only; CI auto-deploy is roadmap)
+## Status: ✅ Implemented (Railway-only; config-source consolidation in Phase B, CI auto-deploy is roadmap)

--- a/docs/releases/RELEASE-PROCESS.md
+++ b/docs/releases/RELEASE-PROCESS.md
@@ -1,0 +1,189 @@
+# Release process — evidence, SHAs, and tagging
+
+How a MemoryOps AI release records what it proved, and why the evidence is split
+across two artifacts instead of one file.
+
+Written after v2.4, which had to re-cut its release candidate twice: once because the
+candidate turned out not to be deployable, and once because recording the deployment
+evidence changed the SHA the evidence described.
+
+---
+
+## 1. The two artifacts
+
+Release evidence lives in two places, on purpose.
+
+### In-tree manifest — `docs/releases/vX.Y-release-truth.md`
+
+Committed, tagged, and permanent. Contains everything knowable **before** the tag:
+
+- the release candidate SHA and how it was chosen
+- code evidence: test totals, lint, evals, benchmark, guards, secret scans — each with
+  the command that produces it
+- deployment evidence from the **validated** candidate deployment
+- what the release explicitly does **not** claim
+
+### GitHub Release body
+
+Written after the tag exists. Contains everything only knowable **after** it:
+
+- the smoke result executed against the exact tagged, deployed commit
+- final confirmation that each service reports the tagged SHA
+- links to the manifest at its immutable blob URL
+
+---
+
+## 2. Why they cannot be one artifact
+
+A release manifest cannot contain:
+
+- the SHA of the commit that introduces it, nor
+- the result of a run that postdates it.
+
+Both are self-reference. Editing the manifest to record a smoke result changes the
+commit the result describes, so the new commit needs a new run, which needs another
+edit. That regress is not a process failure to be tidied up — it is a property of
+putting a document inside the thing it describes.
+
+The escape is to stop trying. The tagged tree carries evidence that is true at tag
+time; the Release body carries evidence generated afterwards. Neither lies, and
+neither needs rewriting.
+
+> **Do not** edit the manifest after the final verification run to "finish" it.
+> That creates a new SHA and restarts the problem. This is exactly what happened in
+> v2.4, and it cost a full re-verification cycle.
+
+---
+
+## 3. Release sequence
+
+```
+candidate SHA
+  → CI green at that SHA
+  → clean-worktree verification at that SHA
+  → deploy that SHA
+  → production smoke against that deployment
+  → (if the manifest must change) one evidence commit
+  → re-verify + redeploy the final SHA
+  → STOP editing the tree
+  → tag
+  → record the tagged-deployment smoke in the GitHub Release body
+```
+
+The step most often skipped is **deploy before tag**. A candidate that passes every
+code gate can still be undeployable — v2.4's first candidate was, twice over:
+
+- a config-as-code `startCommand` containing `$PORT`, which does not expand in exec
+  form, so the process received the literal string;
+- a web layout that resolved its runtime mode at build time rather than per request.
+
+Neither was expressible as a unit test. Only a deployment found them.
+
+---
+
+## 4. Preserving SHA identity
+
+When a release claims
+
+```
+CI SHA = verified SHA = deployed SHA = tag SHA
+```
+
+every step between candidate and tag must preserve the commit object.
+
+**Required once the candidate SHA is established:**
+
+- **No squash merge** — produces a new commit, so the tag would name something CI
+  never tested.
+- **No rebase merge** — rewrites the commit.
+- **Fast-forward only.** `git push origin <branch>:main` when the branch's parent is
+  the current `main`. Confirm first:
+
+```bash
+git rev-parse HEAD^                              # must equal current origin/main
+git merge-base --is-ancestor origin/main HEAD    # must succeed
+```
+
+- Check for branch protection or rulesets that would force a merge commit **before**
+  committing to this approach, not after.
+
+For ordinary work none of this applies — squash away. It matters only between
+establishing a candidate and tagging it.
+
+---
+
+## 5. Docs-only successors
+
+Sometimes the manifest must change after the candidate is validated — correcting a
+superseded RC reference, say. That successor commit is legitimate provided it changes
+**only** documentation, and provided the claim is stated precisely:
+
+> This commit changes no runtime source or configuration input consumed by the API,
+> web, or worker Dockerfiles. The API builds from `services/api`, the web from
+> `apps/web`, and the worker copies only `services/api` and `services/worker` — no
+> build context includes `docs/`. The runtime source is therefore equivalent to
+> `<candidate>`. Normal build and deployment risk still applies; this is a statement
+> about build inputs, not a guarantee of identical image digests.
+
+Verifiable by anyone:
+
+```bash
+git diff <candidate> <successor> -- ':(exclude)docs'   # must be empty
+```
+
+Say **equivalent runtime source**, not *"byte-identical images"* or *"risk-free"*.
+The build still runs, and a rebuild can still fail. Redeploy and re-verify the
+successor rather than assuming it inherits the candidate's evidence.
+
+---
+
+## 6. Release gate
+
+A release is gated on `scripts/release_smoke_v24.py` against the deployed stack:
+
+```bash
+python scripts/release_smoke_v24.py \
+  --api-url https://<api> --web-url https://<web> \
+  --jwt-key "$MEMORYOPS_AUTH_JWT_KEY" --production
+```
+
+Required: `FAILED 0`, `SKIPPED 0`, `RESULT: PASS`.
+
+**Skipped is not passed.** The harness exits `2` (`INCOMPLETE`) when a section did
+not run, because missing evidence is not evidence of absence.
+
+Exit codes: `0` pass · `1` fail · `2` incomplete · `3` environment fault.
+
+Read individual lines, not only the totals. Some checks **record** rather than assert
+— `/metrics` reports its policy either way, so `[PASS] /metrics is protected` and
+`[NOTE] /metrics is PUBLICLY reachable` both leave the run green.
+
+`scripts/railway_smoke_test.py` is **not** a release gate — it predates authenticated
+route enforcement. See [`../deployment/railway-smoke-test.md`](../deployment/railway-smoke-test.md).
+
+---
+
+## 7. Release body template
+
+```markdown
+## Deployment evidence — tagged commit <SHA>
+
+| Service | Deployed commit |
+|---------|-----------------|
+| memoryops-api    | <SHA> |
+| memoryops-web    | <SHA> |
+| memoryops-worker | <SHA> |
+
+PASSED <n>   FAILED 0   SKIPPED 0
+RESULT: PASS
+
+- `GET /readyz` → {"ready":true,"degraded":false}
+- `GET /healthz/workers` → {"healthy":true}
+- `GET /metrics` → 401 (operator-protected)
+- `GET /docs`, `/redoc`, `/openapi.json` → 404
+
+Full release truth: docs/releases/vX.Y-release-truth.md @ <SHA>
+```
+
+Never paste a signing key, operator password, or connection string into a Release
+body — including inside pasted smoke output. Check before publishing.

--- a/docs/rollout.md
+++ b/docs/rollout.md
@@ -158,7 +158,8 @@ changes vs v0.12**.
 - Observability: OpenTelemetry traces → Tempo/Jaeger; metrics → Prometheus/Grafana; LLM traces →
   Langfuse.
 - Workers on Celery/Temporal with retries + dead-letter queues.
-- Deploy: **Railway only** — one project, five services (web, api, worker,
-  managed Postgres+pgvector, Redis). No Vercel. See
+- Deploy: **Railway only** — one project, four services (web, api, worker,
+  managed Postgres+pgvector). Redis was removed: declared and health-gated, but no
+  runtime code ever read `REDIS_URL`. No Vercel. See
   [docs/deployment/railway.md](deployment/railway.md). (Aligned in v0.3.2.)
 - Cost controls: cache embeddings, batch extraction, track cost per write/retrieval.

--- a/docs/security/repository-trust-guards.md
+++ b/docs/security/repository-trust-guards.md
@@ -133,6 +133,48 @@ consumer — not to allowlist the config.
 Import matching resolves the module name, so `import redis_notes` and `from redisx
 import …` are not confused for `redis`.
 
+### `railway-deployment-config`
+
+**Claim:** the Railway configuration in the repository describes the deployment that
+actually runs.
+
+v2.4 shipped a release candidate that passed every code gate and could not be
+deployed. Two defects caused it, and neither was expressible as a unit test:
+
+- `railway/api.railway.json` declared `startCommand` with `--port $PORT`. A
+  config-as-code start command on a Dockerfile service runs in **exec form without
+  shell expansion**, so uvicorn received the four characters `$PORT`. This repository
+  had *already documented* that exact failure for the playground service; the API hit
+  it independently anyway, which is why it is now a guard rather than a paragraph.
+- `railway/web.railway.json` health-checked `/`, which answers `307 → /signin` in
+  authenticated mode. It works in demo mode, which is precisely why the mistake
+  survives review.
+
+Both were fixed in the Railway dashboard. That restored production and left the
+repository describing a deployment that no longer existed — so anything built from the
+checked-in config reproduced the outage.
+
+The guard asserts that every canonical `railway/*.railway.json` exists, that no
+`startCommand` anywhere contains a literal `$PORT`, that `api`/`web`/`worker` declare
+no `startCommand` at all (their Dockerfile `CMD` is authoritative), that the web
+health check is not `/`, and that no service has two competing config sources.
+
+**Parsed, not grepped** — for the usual reason. `docs/deployment/railway.md` explains
+the `$PORT` failure at length, and a substring search would fail the check that exists
+to prevent it.
+
+**One transitional exception**, named in `TRANSITIONAL_DUPLICATE_CONFIGS`:
+`services/api/railway.toml` coexists with `railway/api.railway.json` because Railway
+currently reads the TOML. It is permitted *by name*, not by shape, so deleting the
+exception after the Phase B switchover tightens enforcement to "exactly one config
+source per service" with no further code change. Any other service gaining a second
+source is a finding today.
+
+The playground is deliberately outside `DOCKERFILE_OWNS_START`: its Dockerfile `CMD`
+is `sh -c "streamlit run … --server.port ${PORT:-8501} …"`, which *does* expand
+`$PORT` because it runs through a shell. It is the reference implementation for
+dynamic port binding, not an exception to the rule.
+
 ## Adding a guard
 
 Add the function to `scripts/repo_trust_guards.py`, register it in `GUARDS`, and add

--- a/railway/api.railway.json
+++ b/railway/api.railway.json
@@ -5,7 +5,6 @@
     "dockerfilePath": "Dockerfile"
   },
   "deploy": {
-    "startCommand": "uvicorn app.main:app --host 0.0.0.0 --port $PORT",
     "healthcheckPath": "/healthz",
     "healthcheckTimeout": 100,
     "numReplicas": 1,

--- a/railway/web.railway.json
+++ b/railway/web.railway.json
@@ -5,8 +5,7 @@
     "dockerfilePath": "Dockerfile"
   },
   "deploy": {
-    "startCommand": "npm run start -- --port $PORT --hostname 0.0.0.0",
-    "healthcheckPath": "/",
+    "healthcheckPath": "/architecture",
     "healthcheckTimeout": 100,
     "numReplicas": 1,
     "restartPolicyType": "ON_FAILURE",

--- a/railway/worker.railway.json
+++ b/railway/worker.railway.json
@@ -5,7 +5,6 @@
     "dockerfilePath": "services/worker/Dockerfile"
   },
   "deploy": {
-    "startCommand": "python main.py",
     "numReplicas": 1,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10

--- a/scripts/release_smoke_v24.py
+++ b/scripts/release_smoke_v24.py
@@ -39,6 +39,7 @@ import base64
 import hashlib
 import hmac
 import json
+import ssl
 import sys
 import time
 import urllib.error
@@ -54,6 +55,19 @@ TIMEOUT_SECONDS = 20
 #: treats an omitted ``roles`` claim and a JSON ``null`` one as different states,
 #: so ``None`` cannot double as the default here.
 _OMITTED = object()
+
+#: Pseudo-statuses for conditions that are not HTTP answers. Kept negative so they
+#: can never collide with a real status code.
+STATUS_CONNECTION_ERROR = 0
+STATUS_TLS_ERROR = -1
+
+#: Exit codes. Distinct so a caller (or CI) can tell "the boundary is wrong" from
+#: "this machine cannot make an HTTPS request" — conflating them is what made a
+#: missing CA bundle look like a dozen authorization failures.
+EXIT_PASS = 0
+EXIT_FAIL = 1
+EXIT_INCOMPLETE = 2
+EXIT_ENVIRONMENT = 3
 
 # ── Result recording ─────────────────────────────────────────────────────────
 
@@ -135,7 +149,14 @@ def request(
         raw = exc.read().decode("utf-8", "replace")
         status, resp_headers = exc.code, dict(exc.headers or {})
     except urllib.error.URLError as exc:
-        return 0, f"connection error: {exc.reason}", {}
+        # A TLS trust-store problem is a property of *this machine*, not of the
+        # deployment. Reported as its own status so it can never be counted as a
+        # failed boundary check: during the v2.4 release a missing CA bundle
+        # produced twelve "failures" that read as a breached trust boundary, while
+        # curl reached the same URLs successfully.
+        if isinstance(exc.reason, ssl.SSLCertVerificationError):
+            return STATUS_TLS_ERROR, f"TLS certificate verification failed: {exc.reason}", {}
+        return STATUS_CONNECTION_ERROR, f"connection error: {exc.reason}", {}
 
     try:
         return status, json.loads(raw), resp_headers
@@ -262,8 +283,22 @@ PRINCIPAL_MATRIX: list[tuple[str, str, str, str, dict | None, str]] = [
 ]
 
 
+def tls_preflight(api: str) -> str | None:
+    """One request to prove HTTPS works from here. Returns an error message or None.
+
+    Run before the matrix so a trust-store problem is reported once, as an
+    environment fault, instead of as ~68 boundary failures.
+    """
+    status, body, _ = request("GET", f"{api}/healthz")
+    if status == STATUS_TLS_ERROR:
+        return str(body)
+    return None
+
+
 def _classify(status: int, expect: str) -> tuple[bool, str]:
-    if status == 0:
+    if status == STATUS_TLS_ERROR:
+        return False, "TLS verification failed — environment fault, not a boundary result"
+    if status == STATUS_CONNECTION_ERROR:
         return False, "connection failed"
     if status == 401:
         return False, "401 — auth not configured as this smoke assumes (check --jwt-key/aud/iss)"
@@ -304,11 +339,18 @@ def section_infrastructure(api: str, r: Results) -> None:
         f"got {status}: {body}",
     )
 
+    # Asserting only `status == 200` was too weak: without OPERATIONAL_DATABASE_URL
+    # the endpoint answers 200 with `{"healthy": false}` — a worker whose health is
+    # not observable at all — and the check passed anyway. v2.4 caught that only
+    # because the body was read by hand. The gate now requires the body to say so.
     status, body, _ = request("GET", f"{api}/healthz/workers")
+    healthy = isinstance(body, dict) and body.get("healthy") is True
     r.check(
-        "worker heartbeat GET /healthz/workers is 200",
-        status == 200,
-        f"got {status}: {body}",
+        'worker heartbeat GET /healthz/workers reports {"healthy": true}',
+        status == 200 and healthy,
+        f"got {status}: {body} — `healthy` must be exactly true. A false/null/absent "
+        "value usually means OPERATIONAL_DATABASE_URL is unset, so global worker "
+        "health cannot be observed",
     )
 
 
@@ -809,6 +851,24 @@ def main() -> int:
     if web:
         print(f"                     web {web}")
 
+    tls_error = tls_preflight(api)
+    if tls_error:
+        print(
+            "\nRESULT: ENVIRONMENT — cannot verify TLS from this machine; no boundary\n"
+            "checks were run.\n"
+            f"\n  {tls_error}\n"
+            "\nThis is a local trust-store problem, not a finding about the deployment.\n"
+            "Fix it and re-run:\n"
+            "\n  pip install certifi\n"
+            "  export SSL_CERT_FILE=$(python -m certifi)\n"
+            "\nOn macOS, a python.org interpreter also ships "
+            '"Install Certificates.command".\n'
+            "\nDo NOT disable certificate verification to get past this — the smoke "
+            "test\nasserts a production security boundary, and an unverified "
+            "connection cannot\nsupport that claim."
+        )
+        return EXIT_ENVIRONMENT
+
     section_infrastructure(api, r)
     section_public_surface(
         api, r, expect_docs_closed=not args.allow_docs, production=args.production
@@ -842,12 +902,12 @@ def main() -> int:
 
     if r.failed:
         print("\nRESULT: FAIL — the deployed trust boundary does not match the release claim.")
-        return 1
+        return EXIT_FAIL
     if r.skipped:
         print("\nRESULT: INCOMPLETE — everything run passed, but sections were skipped.")
-        return 2
+        return EXIT_INCOMPLETE
     print("\nRESULT: PASS — deployed trust boundary matches the v2.4 claim.")
-    return 0
+    return EXIT_PASS
 
 
 if __name__ == "__main__":

--- a/scripts/repo_trust_guards.py
+++ b/scripts/repo_trust_guards.py
@@ -446,11 +446,228 @@ def check_no_retired_infrastructure(root: Path = REPO) -> list[Finding]:
     return findings
 
 
+# ── guard 5: Railway deployment configuration ────────────────────────────────
+#
+# v2.4 shipped a release candidate that passed every code gate and could not be
+# deployed. Two deployment-only defects caused it, and neither was expressible as a
+# unit test:
+#
+#   * `railway/api.railway.json` declared `startCommand` with `--port $PORT`. A
+#     config-as-code start command on a Dockerfile service runs in **exec form
+#     without shell expansion**, so uvicorn received the four characters `$PORT`.
+#     The repository already documented this exact failure for the playground
+#     service; the API hit it independently anyway.
+#   * `railway/web.railway.json` used `/` as the health check path. In authenticated
+#     mode `/` answers 307 to `/signin`, so the health check never succeeds.
+#
+# Both were fixed in the dashboard, which meant the repository no longer described
+# the deployment. This guard makes the repository the source of truth again.
+
+#: Service name -> canonical config file. `railway/*.railway.json` is the canonical
+#: form because Railway auto-detects `railway.toml` at a service's *root directory*,
+#: and both the worker and the playground are rooted at the repository root — they
+#: would collide on a single top-level file. Explicit per-service config paths are
+#: the only scheme that works for all four services.
+CANONICAL_RAILWAY_CONFIGS = {
+    "api": "railway/api.railway.json",
+    "web": "railway/web.railway.json",
+    "worker": "railway/worker.railway.json",
+    "playground": "railway/playground.railway.json",
+}
+
+#: Services whose Dockerfile `CMD` is authoritative, so their config must not set a
+#: `startCommand` at all. Declaring it in two places is how the two drift.
+#:
+#: The playground is deliberately absent: its Dockerfile `CMD` is
+#: `sh -c "streamlit run … --server.port ${PORT:-8501} …"`, which *does* expand
+#: `$PORT` because it runs through a shell. It is the reference implementation for
+#: dynamic port binding, not an exception to the rule.
+DOCKERFILE_OWNS_START = ("api", "web", "worker")
+
+#: TRANSITIONAL — remove in Phase B.
+#:
+#: Railway production currently reads the API service's configuration from
+#: `services/api/railway.toml`, because that is what the dashboard's Config File
+#: setting points at. Deleting it before the switchover would leave the platform
+#: reading a file the repository no longer contains, so it stays until:
+#:
+#:   1. the API service's Config File is pointed at `railway/api.railway.json`,
+#:   2. the service is redeployed and `release_smoke_v24.py` passes, then
+#:   3. `services/api/railway.toml` is deleted and this exception is removed.
+#:
+#: Until then this is the *only* permitted duplicate. Any other service gaining a
+#: second config source is a finding.
+TRANSITIONAL_DUPLICATE_CONFIGS = {"api": "services/api/railway.toml"}
+
+#: Where a non-canonical Railway config file implies its service lives.
+_CONFIG_DIR_TO_SERVICE = {
+    "services/api": "api",
+    "apps/web": "web",
+    "services/worker": "worker",
+    "apps/playground": "playground",
+    "": "worker",  # repo root is the worker's root directory
+}
+
+_START_COMMAND = re.compile(r"startCommand")
+_LITERAL_PORT = re.compile(r"\$\{?PORT\}?")
+
+
+def _line_of(text: str, needle: str) -> int:
+    for number, line in enumerate(text.splitlines(), start=1):
+        if needle in line:
+            return number
+    return 1
+
+
+def _load_railway_config(path: Path) -> tuple[dict, str]:
+    """Return (parsed, raw_text). Unparseable files yield an empty mapping."""
+    raw = path.read_text(encoding="utf-8", errors="replace")
+    try:
+        if path.suffix == ".json":
+            import json
+
+            return json.loads(raw), raw
+        import tomllib
+
+        return tomllib.loads(raw), raw
+    except Exception:  # noqa: BLE001 — a malformed config is reported, not raised
+        return {}, raw
+
+
+def _discover_railway_configs(root: Path) -> list[Path]:
+    found: list[Path] = []
+    for path in root.rglob("railway.toml"):
+        if not any(part in _SKIP_DIRS for part in path.parts):
+            found.append(path)
+    for path in (root / "railway").glob("*.railway.json"):
+        found.append(path)
+    return sorted(found)
+
+
+def check_railway_deployment_config(root: Path = REPO) -> list[Finding]:
+    """Railway config-as-code must describe the deployment that actually runs.
+
+    Asserts, for the canonical `railway/*.railway.json` files:
+
+    * every expected service has one,
+    * no ``startCommand`` anywhere contains a literal ``$PORT``,
+    * api / web / worker declare no ``startCommand`` (their Dockerfile owns it),
+    * the web health check is not ``/`` — authenticated mode redirects it,
+    * no service except the documented transitional API exception has two config
+      sources.
+
+    Parsed rather than grepped, so prose about ``$PORT`` in a doc or a comment is
+    not a finding — the same reason every other guard here parses.
+    """
+    findings: list[Finding] = []
+
+    for service, relative in CANONICAL_RAILWAY_CONFIGS.items():
+        path = root / relative
+        if not path.exists():
+            findings.append(
+                Finding(
+                    "railway-deployment-config",
+                    relative,
+                    1,
+                    f"canonical Railway config for `{service}` is missing; Railway "
+                    "would fall back to auto-detection and the repository would stop "
+                    "describing the deployment",
+                )
+            )
+            continue
+
+        config, raw = _load_railway_config(path)
+        deploy = config.get("deploy") or {}
+
+        start = deploy.get("startCommand")
+        if start is not None and service in DOCKERFILE_OWNS_START:
+            findings.append(
+                Finding(
+                    "railway-deployment-config",
+                    relative,
+                    _line_of(raw, "startCommand"),
+                    f"`{service}` declares a startCommand; its Dockerfile CMD is "
+                    "authoritative. Declaring the launch in two places is how they "
+                    "drift — remove it here",
+                )
+            )
+
+        if service == "web":
+            health = deploy.get("healthcheckPath")
+            if health == "/":
+                findings.append(
+                    Finding(
+                        "railway-deployment-config",
+                        relative,
+                        _line_of(raw, "healthcheckPath"),
+                        "web health check is `/`, which answers 307 -> /signin in "
+                        "authenticated mode, so the check can never pass. Use "
+                        "`/architecture`",
+                    )
+                )
+
+    # A literal $PORT must not appear in *any* Railway config's startCommand, not
+    # only the canonical ones — the transitional TOML is deployed today.
+    for path in _discover_railway_configs(root):
+        config, raw = _load_railway_config(path)
+        start = (config.get("deploy") or {}).get("startCommand")
+        if isinstance(start, str) and _LITERAL_PORT.search(start):
+            findings.append(
+                Finding(
+                    "railway-deployment-config",
+                    _rel(path, root),
+                    _line_of(raw, "startCommand"),
+                    "startCommand contains a literal `$PORT`. Config-as-code start "
+                    "commands on Dockerfile services run in exec form without shell "
+                    "expansion, so the process receives the characters `$PORT`. Let "
+                    "the Dockerfile CMD own the port, or expand it via `sh -c`",
+                )
+            )
+
+    # Exactly one config source per service, except the documented API transition.
+    by_service: dict[str, list[str]] = {}
+    canonical_paths = {v for v in CANONICAL_RAILWAY_CONFIGS.values()}
+    for path in _discover_railway_configs(root):
+        relative = _rel(path, root)
+        if relative in canonical_paths:
+            service = next(
+                s for s, v in CANONICAL_RAILWAY_CONFIGS.items() if v == relative
+            )
+        else:
+            parent = _rel(path.parent, root)
+            service = _CONFIG_DIR_TO_SERVICE.get(parent, parent or "<root>")
+        by_service.setdefault(service, []).append(relative)
+
+    for service, paths in sorted(by_service.items()):
+        if len(paths) < 2:
+            continue
+        permitted = {CANONICAL_RAILWAY_CONFIGS.get(service)}
+        allowed_duplicate = TRANSITIONAL_DUPLICATE_CONFIGS.get(service)
+        if allowed_duplicate:
+            permitted.add(allowed_duplicate)
+        unexpected = [p for p in paths if p not in permitted]
+        if unexpected or not allowed_duplicate:
+            findings.append(
+                Finding(
+                    "railway-deployment-config",
+                    sorted(paths)[0],
+                    1,
+                    f"`{service}` has {len(paths)} competing Railway config sources "
+                    f"({', '.join(sorted(paths))}). Exactly one must be canonical; "
+                    "two sources silently diverge, which is how the API shipped a "
+                    "`$PORT` start command it never ran",
+                )
+            )
+
+    return findings
+
+
 GUARDS = {
     "sys-path-mutation": check_no_sys_path_mutation,
     "committed-secret-literal": check_no_committed_secret_literals,
     "demo-identity-in-server-code": check_no_demo_identity_in_server_code,
     "retired-infrastructure": check_no_retired_infrastructure,
+    "railway-deployment-config": check_railway_deployment_config,
 }
 
 

--- a/services/api/tests/test_release_smoke_v24.py
+++ b/services/api/tests/test_release_smoke_v24.py
@@ -1,0 +1,177 @@
+"""The release smoke harness's own failure modes.
+
+The harness asserts a production security boundary, so the ways it can be *wrong*
+matter as much as the checks it makes. Two were found during the v2.4 release and
+are pinned here:
+
+* a missing CA bundle produced twelve "failed" checks that read as a breached trust
+  boundary, while ``curl`` reached the same URLs successfully;
+* the worker heartbeat check asserted only ``status == 200``, so a deployment whose
+  worker health was not observable at all (``{"healthy": false}``) passed it.
+
+These are unit tests over the classification logic — they make no network calls and
+need no deployment.
+"""
+
+from __future__ import annotations
+
+import ssl
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import release_smoke_v24 as smoke  # noqa: E402
+
+
+# ── TLS/CA failures are environment faults, not boundary results ────────────
+def test_a_certificate_failure_is_classified_as_its_own_status(monkeypatch):
+    """`CERTIFICATE_VERIFY_FAILED` must not look like an HTTP answer."""
+
+    def raise_cert_error(*args, **kwargs):
+        raise urllib.error.URLError(
+            ssl.SSLCertVerificationError(
+                "[SSL: CERTIFICATE_VERIFY_FAILED] unable to get local issuer certificate"
+            )
+        )
+
+    monkeypatch.setattr(smoke.urllib.request, "urlopen", raise_cert_error)
+    status, body, _ = smoke.request("GET", "https://example.test/healthz")
+
+    assert status == smoke.STATUS_TLS_ERROR
+    assert status != smoke.STATUS_CONNECTION_ERROR
+    assert "TLS certificate verification failed" in body
+
+
+def test_a_certificate_failure_is_never_reported_as_a_denied_check():
+    """The specific misreading to prevent.
+
+    A TLS fault must not satisfy a DENIED expectation, or a machine with no CA
+    bundle would "prove" that every protected route was correctly refusing callers.
+    """
+    ok, detail = smoke._classify(smoke.STATUS_TLS_ERROR, smoke.DENIED)
+    assert ok is False
+    assert "environment fault" in detail
+
+    ok, detail = smoke._classify(smoke.STATUS_TLS_ERROR, smoke.ALLOWED)
+    assert ok is False
+    assert "environment fault" in detail
+
+
+def test_an_ordinary_connection_error_stays_distinct_from_a_tls_error(monkeypatch):
+    def raise_conn_error(*args, **kwargs):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(smoke.urllib.request, "urlopen", raise_conn_error)
+    status, body, _ = smoke.request("GET", "https://example.test/healthz")
+
+    assert status == smoke.STATUS_CONNECTION_ERROR
+    assert "connection error" in body
+
+
+def test_the_preflight_reports_a_certificate_failure(monkeypatch):
+    monkeypatch.setattr(
+        smoke, "request", lambda *a, **k: (smoke.STATUS_TLS_ERROR, "cert bad", {})
+    )
+    assert smoke.tls_preflight("https://example.test") == "cert bad"
+
+
+def test_the_preflight_is_silent_when_tls_works(monkeypatch):
+    monkeypatch.setattr(smoke, "request", lambda *a, **k: (200, {"status": "ok"}, {}))
+    assert smoke.tls_preflight("https://example.test") is None
+
+
+def test_the_environment_exit_code_is_distinct_from_failure_and_incomplete():
+    """CI must be able to tell "boundary is wrong" from "this machine cannot do TLS"."""
+    codes = {
+        smoke.EXIT_PASS,
+        smoke.EXIT_FAIL,
+        smoke.EXIT_INCOMPLETE,
+        smoke.EXIT_ENVIRONMENT,
+    }
+    assert len(codes) == 4
+    assert smoke.EXIT_ENVIRONMENT not in (smoke.EXIT_FAIL, smoke.EXIT_INCOMPLETE)
+
+
+# ── C1 worker heartbeat requires healthy is exactly True ────────────────────
+def _worker_health_result(body, status: int = 200) -> smoke.Results:
+    r = smoke.Results()
+    responses = {
+        "/healthz": (200, {"status": "ok"}, {}),
+        "/readyz": (200, {"ready": True}, {}),
+        "/healthz/workers": (status, body, {}),
+    }
+
+    def fake_request(method, url, **kwargs):
+        for suffix, response in responses.items():
+            if url.endswith(suffix):
+                return response
+        raise AssertionError(f"unexpected url {url}")
+
+    original = smoke.request
+    smoke.request = fake_request
+    try:
+        smoke.section_infrastructure("https://example.test", r)
+    finally:
+        smoke.request = original
+    return r
+
+
+def _worker_check(r: smoke.Results) -> tuple[bool, str]:
+    for name in r.passed:
+        if "worker heartbeat" in name:
+            return True, name
+    for name, detail in r.failed:
+        if "worker heartbeat" in name:
+            return False, detail
+    raise AssertionError("worker heartbeat check did not run")
+
+
+def test_worker_heartbeat_passes_only_on_healthy_true():
+    ok, _ = _worker_check(_worker_health_result({"healthy": True}))
+    assert ok
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"healthy": False},
+        {"healthy": None},
+        {},
+        {"status": "ok"},
+        "not json at all",
+    ],
+    ids=["false", "null", "missing", "wrong-key", "non-json"],
+)
+def test_worker_heartbeat_fails_on_anything_but_true(body):
+    """A 200 alone is not evidence of a healthy worker.
+
+    `{"healthy": false}` is exactly what a deployment without
+    OPERATIONAL_DATABASE_URL returns — worker health is not observable, which is
+    not the same as a worker being fine.
+    """
+    ok, detail = _worker_check(_worker_health_result(body))
+    assert not ok
+    assert "OPERATIONAL_DATABASE_URL" in detail
+
+
+def test_worker_heartbeat_fails_on_non_200_even_when_body_says_healthy():
+    ok, _ = _worker_check(_worker_health_result({"healthy": True}, status=503))
+    assert not ok
+
+
+# ── the harness never weakens TLS ───────────────────────────────────────────
+def test_the_harness_contains_no_verification_bypass():
+    """A green run must never have been bought by disabling certificate checks."""
+    source = (REPO_ROOT / "scripts" / "release_smoke_v24.py").read_text(encoding="utf-8")
+    for bypass in (
+        "_create_unverified_context",
+        "CERT_NONE",
+        "check_hostname = False",
+        "verify=False",
+    ):
+        assert bypass not in source, f"TLS verification bypass present: {bypass}"

--- a/services/api/tests/test_repo_trust_guards.py
+++ b/services/api/tests/test_repo_trust_guards.py
@@ -11,6 +11,7 @@ rather than editing the repository.
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -20,11 +21,14 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from repo_trust_guards import (  # noqa: E402
+    CANONICAL_RAILWAY_CONFIGS,
     GUARDS,
+    TRANSITIONAL_DUPLICATE_CONFIGS,
     check_no_committed_secret_literals,
     check_no_demo_identity_in_server_code,
     check_no_retired_infrastructure,
     check_no_sys_path_mutation,
+    check_railway_deployment_config,
     run_all,
 )
 
@@ -49,6 +53,7 @@ def test_every_guard_is_registered_and_callable():
         "committed-secret-literal",
         "demo-identity-in-server-code",
         "retired-infrastructure",
+        "railway-deployment-config",
     }
     for name, guard in GUARDS.items():
         assert callable(guard), name
@@ -343,3 +348,121 @@ def test_a_similarly_named_module_is_not_confused_for_the_retired_one(tmp_path):
     """`redis_notes` is not `redis`; import matching is on the module, not a substring."""
     _write(tmp_path, "services/api/app/thing.py", "import redis_notes\nfrom redisx import y\n")
     assert check_no_retired_infrastructure(tmp_path) == []
+
+
+# ── guard 5: Railway deployment configuration ───────────────────────────────
+#
+# The two defects below both reached production in v2.4 and were invisible to every
+# other gate: a `$PORT` that never expanded, and a health check pointed at a route
+# that redirects. Each negative test reproduces one of them exactly.
+
+_VALID_DEPLOY = {
+    "api": '{"deploy": {"healthcheckPath": "/healthz", "numReplicas": 1}}',
+    "web": '{"deploy": {"healthcheckPath": "/architecture", "numReplicas": 1}}',
+    "worker": '{"deploy": {"numReplicas": 1}}',
+    "playground": '{"deploy": {"healthcheckPath": "/_stcore/health"}}',
+}
+
+
+def _railway_tree(root: Path, **overrides: str) -> Path:
+    """A tree with every canonical config present and valid, minus any overrides."""
+    for service, relative in CANONICAL_RAILWAY_CONFIGS.items():
+        _write(root, relative, overrides.get(service, _VALID_DEPLOY[service]))
+    return root
+
+
+def test_a_valid_railway_tree_is_clean(tmp_path):
+    assert check_railway_deployment_config(_railway_tree(tmp_path)) == []
+
+
+def test_the_repository_railway_config_is_clean():
+    assert check_railway_deployment_config(REPO_ROOT) == []
+
+
+@pytest.mark.parametrize(
+    "start",
+    [
+        "uvicorn app.main:app --host 0.0.0.0 --port $PORT",
+        "npm run start -- --port ${PORT} --hostname 0.0.0.0",
+    ],
+)
+def test_a_literal_port_in_a_start_command_is_rejected(tmp_path, start):
+    """The exact v2.4 defect: exec form does not expand `$PORT`."""
+    tree = _railway_tree(
+        tmp_path, playground=json.dumps({"deploy": {"startCommand": start}})
+    )
+    findings = check_railway_deployment_config(tree)
+    assert any("literal `$PORT`" in f.detail for f in findings)
+
+
+def test_a_shell_expanded_port_in_the_dockerfile_is_not_a_finding(tmp_path):
+    """The playground expands `${PORT:-8501}` via `sh -c` in its Dockerfile CMD.
+
+    The guard inspects Railway configs, not Dockerfiles, so the reference
+    implementation for dynamic ports must not trip it.
+    """
+    tree = _railway_tree(tmp_path)
+    _write(
+        tree,
+        "apps/playground/Dockerfile",
+        'CMD ["sh", "-c", "streamlit run app.py --server.port ${PORT:-8501}"]\n',
+    )
+    assert check_railway_deployment_config(tree) == []
+
+
+def test_a_root_healthcheck_on_web_is_rejected(tmp_path):
+    """`/` answers 307 -> /signin in authenticated mode, so it can never pass."""
+    tree = _railway_tree(tmp_path, web='{"deploy": {"healthcheckPath": "/"}}')
+    findings = check_railway_deployment_config(tree)
+    assert any("307" in f.detail for f in findings)
+
+
+def test_the_architecture_healthcheck_is_accepted(tmp_path):
+    tree = _railway_tree(tmp_path, web='{"deploy": {"healthcheckPath": "/architecture"}}')
+    assert check_railway_deployment_config(tree) == []
+
+
+@pytest.mark.parametrize("service", ["api", "web", "worker"])
+def test_a_start_command_override_is_rejected(tmp_path, service):
+    """Declaring the launch in both the Dockerfile and the config is how they drift."""
+    tree = _railway_tree(tmp_path, **{service: '{"deploy": {"startCommand": "run it"}}'})
+    findings = check_railway_deployment_config(tree)
+    assert any("Dockerfile CMD is" in f.detail for f in findings)
+
+
+def test_a_missing_canonical_config_is_rejected(tmp_path):
+    tree = _railway_tree(tmp_path)
+    (tree / CANONICAL_RAILWAY_CONFIGS["worker"]).unlink()
+    findings = check_railway_deployment_config(tree)
+    assert any("is missing" in f.detail for f in findings)
+
+
+def test_the_transitional_api_duplicate_is_accepted(tmp_path):
+    """Production still reads services/api/railway.toml; Phase B removes it.
+
+    This is the one permitted duplicate, and it is permitted by name rather than by
+    shape so Phase B can delete the exception and get enforcement for free.
+    """
+    tree = _railway_tree(tmp_path)
+    _write(tree, TRANSITIONAL_DUPLICATE_CONFIGS["api"], '[deploy]\nhealthcheckPath = "/healthz"\n')
+    assert check_railway_deployment_config(tree) == []
+
+
+def test_a_duplicate_config_for_any_other_service_is_rejected(tmp_path):
+    """The exception is for the API only — web gaining a second source is a finding."""
+    tree = _railway_tree(tmp_path)
+    _write(tree, "apps/web/railway.toml", '[deploy]\nhealthcheckPath = "/architecture"\n')
+    findings = check_railway_deployment_config(tree)
+    assert any("competing Railway config sources" in f.detail for f in findings)
+
+
+def test_the_transitional_toml_is_still_checked_for_a_literal_port(tmp_path):
+    """Being a permitted duplicate does not exempt it — it is what production runs."""
+    tree = _railway_tree(tmp_path)
+    _write(
+        tree,
+        TRANSITIONAL_DUPLICATE_CONFIGS["api"],
+        '[deploy]\nstartCommand = "uvicorn app.main:app --port $PORT"\n',
+    )
+    findings = check_railway_deployment_config(tree)
+    assert any("literal `$PORT`" in f.detail for f in findings)


### PR DESCRIPTION
## Scope

v2.4.1 Phase A repository hardening only.

## What this PR fixes

- canonical per-service Railway JSON configuration
- removal of stale `startCommand` overrides
- authenticated web `/architecture` healthcheck
- Railway deployment trust guard
- production web/auth environment documentation
- `OPERATIONAL_DATABASE_URL` + restricted `memoryops_monitor` setup
- release smoke TLS/CA preflight
- worker heartbeat requires `healthy=true`
- old Railway smoke relabelled as liveness-only
- documented release evidence/SHA process

## Why

v2.4 shipped a release candidate that passed every code gate and could not be
deployed. Two defects caused it, neither expressible as a unit test:

- `railway/api.railway.json` declared `--port $PORT`. A config-as-code `startCommand`
  on a Dockerfile service runs in **exec form without shell expansion**, so uvicorn
  received the four characters `$PORT`. This repository had already documented that
  exact failure for the playground service; the API hit it independently anyway.
- `railway/web.railway.json` health-checked `/`, which answers `307 → /signin` in
  authenticated mode. It works in demo mode, which is why the mistake survives review.

Both were fixed in the Railway dashboard. That restored production and left the
repository describing a deployment that no longer existed — so anything built from the
checked-in config reproduced the outage. This PR makes the repository the source of
truth again, and makes both mistakes unexpressible via a parsed structural guard.

## Verification

- API: **1111 tests**
- Web: **96 tests**
- Railway/smoke targeted tests: **71 passed**
- Trust guards: **5 clean**
- Benchmark: **50/50**
- SDK: **25**
- Paper harness: **54**
- demo + authenticated builds pass
- evals **PASS**
- PR invariant gate **PASS**
- gitleaks clean
- `git diff --check` clean

## Important transition state

`services/api/railway.toml` **intentionally remains** temporarily.

`railway/*.railway.json` is the target canonical configuration, but production Railway
has **NOT** been switched to it in this PR.

Full F1 closure happens only in Phase B after:

- Railway Config File settings are confirmed
- services are migrated deliberately
- production smoke passes
- `services/api/railway.toml` is removed
- the temporary guard exception is removed

The guard permits this one duplicate **by name** (`TRANSITIONAL_DUPLICATE_CONFIGS`),
not by shape — so deleting the exception in Phase B tightens enforcement to "exactly
one config source per service" with no further code change. Any *other* service
gaining a second source is a finding today.

## Production impact

**None in Phase A.** No Railway settings changed. No deployment performed. No
application runtime behavior changed.

Phase A causes no production runtime change because the canonical Railway JSON configs
are not live yet. During Phase B, when those configs are activated, API/Web/Worker
startup will delegate to their existing Dockerfile `CMD`s, which match the startup
behavior already validated in production.

## Release-tooling behavior changes

Two, both in `scripts/release_smoke_v24.py`, and both make the gate stricter or
clearer rather than changing the product:

- **TLS faults are no longer boundary results.** A missing CA bundle previously
  produced twelve "failed" checks that read as a breached trust boundary, while `curl`
  reached the same URLs successfully. Certificate errors now get their own status, a
  preflight aborts before the matrix runs, and exit code `3` separates "this machine
  cannot do TLS" from "the boundary is wrong". No verification bypass was added, and a
  test asserts none appears later.
- **C1 requires `healthy` to be exactly `true`.** It previously asserted only status
  200, so a deployment reporting `{"healthy": false}` — exactly what an unset
  `OPERATIONAL_DATABASE_URL` produces — passed. v2.4 caught that only because the body
  was read by hand.

## Out of scope

- `MEMORYOPS_AUTH_JWT_KEY` startup validation
- 422-before-authorization behavior
- Dockerfile dynamic `$PORT` support
- pre-existing Ruff findings in untouched test files