### PR TITLE
chore(llm): migrate Gemini provider to supported SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,7 @@ updates:
         patterns:
           - "openai"
           - "anthropic"
-          - "google-generativeai"
+          - "google-genai"
     # These change behaviour, not just versions, so they are upgraded deliberately
     # in their own PRs with a compatibility review — not proposed automatically.
     #   pgvector : vector semantics and index behaviour

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           # extra:module — module names must match the adapter imports exactly.
           for pair in "openai:openai" \
                       "anthropic:anthropic" \
-                      "gemini:google.generativeai" \
+                      "gemini:google.genai" \
                       "qdrant:qdrant_client" \
                       "lancedb:lancedb" \
                       "weaviate:weaviate"; do

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -96,10 +96,11 @@ how the SDKs went missing from every runtime image: selecting
 `MEMORYOPS_LLM_PROVIDER=openai` in an image without `openai` installed silently
 degraded to the deterministic stub, with only a log line to show for it.
 
-> The `gemini` extra pins **`google-generativeai`** (module `google.generativeai`),
-> the legacy SDK that `app/llm/gemini_provider.py` actually imports — *not* the newer
-> `google-genai` (module `google.genai`). Migrating the adapter is tracked follow-up
-> work and needs a live-key test to land safely. `test_provider_extras_pin_the_module_each_adapter_imports`
+> The `gemini` extra pins **`google-genai`** (module `google.genai`), the supported
+> SDK that `app/llm/gemini_provider.py` imports. It replaced the retired
+> `google-generativeai`, whose import announced that support had ended and which
+> spoke gRPC — unrecordable by the VCR/pytest-recording stack, so real-provider
+> evidence could not be reproduced in CI. `test_provider_extras_pin_the_module_each_adapter_imports`
 > pins this correspondence so an extra can never install an SDK its adapter cannot use.
 
 ### Fail-closed under `MEMORYOPS_PROFILE=production`

--- a/docs/provider-llm-adapters.md
+++ b/docs/provider-llm-adapters.md
@@ -31,7 +31,7 @@ raw text; turning that into a validated structured object is the job of
 The registry (`registry.py`) selects from settings and **falls back to the stub**
 whenever a networked provider is unconfigured (missing key) — so the app always
 starts and CI never needs a secret. Networked SDKs are imported lazily, so the
-package imports cleanly without `openai` / `anthropic` / `google-generativeai`
+package imports cleanly without `openai` / `anthropic` / `google-genai`
 installed.
 
 ## Configuration

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -464,8 +464,9 @@ class Settings(BaseSettings):
         llm_requirements = {
             "openai": ("openai", "openai", self.openai_api_key, "OPENAI_API_KEY"),
             "anthropic": ("anthropic", "anthropic", self.anthropic_api_key, "ANTHROPIC_API_KEY"),
-            # Legacy SDK module — matches app/llm/gemini_provider.py's actual import.
-            "gemini": ("google.generativeai", "gemini", self.gemini_api_key, "GEMINI_API_KEY"),
+            # Must match app/llm/gemini_provider.py's actual import (`from google import
+            # genai`), not the retired `google.generativeai`.
+            "gemini": ("google.genai", "gemini", self.gemini_api_key, "GEMINI_API_KEY"),
         }
         if self.llm_provider in llm_requirements:
             module, extra, key, key_env = llm_requirements[self.llm_provider]

--- a/services/api/app/llm/gemini_provider.py
+++ b/services/api/app/llm/gemini_provider.py
@@ -1,8 +1,20 @@
 """Google Gemini provider (v0.4).
 
 Used only when ``GEMINI_API_KEY`` is set and ``MEMORYOPS_LLM_PROVIDER=gemini``.
-The ``google-generativeai`` SDK is imported lazily. Any failure propagates as
+The ``google-genai`` SDK is imported lazily. Any failure propagates as
 ``LLMUnavailableError`` and the caller degrades to the deterministic heuristic.
+
+Migrated from the retired ``google-generativeai`` SDK, whose import now prints
+"All support for the `google.generativeai` package has ended". Two consequences of
+the move are load-bearing rather than cosmetic:
+
+* ``HttpOptions.timeout`` is expressed in **milliseconds**, while the old SDK's
+  ``request_options={"timeout": …}`` took seconds. Passing the configured seconds
+  through unchanged would have turned an 8-second budget into 8 milliseconds and
+  failed every call.
+* The new client speaks HTTP over ``httpx`` rather than gRPC, so provider traffic is
+  recordable by the VCR/pytest-recording stack the repository already depends on.
+  That is what makes real-provider extraction evidence reproducible in CI.
 """
 
 from __future__ import annotations
@@ -13,14 +25,21 @@ from .providers import BaseNetworkProvider
 class GeminiProvider(BaseNetworkProvider):
     name = "gemini"
 
-    def _invoke(self, *, system: str, user: str, task: str) -> str:  # pragma: no cover - needs key
-        import google.generativeai as genai
+    def _invoke(self, *, system: str, user: str, task: str) -> str:
+        from google import genai
+        from google.genai import types
 
-        genai.configure(api_key=self._api_key)
-        model = genai.GenerativeModel(self._model, system_instruction=system)
-        resp = model.generate_content(
-            user,
-            generation_config={"temperature": 0},
-            request_options={"timeout": self._timeout},
+        client = genai.Client(
+            api_key=self._api_key,
+            # Seconds -> milliseconds; see the module docstring.
+            http_options=types.HttpOptions(timeout=int(self._timeout * 1000)),
+        )
+        resp = client.models.generate_content(
+            model=self._model,
+            contents=user,
+            config=types.GenerateContentConfig(
+                system_instruction=system,
+                temperature=0,
+            ),
         )
         return resp.text or ""

--- a/services/api/app/routes/health.py
+++ b/services/api/app/routes/health.py
@@ -195,8 +195,8 @@ _LLM_SDK_MODULES = {
     # provider -> (module the adapter imports, install extra)
     "openai": ("openai", "openai"),
     "anthropic": ("anthropic", "anthropic"),
-    # Legacy SDK: app/llm/gemini_provider.py imports google.generativeai.
-    "gemini": ("google.generativeai", "gemini"),
+    # app/llm/gemini_provider.py imports `from google import genai` (google-genai).
+    "gemini": ("google.genai", "gemini"),
 }
 
 

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -55,17 +55,17 @@ postgres = [
 # production extra below carries all three.
 openai = ["openai==2.52.0"]
 anthropic = ["anthropic==0.120.2"]
-# NOTE: this is the legacy `google-generativeai` SDK (module `google.generativeai`),
-# not the newer `google-genai` (module `google.genai`). It is pinned to match what
-# app/llm/gemini_provider.py actually imports — pinning the newer package here would
-# install an SDK the adapter cannot use, which is precisely the failure mode this
-# dependency unification exists to prevent. Migrating the adapter to `google-genai`
-# is tracked as follow-up work and needs a live-key test to land safely.
-gemini = ["google-generativeai==0.8.6"]
+# `google-genai` (module `google.genai`) — the supported SDK. The retired
+# `google-generativeai` was replaced once its import began announcing that support
+# had ended; it also spoke gRPC, which the VCR/pytest-recording stack cannot record,
+# so real-provider evidence could not be reproduced in CI. This pin must keep
+# matching what app/llm/gemini_provider.py actually imports: pinning a package the
+# adapter cannot use is the exact failure mode the dependency unification prevents.
+gemini = ["google-genai==2.17.0"]
 providers = [
   "openai==2.52.0",
   "anthropic==0.120.2",
-  "google-generativeai==0.8.6",
+  "google-genai==2.17.0",
 ]
 
 # ── Optional vector backends (ADR-021) ───────────────────────────────────────
@@ -86,7 +86,7 @@ production = [
   "pgvector==0.3.6",
   "openai==2.52.0",
   "anthropic==0.120.2",
-  "google-generativeai==0.8.6",
+  "google-genai==2.17.0",
 ]
 
 dev = [

--- a/services/api/requirements-production.txt
+++ b/services/api/requirements-production.txt
@@ -13,4 +13,4 @@ psycopg[binary]==3.2.3
 pgvector==0.3.6
 openai==2.52.0
 anthropic==0.120.2
-google-generativeai==0.8.6
+google-genai==2.17.0

--- a/services/api/requirements-providers.txt
+++ b/services/api/requirements-providers.txt
@@ -10,4 +10,4 @@
 # [project.optional-dependencies].providers
 openai==2.52.0
 anthropic==0.120.2
-google-generativeai==0.8.6
+google-genai==2.17.0

--- a/services/api/tests/test_gemini_provider.py
+++ b/services/api/tests/test_gemini_provider.py
@@ -1,0 +1,219 @@
+"""The Gemini adapter's contract, pinned across the `google-genai` migration.
+
+`google-genai` is an optional extra and is absent from `requirements-dev.txt`, so CI
+runs these without it installed. Every test therefore injects a fake `google.genai`
+into `sys.modules` rather than importing the real SDK — which also keeps them
+offline, key-free and deterministic. No test here makes a network call.
+
+The migration replaced a retired SDK, and two of its differences are behavioural
+rather than cosmetic; both are asserted below:
+
+* `HttpOptions.timeout` is in **milliseconds**, where the old
+  `request_options={"timeout": …}` took seconds. Forwarding the configured seconds
+  unchanged would turn an 8-second budget into 8 milliseconds.
+* the new client speaks HTTP via `httpx` instead of gRPC, which is what makes
+  provider traffic recordable by the VCR/pytest-recording stack.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+import types as pytypes
+from pathlib import Path
+
+import pytest
+
+from app.llm.base import LLMUnavailableError
+from app.llm.gemini_provider import GeminiProvider
+
+_PROVIDER_SRC = Path(__file__).resolve().parents[1] / "app" / "llm" / "gemini_provider.py"
+
+#: Resolved at import time, before any fixture can shadow `google.genai`.
+_HAS_REAL_SDK = importlib.util.find_spec("google.genai") is not None
+
+
+class _Recorder(dict):
+    """Captures what the adapter passed to the SDK."""
+
+    calls: int = 0
+
+
+@pytest.fixture
+def gemini_sdk(monkeypatch):
+    """Install a fake `google.genai`; return the recorder.
+
+    Behaviour is driven by attributes set on the returned recorder *before* the call:
+    ``text`` (response text), ``fail_times`` (raise N times, then succeed).
+    """
+    rec = _Recorder()
+    rec["text"] = "ok"
+    rec["fail_times"] = 0
+
+    class _Response:
+        def __init__(self, text):
+            self.text = text
+
+    class _Models:
+        def generate_content(self, **kwargs):
+            rec["generate_content"] = kwargs
+            rec.calls += 1
+            if rec.calls <= rec["fail_times"]:
+                raise RuntimeError("transient upstream failure")
+            return _Response(rec["text"])
+
+    class _Client:
+        def __init__(self, **kwargs):
+            rec["client_kwargs"] = kwargs
+            self.models = _Models()
+
+    def _http_options(**kw):
+        rec["http_options"] = kw
+        return kw
+
+    def _generate_config(**kw):
+        rec["generate_config"] = kw
+        return kw
+
+    types_mod = pytypes.ModuleType("google.genai.types")
+    types_mod.HttpOptions = _http_options
+    types_mod.GenerateContentConfig = _generate_config
+
+    genai_mod = pytypes.ModuleType("google.genai")
+    genai_mod.Client = _Client
+    genai_mod.types = types_mod
+
+    google_mod = pytypes.ModuleType("google")
+    google_mod.genai = genai_mod
+
+    monkeypatch.setitem(sys.modules, "google", google_mod)
+    monkeypatch.setitem(sys.modules, "google.genai", genai_mod)
+    monkeypatch.setitem(sys.modules, "google.genai.types", types_mod)
+    return rec
+
+
+def _provider(**kw) -> GeminiProvider:
+    defaults = {
+        "api_key": "test-key-not-real",
+        "model": "gemini-2.5-flash",
+        "timeout": 8.0,
+        "max_retries": 0,
+    }
+    return GeminiProvider(**{**defaults, **kw})
+
+
+# ── construction and wiring ─────────────────────────────────────────────────
+def test_provider_name_is_gemini():
+    assert _provider().name == "gemini"
+
+
+def test_configured_model_is_used(gemini_sdk):
+    _provider(model="gemini-2.0-flash").complete(system="S", user="U")
+    assert gemini_sdk["generate_content"]["model"] == "gemini-2.0-flash"
+
+
+def test_prompt_reaches_the_client(gemini_sdk):
+    _provider().complete(system="SYSTEM-PROMPT", user="USER-MESSAGE")
+    assert gemini_sdk["generate_content"]["contents"] == "USER-MESSAGE"
+    assert gemini_sdk["generate_config"]["system_instruction"] == "SYSTEM-PROMPT"
+
+
+def test_temperature_is_zero_for_determinism(gemini_sdk):
+    _provider().complete(system="S", user="U")
+    assert gemini_sdk["generate_config"]["temperature"] == 0
+
+
+def test_api_key_is_passed_to_the_client(gemini_sdk):
+    _provider(api_key="key-abc").complete(system="S", user="U")
+    assert gemini_sdk["client_kwargs"]["api_key"] == "key-abc"
+
+
+# ── the millisecond trap ────────────────────────────────────────────────────
+@pytest.mark.parametrize(("seconds", "expected_ms"), [(8.0, 8000), (1.5, 1500), (30.0, 30000)])
+def test_timeout_is_converted_from_seconds_to_milliseconds(gemini_sdk, seconds, expected_ms):
+    """`HttpOptions.timeout` is milliseconds; the settings value is seconds.
+
+    Forwarding seconds unchanged would make an 8-second budget an 8-millisecond one
+    and fail every call — a silent, total provider outage that degrades to the
+    heuristic while looking like a provider problem.
+    """
+    _provider(timeout=seconds).complete(system="S", user="U")
+    assert gemini_sdk["http_options"]["timeout"] == expected_ms
+
+
+# ── response parsing ────────────────────────────────────────────────────────
+def test_text_response_is_returned(gemini_sdk):
+    gemini_sdk["text"] = '{"memories": []}'
+    assert _provider().complete(system="S", user="U") == '{"memories": []}'
+
+
+@pytest.mark.parametrize("empty", [None, ""])
+def test_empty_response_becomes_empty_string(gemini_sdk, empty):
+    """`resp.text` can be None; the contract returns `str`, never None."""
+    gemini_sdk["text"] = empty
+    assert _provider().complete(system="S", user="U") == ""
+
+
+# ── error, key and retry handling ───────────────────────────────────────────
+def test_missing_api_key_raises_unavailable_without_calling_the_sdk(gemini_sdk):
+    with pytest.raises(LLMUnavailableError):
+        _provider(api_key="").complete(system="S", user="U")
+    assert gemini_sdk.calls == 0
+
+
+def test_sdk_failure_is_normalised_to_llm_unavailable(gemini_sdk):
+    """Invariant #4: a provider outage degrades, never crashes the chat path."""
+    gemini_sdk["fail_times"] = 99
+    with pytest.raises(LLMUnavailableError):
+        _provider().complete(system="S", user="U")
+
+
+def test_transient_failures_are_retried_per_the_base_contract(gemini_sdk):
+    """`max_retries` is *additional* attempts, so 2 means up to 3 calls."""
+    gemini_sdk["fail_times"] = 2
+    assert _provider(max_retries=2).complete(system="S", user="U") == "ok"
+    assert gemini_sdk.calls == 3
+
+
+def test_retries_are_bounded(gemini_sdk):
+    gemini_sdk["fail_times"] = 99
+    with pytest.raises(LLMUnavailableError):
+        _provider(max_retries=1).complete(system="S", user="U")
+    assert gemini_sdk.calls == 2
+
+
+# ── migration guards ────────────────────────────────────────────────────────
+def test_no_active_legacy_sdk_import_remains():
+    """Prose about the retired SDK is fine; an actual import is not.
+
+    Parsed rather than grepped — the module docstring names `google.generativeai`
+    while explaining why it was replaced, and a substring search would fail on the
+    file's own explanation.
+    """
+    tree = ast.parse(_PROVIDER_SRC.read_text(encoding="utf-8"))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported += [a.name for a in node.names]
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported += [f"{node.module}.{a.name}" for a in node.names]
+    assert not any(n.startswith("google.generativeai") for n in imported), imported
+    assert any("genai" in n for n in imported), imported
+
+
+@pytest.mark.skipif(not _HAS_REAL_SDK, reason="google-genai not installed (optional extra)")
+def test_real_sdk_uses_an_http_transport_vcr_can_record():
+    """The reason for the migration, asserted against the real SDK when present.
+
+    gRPC cannot be recorded by VCR/pytest-recording, so provider evidence could not
+    be replayed in CI. Skipped when the optional extra is absent, which is the CI
+    default.
+    """
+    import inspect
+
+    import google.genai._api_client as api_client
+
+    src = inspect.getsource(api_client)
+    assert "httpx" in src, "google-genai sync client is expected to use httpx"
+    assert "class SyncHttpxClient(httpx.Client)" in src

--- a/services/api/tests/test_gemini_provider.py
+++ b/services/api/tests/test_gemini_provider.py
@@ -30,8 +30,23 @@ from app.llm.gemini_provider import GeminiProvider
 
 _PROVIDER_SRC = Path(__file__).resolve().parents[1] / "app" / "llm" / "gemini_provider.py"
 
+def _real_sdk_installed() -> bool:
+    """Whether the optional `google-genai` extra is present.
+
+    `find_spec("google.genai")` **raises** ModuleNotFoundError when the parent
+    package `google` is absent — it only returns None when the parent exists and the
+    leaf does not. CI installs `requirements-dev.txt`, which carries no provider SDK,
+    so the parent is genuinely missing there and the unguarded call was a collection
+    error that took down the whole suite.
+    """
+    try:
+        return importlib.util.find_spec("google.genai") is not None
+    except ModuleNotFoundError:
+        return False
+
+
 #: Resolved at import time, before any fixture can shadow `google.genai`.
-_HAS_REAL_SDK = importlib.util.find_spec("google.genai") is not None
+_HAS_REAL_SDK = _real_sdk_installed()
 
 
 class _Recorder(dict):

--- a/services/api/tests/test_packaging.py
+++ b/services/api/tests/test_packaging.py
@@ -116,8 +116,8 @@ def test_requirements_files_match_pyproject():
 def test_provider_extras_pin_the_module_each_adapter_imports(pyproject):
     """An extra must install the SDK its adapter actually imports.
 
-    `app/llm/gemini_provider.py` imports `google.generativeai` (the legacy
-    `google-generativeai` distribution), not `google.genai` (`google-genai`).
+    `app/llm/gemini_provider.py` imports `google.genai` (the `google-genai`
+    distribution), not the retired `google.generativeai` (`google-generativeai`).
     Pinning the wrong one installs an SDK the adapter cannot use — a broken extra
     that looks correct.
     """
@@ -125,7 +125,7 @@ def test_provider_extras_pin_the_module_each_adapter_imports(pyproject):
     expected_distribution = {
         "openai": "openai",
         "anthropic": "anthropic",
-        "gemini": "google-generativeai",
+        "gemini": "google-genai",
         "qdrant": "qdrant-client",
         "lancedb": "lancedb",
         "weaviate": "weaviate-client",
@@ -149,7 +149,7 @@ def test_production_extra_covers_postgres_and_all_providers(pyproject):
         "pgvector",
         "openai",
         "anthropic",
-        "google-generativeai",
+        "google-genai",
     ):
         assert any(name.startswith(required) for name in production), (
             f"production extra is missing {required}: {sorted(production)}"

--- a/services/api/tests/test_production_profile.py
+++ b/services/api/tests/test_production_profile.py
@@ -109,7 +109,7 @@ def test_production_rejects_llm_provider_without_sdk(monkeypatch):
 
 
 def test_production_gemini_checks_the_module_the_adapter_imports(monkeypatch):
-    """The adapter imports `google.generativeai` (legacy SDK), not `google.genai`.
+    """The adapter imports `google.genai`, not the retired `google.generativeai`.
 
     Guards against the extras pinning a package whose module the adapter can't use.
     """
@@ -122,7 +122,7 @@ def test_production_gemini_checks_the_module_the_adapter_imports(monkeypatch):
 
     monkeypatch.setattr(importlib.util, "find_spec", fake)
     _hardened(llm_provider="gemini", gemini_api_key="k").production_readiness_errors()
-    assert "google.generativeai" in seen
+    assert "google.genai" in seen
 
 
 def test_production_rejects_openai_embeddings_without_key_or_sdk(monkeypatch):

--- a/services/api/tests/test_readiness_truthfulness.py
+++ b/services/api/tests/test_readiness_truthfulness.py
@@ -82,7 +82,7 @@ def test_gemini_probe_uses_the_module_the_adapter_imports(monkeypatch):
     seen: list[str] = []
     monkeypatch.setattr(health, "_module_missing", lambda m: seen.append(m) or False)
     health._check_llm_provider(_settings(llm_provider="gemini", gemini_api_key="k"))
-    assert seen == ["google.generativeai"]
+    assert seen == ["google.genai"]
 
 
 # ── embedding provider ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Scope

Migrates the Gemini provider from the retired `google-generativeai` SDK to the
supported `google-genai` SDK while preserving the existing MemoryOps provider
contract.

This is a prerequisite for making the existing Gemini extraction-quality evidence
recordable and reproducible in CI.

## Changes

- replace `google-generativeai` with `google-genai`
- keep the Gemini provider synchronous
- preserve the existing provider interface and model configuration
- preserve prompt and extraction behavior
- update dependency mirrors through the repository sync tooling
- update provider/readiness module detection for the new SDK
- add focused Gemini provider equivalence tests
- update existing dependency/provider documentation in place

## Why now

Importing the old SDK prints *"All support for the `google.generativeai` package has
ended"*. It also spoke **gRPC** by default, and VCR records **HTTP** — so the
real-provider extraction evidence in `benchmark/EXTRACTION_QUALITY.md` could not be
replayed in CI no matter how the tests were written. `google-genai`'s sync client is
`SyncHttpxClient(httpx.Client)`, which the existing pytest-recording/VCR stack can
record. One change fixes both problems.

## Important compatibility fix

`google-genai`'s `HttpOptions.timeout` uses **milliseconds**, while the previous SDK
configuration was expressed in **seconds**.

Passing the existing value through unchanged would have turned the configured
8-second timeout into roughly 8 milliseconds and caused real Gemini calls to fail
while potentially degrading into fallback behavior — a silent, total provider outage
that would have looked like a provider fault rather than a bug here.

The provider now performs an explicit seconds-to-milliseconds conversion, covered by
three parametrised tests.

## Note on the module-name references

The module the adapter imports is named in four other places — the production
readiness check, the readiness probe, the CI extras matrix, and the dependabot group.
All were updated together, because the purpose of that correspondence is that an
extra can never install an SDK its adapter cannot use.

## Test design

`google-genai` is an optional extra, absent from `requirements-dev.txt`, so CI runs
without it. The new tests inject a fake `google.genai` into `sys.modules` rather than
importing the real SDK — offline, key-free, deterministic, no network calls. The one
test that touches the real SDK (asserting the httpx transport that motivated this
migration) skips when the extra is not installed.

The legacy-import guard parses the AST rather than grepping: the provider's own
docstring names `google.generativeai` while explaining why it was replaced, and a
substring search would fail on that explanation.

## Verification

- Gemini provider tests: **17 passed**
- affected existing tests: 63 passed, 2 pre-existing skips
- full API suite: **1136 collected, exit 0** (was 1119; +17 = the new file)
- Ruff: clean
- dependency mirrors: current
- trust guards: 5 clean
- eval harness: PASS
- governance benchmark: 50/50
- SDK tests: 25
- paper harness: 54
- PR invariant gate: PASS
- `git diff --check`: clean
- gitleaks: clean
- clean install of `.[gemini]` installs `google-genai==2.17.0` only; legacy distribution absent
- offline extraction result unchanged:
  - precision 1.00
  - recall 0.53
  - F1 0.69

## Runtime impact

The Gemini SDK implementation changes from the retired SDK to the supported SDK.

The following remain unchanged:

- public MemoryOps API
- provider selection semantics
- model default
- extraction prompt/schema
- retry envelope
- gateway behavior
- storage/retrieval behavior
- authentication/authorization
- Railway configuration

No async migration is included. No provider cassette is included.

The recorded Gemini evidence work follows in a separate PR after this migration is
merged.