### PR TITLE
fix(llm): enforce Gemini minimum request deadline

### DIFF
--- a/services/api/app/llm/gemini_provider.py
+++ b/services/api/app/llm/gemini_provider.py
@@ -12,6 +12,10 @@ the move are load-bearing rather than cosmetic:
   ``request_options={"timeout": …}`` took seconds. Passing the configured seconds
   through unchanged would have turned an 8-second budget into 8 milliseconds and
   failed every call.
+* The deadline is now **sent to the server**, which enforces a 10-second minimum.
+  Under gRPC it was applied client-side, so the repository's 8-second default was
+  accepted; over REST it is rejected with ``400 INVALID_ARGUMENT`` and every call
+  degrades to the heuristic. See ``GEMINI_MIN_DEADLINE_SECONDS``.
 * The new client speaks HTTP over ``httpx`` rather than gRPC, so provider traffic is
   recordable by the VCR/pytest-recording stack the repository already depends on.
   That is what makes real-provider extraction evidence reproducible in CI.
@@ -21,6 +25,16 @@ from __future__ import annotations
 
 from .providers import BaseNetworkProvider
 
+#: Gemini's REST API rejects a manually supplied deadline below this, with
+#: ``400 INVALID_ARGUMENT: Manually set deadline 8s is too short. Minimum allowed
+#: deadline is 10s``. The retired gRPC SDK applied the deadline client-side only, so
+#: the repository's 8-second default worked and this constraint was invisible; the
+#: REST transport sends it to the server, which validates it.
+#:
+#: Provider-local on purpose. It is a Gemini API rule, not a MemoryOps policy, so
+#: `llm_timeout_seconds` keeps its meaning for OpenAI and Anthropic.
+GEMINI_MIN_DEADLINE_SECONDS = 10.0
+
 
 class GeminiProvider(BaseNetworkProvider):
     name = "gemini"
@@ -29,10 +43,13 @@ class GeminiProvider(BaseNetworkProvider):
         from google import genai
         from google.genai import types
 
+        # Raise the configured deadline to Gemini's floor; never lower a longer one.
+        effective_timeout_seconds = max(self._timeout, GEMINI_MIN_DEADLINE_SECONDS)
+
         client = genai.Client(
             api_key=self._api_key,
             # Seconds -> milliseconds; see the module docstring.
-            http_options=types.HttpOptions(timeout=int(self._timeout * 1000)),
+            http_options=types.HttpOptions(timeout=int(effective_timeout_seconds * 1000)),
         )
         resp = client.models.generate_content(
             model=self._model,

--- a/services/api/tests/test_gemini_provider.py
+++ b/services/api/tests/test_gemini_provider.py
@@ -26,7 +26,7 @@ from pathlib import Path
 import pytest
 
 from app.llm.base import LLMUnavailableError
-from app.llm.gemini_provider import GeminiProvider
+from app.llm.gemini_provider import GEMINI_MIN_DEADLINE_SECONDS, GeminiProvider
 
 _PROVIDER_SRC = Path(__file__).resolve().parents[1] / "app" / "llm" / "gemini_provider.py"
 
@@ -145,16 +145,78 @@ def test_api_key_is_passed_to_the_client(gemini_sdk):
 
 
 # ── the millisecond trap ────────────────────────────────────────────────────
-@pytest.mark.parametrize(("seconds", "expected_ms"), [(8.0, 8000), (1.5, 1500), (30.0, 30000)])
+@pytest.mark.parametrize(("seconds", "expected_ms"), [(12.5, 12500), (30.0, 30000), (60.0, 60000)])
 def test_timeout_is_converted_from_seconds_to_milliseconds(gemini_sdk, seconds, expected_ms):
     """`HttpOptions.timeout` is milliseconds; the settings value is seconds.
 
-    Forwarding seconds unchanged would make an 8-second budget an 8-millisecond one
+    Forwarding seconds unchanged would make a 30-second budget a 30-millisecond one
     and fail every call — a silent, total provider outage that degrades to the
     heuristic while looking like a provider problem.
+
+    Values here are all above `GEMINI_MIN_DEADLINE_SECONDS` so this asserts the
+    conversion alone; the floor is covered separately below.
     """
     _provider(timeout=seconds).complete(system="S", user="U")
     assert gemini_sdk["http_options"]["timeout"] == expected_ms
+
+
+# ── Gemini's server-side minimum deadline ───────────────────────────────────
+@pytest.mark.parametrize(
+    ("configured_seconds", "expected_ms"),
+    [
+        (8.0, 10_000),      # the repository default — rejected by Gemini before the floor
+        (1.5, 10_000),
+        (9.999, 10_000),    # just under
+        (10.0, 10_000),     # exactly at
+        (12.5, 12_500),     # above: must NOT be reduced
+        (30.0, 30_000),
+    ],
+)
+def test_deadline_is_raised_to_geminis_minimum_but_never_lowered(
+    gemini_sdk, configured_seconds, expected_ms
+):
+    """Gemini REST rejects deadlines under 10s; the provider raises them to the floor.
+
+    This is the regression the `google-genai` migration introduced. The retired gRPC
+    SDK applied the deadline client-side, so `llm_timeout_seconds = 8.0` worked. Over
+    REST the deadline is sent to the server, which answers
+    `400 INVALID_ARGUMENT: Manually set deadline 8s is too short`. Every call then
+    failed and degraded to the heuristic — silently, because invariant #4 means a
+    provider outage never crashes the chat path.
+
+    Found by a live recording attempt in which all 25 turns returned
+    `mode="heuristic"` and zero structured extractions.
+    """
+    _provider(timeout=configured_seconds).complete(system="S", user="U")
+    assert gemini_sdk["http_options"]["timeout"] == expected_ms
+
+
+def test_the_repository_default_timeout_clears_geminis_floor(gemini_sdk):
+    """Guards the specific value that broke: `Settings.llm_timeout_seconds` is 8.0."""
+    from app.core.config import Settings
+
+    default_seconds = Settings().llm_timeout_seconds
+    assert default_seconds < GEMINI_MIN_DEADLINE_SECONDS, (
+        "this test exists because the default is below Gemini's floor; if the default "
+        "is raised, keep the floor but retire this guard"
+    )
+    _provider(timeout=default_seconds).complete(system="S", user="U")
+    sent_ms = gemini_sdk["http_options"]["timeout"]
+    assert sent_ms == int(GEMINI_MIN_DEADLINE_SECONDS * 1000)
+    assert sent_ms >= 10_000, "Gemini rejects any deadline below 10s"
+
+
+def test_the_floor_is_gemini_local_and_not_a_global_policy():
+    """The floor must not leak into the shared timeout contract.
+
+    `llm_timeout_seconds` keeps its meaning for OpenAI and Anthropic; this is a
+    Gemini API rule, not a MemoryOps one.
+    """
+    from app.core.config import Settings
+
+    assert Settings().llm_timeout_seconds == 8.0, (
+        "global default changed — the Gemini floor was meant to avoid exactly that"
+    )
 
 
 # ── response parsing ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Scope

Fixes a Gemini-specific regression introduced by the migration from the retired
`google-generativeai` SDK to `google-genai`.

The repository's default LLM timeout is 8 seconds. The new Gemini REST client sends
that deadline to the Gemini API, which rejects manually configured deadlines below
10 seconds with `400 INVALID_ARGUMENT`.

As a result, every real Gemini extraction using the repository default silently
degraded to the deterministic heuristic through the existing fallback boundary.

## Root cause

The timeout conversion itself was correct — seconds -> milliseconds — but the
**transport semantics changed**.

The old gRPC SDK applied the configured 8-second deadline **client-side**. The new
REST path **transmits** it to Gemini, whose minimum accepted manual deadline is 10
seconds:

```
400 INVALID_ARGUMENT
Manually set deadline 8s is too short. Minimum allowed deadline is 10s.
```

Nothing crashed, because a provider outage degrades to the heuristic (invariant #4).
So a deployment configured for Gemini quietly stopped using it and kept answering.

## How it was found — and why nothing caught it

Discovered while attempting the recorded-evidence run: all 25 dataset turns returned
`mode="heuristic"`, zero structured extractions, and 75 HTTP 400s (25 turns × 3
attempts from the existing retry envelope).

The **zero-fallback assertion** is what caught it. Request count alone looked
plausible — 75 requests to Gemini, responses recorded, a score produced. Only
`ExtractionOutcome.mode` revealed that none of it came from the model.

Worth stating plainly: the migration shipped with 31 green CI checks and 1136 passing
tests while the provider was fully non-functional. `/readyz` verifies only that the
SDK imports, and no test made a real provider call.

## Fix

A provider-local minimum deadline, applied before the millisecond conversion:

```python
GEMINI_MIN_DEADLINE_SECONDS = 10.0
effective_timeout_seconds = max(self._timeout, GEMINI_MIN_DEADLINE_SECONDS)
HttpOptions(timeout=int(effective_timeout_seconds * 1000))
```

Provider-local on purpose: 10 seconds is a **Gemini API rule**, not a MemoryOps
policy, so `llm_timeout_seconds` keeps its meaning for OpenAI and Anthropic. A
configured value above the floor is never lowered.

## Verification

### Timeout mapping

| Configured | Transmitted |
|---|---|
| 1.5 s | 10 000 ms |
| 8.0 s (repo default) | 10 000 ms |
| 9.999 s | 10 000 ms |
| 10.0 s | 10 000 ms |
| 12.5 s | 12 500 ms — not reduced |
| 30.0 s | 30 000 ms |

### Automated

- Gemini provider tests: **25 passed** (17 → 25)
- full API suite: **1144 collected, exit 0**
- Ruff: clean
- dependency drift: current
- trust guards: 5 clean
- eval harness: PASS
- governance benchmark: 50/50
- SDK: 25
- paper harness: 54
- PR invariant gate: PASS
- `git diff --check`: clean
- gitleaks: clean

### Real-provider preflight

One live `gemini-2.5-flash` extraction through the real MemoryOps path
(`build_llm_provider` → `extract_memories` → `GeminiProvider` → `google-genai`):

- provider interactions: **1**
- provider: **gemini**
- mode: **structured**
- fallback: **0**
- errors: **0**
- memories extracted: 1

No cassette was recorded. No secret printed.

This is the evidence that the default 8-second configuration no longer fails closed
into heuristic fallback.

## Runtime impact

Gemini requests configured below the provider's 10-second minimum now use a
10-second effective deadline.

No changes to: public API · global timeout default · OpenAI timeout · Anthropic
timeout · retries · prompts · extraction schemas · model defaults · gateway · storage
· authentication/authorization · Railway configuration · async architecture.

## Follow-up

Retry classification is deliberately out of scope.

The failed evidence run also showed that deterministic provider `400` responses are
retried three times by the shared retry envelope. Retrying a permanent client error
is wasteful and inflates any future recording budget — it should be reviewed
separately so permanent client errors are not retried.

The recorded Gemini extraction-evidence PR resumes only after this fix is merged.