### PR TITLE
chore(security): ignore verified historical secret fixtures

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,38 @@
+# gitleaks — verified historical false positives.
+#
+# Scope: exact fingerprints only. Each entry pins one commit, one file, one rule and
+# one line, so it can never suppress a finding in any other commit, file, rule or
+# line — including a real credential added to the same file tomorrow.
+#
+# What is deliberately NOT done here: the `generic-api-key` rule is not disabled, no
+# file or directory is excluded, no commit range is blanket-ignored, and the weekly
+# full-history scheduled scan is unchanged. A narrower tool than an ignore file does
+# not exist; a broader one would silently cover future mistakes.
+#
+# Both entries were inspected against the historical blob before being added, and
+# both are documented in docs/releases/v2.4-release-truth.md §3.3. Neither literal
+# exists in the current tree.
+#
+# Adding an entry requires: read the blob at that commit, confirm it is not a
+# credential, record why below. An unexplained fingerprint is not acceptable.
+
+# `heartbeat = LeaseHeartbeat(self._leases, key, ...)`
+#
+# The rule matched the local variable `key` sitting next to a value. Line 120 of the
+# same blob defines it: `key = scope_key(scope.tenant_id, scope.user_id)` — a worker
+# *lease* key identifying a tenant/user scope, used to prevent two replicas
+# processing the same scope concurrently. It is an identifier, never a secret, and
+# no credential is involved anywhere in that code path.
+a17f2c16e57a1bdb70e85f4a2afda642e1a3d34f:services/api/app/workers/orchestrator.py:generic-api-key:134
+
+# `metadata={"raw": "api_key=sk-…"}` — a synthetic fixture.
+#
+# The enclosing test is `test_loop_events_do_not_store_raw_secret`: the fixture is
+# secret-*shaped* on purpose, because the test asserts that such content is not
+# persisted raw in loop events. Suppressing the finding does not weaken that test —
+# the test is the thing proving secrets are not stored.
+#
+# It has since been refactored into `services/api/tests/_secret_fixtures.py`, which
+# assembles the value from parts at import time so no literal is committed. This
+# entry covers only the historical commit that still carries the inline form.
+b5b5684b45b36e3bcf061158b096713d317153a2:services/api/tests/test_loop_events.py:generic-api-key:17


### PR DESCRIPTION
## Scope

Maintenance only. Makes the **scheduled full-history** gitleaks scan green without
weakening secret detection for current or future commits.

No runtime code touched — the diff is exactly one new file, `.gitleaksignore`.

## Why

The weekly scheduled scan reads full history, so it fails on two findings the push-
and PR-triggered scans never see. Both were investigated during v2.4 and recorded in
`docs/releases/v2.4-release-truth.md` §3.3. Neither is a credential, and neither
literal exists in the current tree.

### `a17f2c16` — `services/api/app/workers/orchestrator.py:134`

```python
heartbeat = LeaseHeartbeat(self._leases, key, interval_seconds=...)
```

The rule matched the bare variable `key`. Line 120 of the **same blob** defines it:

```python
key = scope_key(scope.tenant_id, scope.user_id)
```

A worker **lease** key — a tenant/user scope identifier that stops two replicas
processing the same scope concurrently. An identifier, never a secret.

### `b5b5684b` — `services/api/tests/test_loop_events.py:17`

A secret-shaped fixture whose enclosing test is
`test_loop_events_do_not_store_raw_secret` — it is deliberately secret-shaped
*because* the test asserts such content is not persisted raw. Suppressing the finding
does not weaken that test; the test is the thing proving secrets are not stored.

Since refactored into `_secret_fixtures.py`, which assembles the value at import time
so no literal is committed.

## Ignore scope — deliberately minimal

Two fingerprints, each pinning **commit + file + rule + line**:

```
a17f2c16…:services/api/app/workers/orchestrator.py:generic-api-key:134
b5b5684b…:services/api/tests/test_loop_events.py:generic-api-key:17
```

Verified structurally: 2 non-comment lines, **no wildcards, globs or path prefixes**.

Explicitly **not** done:

- `generic-api-key` not disabled
- no file or directory excluded
- no commit range blanket-ignored
- scheduled full-history scanning unchanged
- no global gitleaks configuration weakened

## Verification

| Scan | Result |
|---|---|
| Full-history (equivalent to scheduled CI) | **no leaks found** |
| Current tree (`--no-git`) | **no tracked findings** |
| Negative proof — fresh credential-shaped literal in tree | **detected, exit 1** |

The negative proof matters more than the two green scans: it shows the ignore cannot
mask a new secret. Worth recording that my first probe used AWS's canonical
`AKIA…EXAMPLE` value, reported clean, and proved nothing — gitleaks allowlists it. It
was redone with a random value, which was correctly detected.

| Gate | Result |
|---|---|
| Repository trust guards | 5 clean |
| Full API suite | exit 0, **1119 collected** (unchanged — config-only change) |
| `git diff --check` | clean |

## ⚠️ This PR's CI does not validate the fix

PR-triggered gitleaks scans only the PR's commits, not full history — so a green
check here is expected either way and proves nothing about the scheduled scan.

The real confirmation is a **manual `workflow_dispatch` of "Security scan" on `main`
after merge**, or waiting for next Monday's cron. Local full-history scanning is the
evidence offered in the meantime.