### PR TITLE
test(extraction): make Gemini evidence reproducible in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,53 @@ jobs:
           MEMORYOPS_STORAGE: memory
         run: python evals/run_evals.py
 
+      # ── Recorded real-provider Gemini evidence ────────────────────────────────
+      # benchmark/EXTRACTION_QUALITY.md publishes a real gemini-2.5-flash score. This
+      # replays the committed cassette so that number is regenerated rather than
+      # remembered — with no Gemini credential and no network.
+      #
+      # The optional extra is installed HERE and not in requirements-dev.txt on
+      # purpose: the base suite must keep running without any provider SDK, which is
+      # what caught an earlier module-level collection error.
+      #
+      # `--block-network` makes an unrecorded request a failure rather than a silent
+      # live call. `-p no:randomly`-style ordering is irrelevant because the cassette
+      # matches on request body, not sequence.
+      - name: Install the Gemini extra (for replay only)
+        working-directory: services/api
+        run: python -m pip install ".[gemini]"
+
+      # A skip here is a failure. Without this the step could pass while proving
+      # nothing — exactly how the evidence gap arose in the first place.
+      - name: Recorded Gemini extraction evidence (no key, no network)
+        working-directory: services/api
+        env:
+          MEMORYOPS_STORAGE: memory
+        run: |
+          set -euo pipefail
+          # Guarantee no real credential is visible to the test.
+          unset GEMINI_API_KEY GOOGLE_API_KEY || true
+          python -m pytest tests/test_extraction_evidence_gemini.py \
+            --record-mode=none --block-network \
+            -p no:cacheprovider -rs --strict-markers \
+            --junitxml=/tmp/gemini-evidence.xml
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+          suite = ET.parse("/tmp/gemini-evidence.xml").getroot()
+          case = next(
+              (c for c in suite.iter("testcase")
+               if c.get("name") == "test_extraction_quality_real_gemini"),
+              None,
+          )
+          assert case is not None, "the evidence test did not run at all"
+          skipped = case.find("skipped")
+          assert skipped is None, (
+              "the recorded Gemini evidence test SKIPPED — it must execute here. "
+              f"reason: {skipped.get('message') if skipped is not None else ''}"
+          )
+          print("recorded Gemini evidence executed (not skipped)")
+          PY
+
   api-postgres:
     name: API — full suite + evals + benchmark + enforced RLS on Postgres + pgvector
     runs-on: ubuntu-latest

--- a/benchmark/EXTRACTION_QUALITY.md
+++ b/benchmark/EXTRACTION_QUALITY.md
@@ -3,24 +3,92 @@
 | Provider | Precision | Recall | F1 | No-op handled | Multi-memory turns |
 | --- | --- | --- | --- | --- | --- |
 | stub | 1.00 | 0.53 | 0.69 | 3/3 | 4/9 |
-| gemini-2.5-flash | 0.94 | 0.94 | 0.94 | 3/3 | 7/9 |
+| gemini-2.5-flash | 0.97 | 0.94 | 0.95 | 3/3 | 7/9 |
 
 > **The gap is the point.** The offline **stub** is high-precision (1.00) but
 > low-recall (0.53) and can only split **4 of 9** compound "multi-memory" turns — it
-> misses roughly half the facts a real model captures. A real model (**gemini-2.5-flash**)
-> nearly doubles recall to **0.94** and handles **7 of 9** multi-memory turns, at a
-> small, honest precision cost (0.94 — it occasionally over-extracts). This is why the
-> stub is a *reproducible test fixture, not the product*: it keeps CI offline and
-> deterministic, but the flagship capability (governed extraction quality) requires a
-> real model, and now that is measured rather than asserted.
->
-> **Reproduce** (the gemini row was produced from a live run, 0 fallbacks):
-> ```bash
-> set -a; source .env; set +a           # GEMINI_API_KEY=...
-> MEMORYOPS_LLM_PROVIDER=gemini GEMINI_MODEL=gemini-2.5-flash \
->   PYTHONPATH=services/api python evals/run_extraction_quality.py \
->   --provider stub gemini --md benchmark/EXTRACTION_QUALITY.md
-> ```
-> Runs offline for `stub`; `--provider openai anthropic gemini` fills in more rows
-> when their keys are set. Note `gemini-1.5-flash` has been retired — use a current
-> model (`gemini-2.5-flash`, `gemini-2.0-flash`, or `gemini-flash-latest`).
+> misses roughly half the facts a real model captures. The recorded
+> **gemini-2.5-flash** run reaches **0.97 precision / 0.94 recall / 0.95 F1**, handles
+> all **3/3** no-op turns correctly, and splits **7 of 9** multi-memory turns. This is
+> why the stub is a *reproducible test fixture, not the product*: it keeps CI offline
+> and deterministic, but the flagship capability — governed extraction quality —
+> requires a real model, and that is now measured and replayable rather than asserted.
+
+## Recorded evidence
+
+The Gemini row is not a remembered number. It is regenerated in CI from a committed
+recording of a real provider run:
+
+- **model:** `gemini-2.5-flash`
+- **dataset:** 25 labeled turns (`evals/datasets/extraction_golden.jsonl`)
+- **real provider interactions:** 25 (25 × HTTP 200)
+- **structured outcomes:** 25
+- **heuristic fallbacks:** 0
+- **strict-empty fallbacks:** 0
+- **provider errors:** 0
+- **raw counts:** `tp=30`, `extracted=31`, `covered=32`, `expected=34`
+- **cassette:** `services/api/tests/cassettes/test_extraction_quality_real_gemini.yaml`
+- **replay:** requires **no** Gemini API key and **no** network access
+
+Extraction *mode* is asserted, not inferred. `extract_memories` falls back to the
+deterministic heuristic whenever a provider call fails (invariant #4), so a headline
+"real provider" score can be partly stub while still issuing 25 HTTP requests. Every
+turn is checked for `mode == "structured"`; 25 requests is not evidence of 25
+structured extractions.
+
+### What this does and does not claim
+
+It claims the committed run **regenerates deterministically**: the same responses, the
+same score, on any machine, with no credential.
+
+It does **not** claim that a new live Gemini call will produce 0.97 / 0.94 / 0.95.
+Hosted-model outputs can vary over time; a cassette is a record, not a forecast.
+
+## Reproduce
+
+Primary path — offline replay, no API key, no network:
+
+```bash
+cd services/api
+pip install -r requirements-dev.txt
+pip install ".[gemini]"
+pytest tests/test_extraction_evidence_gemini.py --record-mode=none --block-network
+```
+
+The `google-genai` SDK is required (replay exercises the real Gemini adapter); a real
+**credential** is not. This is what CI runs.
+
+Score the offline stub for comparison:
+
+```bash
+PYTHONPATH=services/api python evals/run_extraction_quality.py --provider stub
+```
+
+### Optional maintenance: re-recording
+
+Re-recording is **not** the reproduction path and is not run in CI. It needs a live
+key, spends provider quota, and produces new provider outputs that may score
+differently:
+
+```bash
+cd services/api
+GEMINI_API_KEY=<set-in-environment> MEMORYOPS_LLM_PROVIDER=gemini GEMINI_MODEL=gemini-2.5-flash \
+  pytest tests/test_extraction_evidence_gemini.py::test_extraction_quality_real_gemini \
+  --record-mode=once
+```
+
+Do not overwrite the canonical cassette casually. A replacement recording changes the
+published evidence and must be reviewed as such — including re-checking it for
+credential material before it is committed (see `services/api/tests/cassettes/README.md`).
+
+## Historical note
+
+An earlier live `gemini-2.5-flash` run produced **0.94 precision / 0.94 recall /
+0.94 F1**, with 3/3 no-op and 7/9 multi-memory. Its provider responses were not
+recorded, so that run cannot be replayed. The committed recorded run above is
+therefore the canonical reproducible evidence.
+
+The earlier result is not invalid — it was a real observed measurement. It is simply
+non-replayable, and superseded as canonical evidence by a run that can be re-executed.
+The available artifacts do not establish the cause of the difference between the two
+runs.

--- a/evals/run_extraction_quality.py
+++ b/evals/run_extraction_quality.py
@@ -65,6 +65,13 @@ class Score:
     multi_ok: int = 0      # compound turns where >=2 memories were extracted
     multi_total: int = 0
     errors: list[str] = field(default_factory=list)
+    #: ExtractionOutcome.mode -> count ("structured" | "heuristic" | "strict_empty").
+    #: A real-provider score is only real-provider evidence if every turn was
+    #: structured: the heuristic fallback (invariant #4) silently rescues a failed
+    #: provider call, so a headline number can otherwise be part stub. Counting the
+    #: runtime's own signal is the only way to tell — 25 HTTP requests do not imply
+    #: 25 structured extractions.
+    modes: dict[str, int] = field(default_factory=dict)
 
     @property
     def precision(self) -> float:
@@ -88,11 +95,11 @@ def _build_provider(provider_name: str):
     return build_llm_provider(Settings(llm_provider=provider_name))
 
 
-def _extract(provider, settings, message: str) -> list[str]:
+def _extract(provider, settings, message: str):
+    """Return the full ``ExtractionOutcome`` so callers can see ``mode``/``provider``."""
     from app.llm import extract_memories
 
-    outcome = extract_memories(provider, message, settings=settings)
-    return [m.content for m in outcome.memories]
+    return extract_memories(provider, message, settings=settings)
 
 
 def score_provider(provider_name: str, cases: list[dict]) -> Score:
@@ -104,10 +111,12 @@ def score_provider(provider_name: str, cases: list[dict]) -> Score:
     for case in cases:
         facts = case.get("expected_facts", [])
         try:
-            contents = _extract(provider, settings, case["message"])
+            outcome = _extract(provider, settings, case["message"])
         except Exception as exc:  # noqa: BLE001 — record, keep scoring
             s.errors.append(f"{case['id']}: {type(exc).__name__}")
             continue
+        contents = [m.content for m in outcome.memories]
+        s.modes[outcome.mode] = s.modes.get(outcome.mode, 0) + 1
         s.extracted += len(contents)
         s.expected += len(facts)
         s.covered += sum(1 for f in facts if _covers(f, contents))

--- a/services/api/tests/cassettes/README.md
+++ b/services/api/tests/cassettes/README.md
@@ -1,22 +1,96 @@
-# Recorded provider cassettes (P1.1)
+# Recorded provider cassettes
 
 VCR.py cassettes (via `pytest-recording`) that let CI replay **real** LLM-provider
 responses deterministically, with no API key and no network.
 
-## Recording a cassette (one time, with a key)
+## Cassettes here
+
+| Cassette | Test | Status |
+|---|---|---|
+| `test_extraction_quality_real_gemini.yaml` | `tests/test_extraction_evidence_gemini.py` | **required** — CI fails if missing or if it skips |
+| *(none)* | `tests/test_provider_recorded.py` (OpenAI, Anthropic) | optional — those tests skip without a cassette or key |
+
+## Replay (the normal path)
+
+Offline, no credential, no network. This is what CI runs:
 
 ```bash
 cd services/api
-OPENAI_API_KEY=sk-...    pytest tests/test_provider_recorded.py::test_extraction_real_openai_multi    --record-mode=once
-ANTHROPIC_API_KEY=sk-... pytest tests/test_provider_recorded.py::test_extraction_real_anthropic_multi --record-mode=once
+pip install -r requirements-dev.txt
+pip install ".[gemini]"
+pytest tests/test_extraction_evidence_gemini.py --record-mode=none --block-network
 ```
 
-This writes `<test_name>.yaml` here. The `authorization` / `x-api-key` headers are
-scrubbed (see the `@pytest.mark.vcr(filter_headers=...)` on each test), so it is safe
-to commit. Commit the `.yaml` files.
+The provider **SDK** is required — replay exercises the real adapter, which is the
+point. A real **credential** is not: provider construction only needs a non-empty
+string, so the test injects an obvious non-secret placeholder.
 
-## Behavior without a cassette
+## Recording (one-time, live, credential required)
 
-The tests SKIP when neither a cassette nor the relevant API key is present, so the
-default CI run stays green and offline. Once a cassette is committed, CI replays it
-with `--record-mode=none` and the test runs for real.
+Recording spends provider quota and produces new outputs that may score differently
+from the committed run. It is deliberately not part of CI or the reproduction path.
+
+```bash
+cd services/api
+GEMINI_API_KEY=<set-in-environment> MEMORYOPS_LLM_PROVIDER=gemini GEMINI_MODEL=gemini-2.5-flash \
+  pytest tests/test_extraction_evidence_gemini.py::test_extraction_quality_real_gemini \
+  --record-mode=once
+```
+
+## Credential filtering — what is actually scrubbed
+
+Configured in the `vcr_config` fixture on the test module. Values are **removed**, not
+masked; a partially masked key is still a leak.
+
+Request headers:
+
+- `x-goog-api-key` — how `google-genai` sends an API key
+- `authorization` — its OAuth/token paths, and other providers' bearer credentials
+- `x-api-key`, `api-key` — other provider conventions
+- `x-goog-api-client` — client fingerprint, not a credential but not needed either
+
+Query parameters:
+
+- `key` — the Gemini REST API also accepts a query-string credential; filtered
+  defensively even though the current SDK sends a header
+
+> Do not assume `authorization` is the only credential surface. Inspect what the SDK
+> actually sends before recording a new provider — for Gemini it is `x-goog-api-key`,
+> and a filter list copied from another provider would have committed a live key.
+
+## Before committing a cassette
+
+`tests/test_extraction_evidence_gemini.py` enforces these automatically, and they run
+in the base suite even where the provider SDK is absent:
+
+- interaction count matches the dataset (retries would inflate it)
+- every recorded response is HTTP 200 — a cassette of errors is not provider evidence
+- no Google API-key-shaped string
+- no bearer credential material
+- no unsanitized `x-goog-api-key` / `authorization` / `x-api-key` / `api-key`
+- no `key=` query credential
+- **the cassette does not contain the live `GEMINI_API_KEY`**, compared directly
+  against the environment when one is present — the value is never printed, only
+  whether it appears
+
+Also run the repository secret scan before staging:
+
+```bash
+gitleaks detect --no-git --source services/api/tests/cassettes/
+```
+
+If any credential material is found: **delete the cassette, do not commit it**, and
+re-record with the filters corrected.
+
+## Request matching
+
+The Gemini cassette holds 25 interactions against the same endpoint. Matching includes
+the **request body**, so replay pairs each prompt with its own recorded response.
+Ordering alone would silently mis-pair prompts and responses if the suite were
+reordered or partially run. Credential-bearing headers are deliberately not matched on.
+
+## Cassette layout
+
+Cassettes live flat in this directory. `pytest-recording` defaults to
+`cassettes/<module>/<test>.yaml`; the Gemini test overrides `vcr_cassette_dir` to keep
+the flat convention this directory already used.

--- a/services/api/tests/cassettes/test_extraction_quality_real_gemini.yaml
+++ b/services/api/tests/cassettes/test_extraction_quality_real_gemini.yaml
@@ -1,0 +1,2224 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Remember I prefer dark mode in all my
+      apps."}], "role": "user"}], "systemInstruction": {"parts": [{"text": "# Memory
+      Extraction Prompt (v0.4)\n\nYou are the memory extraction component of MemoryOps
+      AI, a governed memory\nlifecycle system. Given a single user message, identify
+      durable facts worth\nremembering: stable preferences, constraints, project context,
+      and explicit\n\"remember this\" requests. Ignore questions, chit-chat, and ephemeral
+      details.\n\nYou do not make storage or safety decisions. A deterministic policy
+      broker runs\nafter you and is authoritative \u2014 never assume your output
+      will be stored as-is,\nand never attempt to bypass safety rules. Do not invent
+      facts the user did not\nstate. Do not extract secrets (API keys, passwords,
+      tokens); the policy broker\nblocks them regardless.\n\nReturn ONLY a JSON object
+      matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1820'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"User prefers dark mode in all applications.\\\",\\n
+        \     \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\": 9,\\n
+        \     \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a durable UI preference.\\\"\\n
+        \   }\\n  ]\\n}\\n```\"\n          }\n        ],\n        \"role\": \"model\"\n
+        \     },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n
+        \ \"usageMetadata\": {\n    \"promptTokenCount\": 388,\n    \"candidatesTokenCount\":
+        87,\n    \"totalTokenCount\": 610,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 388\n      }\n    ],\n
+        \   \"thoughtsTokenCount\": 135,\n    \"serviceTier\": \"standard\"\n  },\n
+        \ \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"q_p5at_4L5b3jrEPyKuH-A0\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '896'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:05 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1466
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "I always take the window seat on flights."}],
+      "role": "user"}], "systemInstruction": {"parts": [{"text": "# Memory Extraction
+      Prompt (v0.4)\n\nYou are the memory extraction component of MemoryOps AI, a
+      governed memory\nlifecycle system. Given a single user message, identify durable
+      facts worth\nremembering: stable preferences, constraints, project context,
+      and explicit\n\"remember this\" requests. Ignore questions, chit-chat, and ephemeral
+      details.\n\nYou do not make storage or safety decisions. A deterministic policy
+      broker runs\nafter you and is authoritative \u2014 never assume your output
+      will be stored as-is,\nand never attempt to bypass safety rules. Do not invent
+      facts the user did not\nstate. Do not extract secrets (API keys, passwords,
+      tokens); the policy broker\nblocks them regardless.\n\nReturn ONLY a JSON object
+      matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1818'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"User prefers window seats on flights.\\\",\\n
+        \     \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\": 8,\\n
+        \     \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a consistent travel preference.\\\"\\n
+        \   }\\n  ]\\n}\\n```\"\n          }\n        ],\n        \"role\": \"model\"\n
+        \     },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n
+        \ \"usageMetadata\": {\n    \"promptTokenCount\": 387,\n    \"candidatesTokenCount\":
+        86,\n    \"totalTokenCount\": 591,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 387\n      }\n    ],\n
+        \   \"thoughtsTokenCount\": 118,\n    \"serviceTier\": \"standard\"\n  },\n
+        \ \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"rfp5araMEc7-jrEPp6vMCA\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '896'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:06 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1319
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "I''m building a Next.js analytics dashboard
+      for my startup."}], "role": "user"}], "systemInstruction": {"parts": [{"text":
+      "# Memory Extraction Prompt (v0.4)\n\nYou are the memory extraction component
+      of MemoryOps AI, a governed memory\nlifecycle system. Given a single user message,
+      identify durable facts worth\nremembering: stable preferences, constraints,
+      project context, and explicit\n\"remember this\" requests. Ignore questions,
+      chit-chat, and ephemeral details.\n\nYou do not make storage or safety decisions.
+      A deterministic policy broker runs\nafter you and is authoritative \u2014 never
+      assume your output will be stored as-is,\nand never attempt to bypass safety
+      rules. Do not invent facts the user did not\nstate. Do not extract secrets (API
+      keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1835'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"The user is building a Next.js analytics
+        dashboard for their startup.\\\",\\n      \\\"type\\\": \\\"project\\\",\\n
+        \     \\\"importance\\\": 7,\\n      \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\":
+        \\\"low\\\",\\n      \\\"rationale\\\": \\\"User stated they are building
+        a specific project, which is important context.\\\"\\n    }\\n  ]\\n}\\n```\"\n
+        \         }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
+        \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        392,\n    \"candidatesTokenCount\": 99,\n    \"totalTokenCount\": 619,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 392\n
+        \     }\n    ],\n    \"thoughtsTokenCount\": 128,\n    \"serviceTier\": \"standard\"\n
+        \ },\n  \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"rvp5arXrMeyOjMcPkZOnuQ4\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '949'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:08 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1339
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Never use emojis when you answer me."}],
+      "role": "user"}], "systemInstruction": {"parts": [{"text": "# Memory Extraction
+      Prompt (v0.4)\n\nYou are the memory extraction component of MemoryOps AI, a
+      governed memory\nlifecycle system. Given a single user message, identify durable
+      facts worth\nremembering: stable preferences, constraints, project context,
+      and explicit\n\"remember this\" requests. Ignore questions, chit-chat, and ephemeral
+      details.\n\nYou do not make storage or safety decisions. A deterministic policy
+      broker runs\nafter you and is authoritative \u2014 never assume your output
+      will be stored as-is,\nand never attempt to bypass safety rules. Do not invent
+      facts the user did not\nstate. Do not extract secrets (API keys, passwords,
+      tokens); the policy broker\nblocks them regardless.\n\nReturn ONLY a JSON object
+      matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1813'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"The user prefers that I never use emojis
+        in my responses.\\\",\\n      \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\":
+        9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a preference for interaction
+        style.\\\"\\n    }\\n  ]\\n}\\n```\"\n          }\n        ],\n        \"role\":
+        \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n
+        \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 386,\n    \"candidatesTokenCount\":
+        92,\n    \"totalTokenCount\": 630,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 386\n      }\n    ],\n
+        \   \"thoughtsTokenCount\": 152,\n    \"serviceTier\": \"standard\"\n  },\n
+        \ \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"sPp5arrODdbj-sAPsODtyAc\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '921'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:09 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1536
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "I''m vegetarian and my sister Mia is
+      allergic to peanuts."}], "role": "user"}], "systemInstruction": {"parts": [{"text":
+      "# Memory Extraction Prompt (v0.4)\n\nYou are the memory extraction component
+      of MemoryOps AI, a governed memory\nlifecycle system. Given a single user message,
+      identify durable facts worth\nremembering: stable preferences, constraints,
+      project context, and explicit\n\"remember this\" requests. Ignore questions,
+      chit-chat, and ephemeral details.\n\nYou do not make storage or safety decisions.
+      A deterministic policy broker runs\nafter you and is authoritative \u2014 never
+      assume your output will be stored as-is,\nand never attempt to bypass safety
+      rules. Do not invent facts the user did not\nstate. Do not extract secrets (API
+      keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1833'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"User is vegetarian.\\\",\\n      \\\"type\\\":
+        \\\"preference\\\",\\n      \\\"importance\\\": 7,\\n      \\\"confidence\\\":
+        1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n      \\\"rationale\\\":
+        \\\"User stated a personal dietary preference.\\\"\\n    },\\n    {\\n      \\\"content\\\":
+        \\\"User's sister Mia is allergic to peanuts.\\\",\\n      \\\"type\\\": \\\"constraint\\\",\\n
+        \     \\\"importance\\\": 8,\\n      \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\":
+        \\\"medium\\\",\\n      \\\"rationale\\\": \\\"User stated a health constraint
+        for a family member.\\\"\\n    }\\n  ]\\n}\\n```\"\n          }\n        ],\n
+        \       \"role\": \"model\"\n      },\n      \"finishReason\": \"STOP\",\n
+        \     \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        391,\n    \"candidatesTokenCount\": 155,\n    \"totalTokenCount\": 812,\n
+        \   \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 391\n      }\n    ],\n    \"thoughtsTokenCount\":
+        266,\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.5-flash\",\n
+        \ \"responseId\": \"sfp5aoWANp3f_uMP3_K0yAU\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '1152'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:11 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=2158
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Remember I live in Boston, I''m allergic
+      to shellfish, and my anniversary is May 3."}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "# Memory Extraction Prompt (v0.4)\n\nYou are the memory
+      extraction component of MemoryOps AI, a governed memory\nlifecycle system. Given
+      a single user message, identify durable facts worth\nremembering: stable preferences,
+      constraints, project context, and explicit\n\"remember this\" requests. Ignore
+      questions, chit-chat, and ephemeral details.\n\nYou do not make storage or safety
+      decisions. A deterministic policy broker runs\nafter you and is authoritative
+      \u2014 never assume your output will be stored as-is,\nand never attempt to
+      bypass safety rules. Do not invent facts the user did not\nstate. Do not extract
+      secrets (API keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1859'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"User lives in Boston.\\\",\\n      \\\"type\\\":
+        \\\"preference\\\",\\n      \\\"importance\\\": 9,\\n      \\\"confidence\\\":
+        1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n      \\\"rationale\\\":
+        \\\"User explicitly stated their current city of residence.\\\"\\n    },\\n
+        \   {\\n      \\\"content\\\": \\\"User is allergic to shellfish.\\\",\\n
+        \     \\\"type\\\": \\\"constraint\\\",\\n      \\\"importance\\\": 10,\\n
+        \     \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"medium\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a critical health constraint.\\\"\\n
+        \   },\\n    {\\n      \\\"content\\\": \\\"User's anniversary is May 3.\\\",\\n
+        \     \\\"type\\\": \\\"episodic\\\",\\n      \\\"importance\\\": 9,\\n      \\\"confidence\\\":
+        1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n      \\\"rationale\\\":
+        \\\"User explicitly stated an important personal date.\\\"\\n    }\\n  ]\\n}\\n```\"\n
+        \         }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
+        \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        399,\n    \"candidatesTokenCount\": 224,\n    \"totalTokenCount\": 677,\n
+        \   \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 399\n      }\n    ],\n    \"thoughtsTokenCount\":
+        54,\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.5-flash\",\n
+        \ \"responseId\": \"tPp5apPTBbrrjrEPj5umiAY\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '1420'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:13 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1484
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "I usually work late on weekdays and
+      I prefer async standups."}], "role": "user"}], "systemInstruction": {"parts":
+      [{"text": "# Memory Extraction Prompt (v0.4)\n\nYou are the memory extraction
+      component of MemoryOps AI, a governed memory\nlifecycle system. Given a single
+      user message, identify durable facts worth\nremembering: stable preferences,
+      constraints, project context, and explicit\n\"remember this\" requests. Ignore
+      questions, chit-chat, and ephemeral details.\n\nYou do not make storage or safety
+      decisions. A deterministic policy broker runs\nafter you and is authoritative
+      \u2014 never assume your output will be stored as-is,\nand never attempt to
+      bypass safety rules. Do not invent facts the user did not\nstate. Do not extract
+      secrets (API keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1837'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"User usually works late on weekdays.\\\",\\n
+        \     \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\": 7,\\n
+        \     \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User stated a preference regarding their work
+        schedule.\\\"\\n    },\\n    {\\n      \\\"content\\\": \\\"User prefers async
+        standups.\\\",\\n      \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\":
+        8,\\n      \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User stated a preference for async standups.\\\"\\n
+        \   }\\n  ]\\n}\\n```\"\n          }\n        ],\n        \"role\": \"model\"\n
+        \     },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n
+        \ \"usageMetadata\": {\n    \"promptTokenCount\": 391,\n    \"candidatesTokenCount\":
+        155,\n    \"totalTokenCount\": 801,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 391\n      }\n    ],\n
+        \   \"thoughtsTokenCount\": 255,\n    \"serviceTier\": \"standard\"\n  },\n
+        \ \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"tfp5av6ULf-h_uMP4MKHkA4\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '1158'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:15 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=2046
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Remember I fly out of SFO, I hate red-eye
+      flights, and I always pack carry-on only."}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "# Memory Extraction Prompt (v0.4)\n\nYou are the memory
+      extraction component of MemoryOps AI, a governed memory\nlifecycle system. Given
+      a single user message, identify durable facts worth\nremembering: stable preferences,
+      constraints, project context, and explicit\n\"remember this\" requests. Ignore
+      questions, chit-chat, and ephemeral details.\n\nYou do not make storage or safety
+      decisions. A deterministic policy broker runs\nafter you and is authoritative
+      \u2014 never assume your output will be stored as-is,\nand never attempt to
+      bypass safety rules. Do not invent facts the user did not\nstate. Do not extract
+      secrets (API keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1860'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"User's preferred departure airport
+        is SFO.\\\",\\n      \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\":
+        8,\\n      \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated their preferred departure
+        airport.\\\"\\n    },\\n    {\\n      \\\"content\\\": \\\"User dislikes red-eye
+        flights.\\\",\\n      \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\":
+        8,\\n      \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a strong travel preference.\\\"\\n
+        \   },\\n    {\\n      \\\"content\\\": \\\"User always packs carry-on only.\\\",\\n
+        \     \\\"type\\\": \\\"constraint\\\",\\n      \\\"importance\\\": 8,\\n
+        \     \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a consistent travel habit/constraint.\\\"\\n
+        \   }\\n  ]\\n}\\n```\"\n          }\n        ],\n        \"role\": \"model\"\n
+        \     },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n
+        \ \"usageMetadata\": {\n    \"promptTokenCount\": 402,\n    \"candidatesTokenCount\":
+        228,\n    \"totalTokenCount\": 1030,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 402\n      }\n    ],\n
+        \   \"thoughtsTokenCount\": 400,\n    \"serviceTier\": \"standard\"\n  },\n
+        \ \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"t_p5apa2NpLN_uMP9pXcmAw\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '1455'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:18 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=3037
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Please answer me in a concise, formal
+      tone."}], "role": "user"}], "systemInstruction": {"parts": [{"text": "# Memory
+      Extraction Prompt (v0.4)\n\nYou are the memory extraction component of MemoryOps
+      AI, a governed memory\nlifecycle system. Given a single user message, identify
+      durable facts worth\nremembering: stable preferences, constraints, project context,
+      and explicit\n\"remember this\" requests. Ignore questions, chit-chat, and ephemeral
+      details.\n\nYou do not make storage or safety decisions. A deterministic policy
+      broker runs\nafter you and is authoritative \u2014 never assume your output
+      will be stored as-is,\nand never attempt to bypass safety rules. Do not invent
+      facts the user did not\nstate. Do not extract secrets (API keys, passwords,
+      tokens); the policy broker\nblocks them regardless.\n\nReturn ONLY a JSON object
+      matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1820'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"User prefers a concise, formal tone
+        for responses.\\\",\\n      \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\":
+        7,\\n      \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a preference for response
+        tone.\\\"\\n    }\\n  ]\\n}\\n```\"\n          }\n        ],\n        \"role\":
+        \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n
+        \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 388,\n    \"candidatesTokenCount\":
+        90,\n    \"totalTokenCount\": 606,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 388\n      }\n    ],\n
+        \   \"thoughtsTokenCount\": 128,\n    \"serviceTier\": \"standard\"\n  },\n
+        \ \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"u_p5apWTApSm1MkP0rHumQI\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '910'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:20 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1378
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "For context, I''m a staff data engineer
+      at a fintech company."}], "role": "user"}], "systemInstruction": {"parts": [{"text":
+      "# Memory Extraction Prompt (v0.4)\n\nYou are the memory extraction component
+      of MemoryOps AI, a governed memory\nlifecycle system. Given a single user message,
+      identify durable facts worth\nremembering: stable preferences, constraints,
+      project context, and explicit\n\"remember this\" requests. Ignore questions,
+      chit-chat, and ephemeral details.\n\nYou do not make storage or safety decisions.
+      A deterministic policy broker runs\nafter you and is authoritative \u2014 never
+      assume your output will be stored as-is,\nand never attempt to bypass safety
+      rules. Do not invent facts the user did not\nstate. Do not extract secrets (API
+      keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1837'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"User is a staff data engineer at a
+        fintech company.\\\",\\n      \\\"type\\\": \\\"system\\\",\\n      \\\"importance\\\":
+        6,\\n      \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"Establishes user's professional role and industry
+        context.\\\"\\n    }\\n  ]\\n}\\n```\"\n          }\n        ],\n        \"role\":
+        \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n
+        \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 393,\n    \"candidatesTokenCount\":
+        94,\n    \"totalTokenCount\": 695,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 393\n      }\n    ],\n
+        \   \"thoughtsTokenCount\": 208,\n    \"serviceTier\": \"standard\"\n  },\n
+        \ \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"vPp5aqi1HuaUjrEPnafB-A8\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '911'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:22 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1769
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "I no longer use Postgres; I switched
+      to Snowflake for the warehouse."}], "role": "user"}], "systemInstruction": {"parts":
+      [{"text": "# Memory Extraction Prompt (v0.4)\n\nYou are the memory extraction
+      component of MemoryOps AI, a governed memory\nlifecycle system. Given a single
+      user message, identify durable facts worth\nremembering: stable preferences,
+      constraints, project context, and explicit\n\"remember this\" requests. Ignore
+      questions, chit-chat, and ephemeral details.\n\nYou do not make storage or safety
+      decisions. A deterministic policy broker runs\nafter you and is authoritative
+      \u2014 never assume your output will be stored as-is,\nand never attempt to
+      bypass safety rules. Do not invent facts the user did not\nstate. Do not extract
+      secrets (API keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1845'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"The user uses Snowflake as their data
+        warehouse instead of Postgres.\\\",\\n      \\\"type\\\": \\\"project\\\",\\n
+        \     \\\"importance\\\": 7,\\n      \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\":
+        \\\"low\\\",\\n      \\\"rationale\\\": \\\"User explicitly stated a change
+        in their data warehouse technology.\\\"\\n    }\\n  ]\\n}\\n```\"\n          }\n
+        \       ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
+        \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        392,\n    \"candidatesTokenCount\": 94,\n    \"totalTokenCount\": 718,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 392\n
+        \     }\n    ],\n    \"thoughtsTokenCount\": 232,\n    \"serviceTier\": \"standard\"\n
+        \ },\n  \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"vvp5aq7xE7K8_uMP2pmDiQc\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '938'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:24 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1901
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "My editor is Neovim and I deploy everything
+      on Railway."}], "role": "user"}], "systemInstruction": {"parts": [{"text": "#
+      Memory Extraction Prompt (v0.4)\n\nYou are the memory extraction component of
+      MemoryOps AI, a governed memory\nlifecycle system. Given a single user message,
+      identify durable facts worth\nremembering: stable preferences, constraints,
+      project context, and explicit\n\"remember this\" requests. Ignore questions,
+      chit-chat, and ephemeral details.\n\nYou do not make storage or safety decisions.
+      A deterministic policy broker runs\nafter you and is authoritative \u2014 never
+      assume your output will be stored as-is,\nand never attempt to bypass safety
+      rules. Do not invent facts the user did not\nstate. Do not extract secrets (API
+      keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1832'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"User's preferred editor is Neovim.\\\",\\n
+        \     \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\": 7,\\n
+        \     \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly states their preferred editor.\\\"\\n
+        \   },\\n    {\\n      \\\"content\\\": \\\"User deploys all projects on Railway.\\\",\\n
+        \     \\\"type\\\": \\\"constraint\\\",\\n      \\\"importance\\\": 7,\\n
+        \     \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly states their deployment platform.\\\"\\n
+        \   }\\n  ]\\n}\\n```\"\n          }\n        ],\n        \"role\": \"model\"\n
+        \     },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n
+        \ \"usageMetadata\": {\n    \"promptTokenCount\": 391,\n    \"candidatesTokenCount\":
+        156,\n    \"totalTokenCount\": 775,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 391\n      }\n    ],\n
+        \   \"thoughtsTokenCount\": 228,\n    \"serviceTier\": \"standard\"\n  },\n
+        \ \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"wPp5avDuEuCZ_uMP6PKriQc\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '1161'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:26 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1928
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "I want all code examples in TypeScript,
+      not JavaScript."}], "role": "user"}], "systemInstruction": {"parts": [{"text":
+      "# Memory Extraction Prompt (v0.4)\n\nYou are the memory extraction component
+      of MemoryOps AI, a governed memory\nlifecycle system. Given a single user message,
+      identify durable facts worth\nremembering: stable preferences, constraints,
+      project context, and explicit\n\"remember this\" requests. Ignore questions,
+      chit-chat, and ephemeral details.\n\nYou do not make storage or safety decisions.
+      A deterministic policy broker runs\nafter you and is authoritative \u2014 never
+      assume your output will be stored as-is,\nand never attempt to bypass safety
+      rules. Do not invent facts the user did not\nstate. Do not extract secrets (API
+      keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1832'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"Code examples should be provided in
+        TypeScript.\\\",\\n      \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\":
+        8,\\n      \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a preference for TypeScript
+        over JavaScript for code examples.\\\"\\n    }\\n  ]\\n}\\n```\"\n          }\n
+        \       ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
+        \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        389,\n    \"candidatesTokenCount\": 92,\n    \"totalTokenCount\": 602,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 389\n
+        \     }\n    ],\n    \"thoughtsTokenCount\": 121,\n    \"serviceTier\": \"standard\"\n
+        \ },\n  \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"wvp5ar2SE8bg_uMPt7n5mAc\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '938'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:27 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1401
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "My daughter''s name is Ada and she turns
+      5 in October."}], "role": "user"}], "systemInstruction": {"parts": [{"text":
+      "# Memory Extraction Prompt (v0.4)\n\nYou are the memory extraction component
+      of MemoryOps AI, a governed memory\nlifecycle system. Given a single user message,
+      identify durable facts worth\nremembering: stable preferences, constraints,
+      project context, and explicit\n\"remember this\" requests. Ignore questions,
+      chit-chat, and ephemeral details.\n\nYou do not make storage or safety decisions.
+      A deterministic policy broker runs\nafter you and is authoritative \u2014 never
+      assume your output will be stored as-is,\nand never attempt to bypass safety
+      rules. Do not invent facts the user did not\nstate. Do not extract secrets (API
+      keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1830'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"User's daughter's name is Ada.\\\",\\n
+        \     \\\"type\\\": \\\"semantic\\\",\\n      \\\"importance\\\": 7,\\n      \\\"confidence\\\":
+        1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n      \\\"rationale\\\":
+        \\\"User explicitly stated their daughter's name.\\\"\\n    },\\n    {\\n
+        \     \\\"content\\\": \\\"User's daughter turns 5 in October.\\\",\\n      \\\"type\\\":
+        \\\"episodic\\\",\\n      \\\"importance\\\": 6,\\n      \\\"confidence\\\":
+        1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n      \\\"rationale\\\":
+        \\\"User explicitly stated their daughter's age and birth month.\\\"\\n    }\\n
+        \ ]\\n}\\n```\"\n          }\n        ],\n        \"role\": \"model\"\n      },\n
+        \     \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\":
+        {\n    \"promptTokenCount\": 393,\n    \"candidatesTokenCount\": 166,\n    \"totalTokenCount\":
+        827,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 393\n      }\n    ],\n    \"thoughtsTokenCount\":
+        268,\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.5-flash\",\n
+        \ \"responseId\": \"w_p5aumhNaqZ-8YP5YLAyAY\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '1161'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:29 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=2136
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Don''t include external links in your
+      answers."}], "role": "user"}], "systemInstruction": {"parts": [{"text": "# Memory
+      Extraction Prompt (v0.4)\n\nYou are the memory extraction component of MemoryOps
+      AI, a governed memory\nlifecycle system. Given a single user message, identify
+      durable facts worth\nremembering: stable preferences, constraints, project context,
+      and explicit\n\"remember this\" requests. Ignore questions, chit-chat, and ephemeral
+      details.\n\nYou do not make storage or safety decisions. A deterministic policy
+      broker runs\nafter you and is authoritative \u2014 never assume your output
+      will be stored as-is,\nand never attempt to bypass safety rules. Do not invent
+      facts the user did not\nstate. Do not extract secrets (API keys, passwords,
+      tokens); the policy broker\nblocks them regardless.\n\nReturn ONLY a JSON object
+      matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1822'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"Do not include external links in answers.\\\",\\n
+        \     \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\": 8,\\n
+        \     \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a preference for how answers
+        should be formatted.\\\"\\n    }\\n  ]\\n}\\n```\"\n          }\n        ],\n
+        \       \"role\": \"model\"\n      },\n      \"finishReason\": \"STOP\",\n
+        \     \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        388,\n    \"candidatesTokenCount\": 91,\n    \"totalTokenCount\": 630,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 388\n
+        \     }\n    ],\n    \"thoughtsTokenCount\": 151,\n    \"serviceTier\": \"standard\"\n
+        \ },\n  \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"xvp5atmsB932jrEP4NXH2A8\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '919'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:31 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1451
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "What did I say my favorite food was?"}],
+      "role": "user"}], "systemInstruction": {"parts": [{"text": "# Memory Extraction
+      Prompt (v0.4)\n\nYou are the memory extraction component of MemoryOps AI, a
+      governed memory\nlifecycle system. Given a single user message, identify durable
+      facts worth\nremembering: stable preferences, constraints, project context,
+      and explicit\n\"remember this\" requests. Ignore questions, chit-chat, and ephemeral
+      details.\n\nYou do not make storage or safety decisions. A deterministic policy
+      broker runs\nafter you and is authoritative \u2014 never assume your output
+      will be stored as-is,\nand never attempt to bypass safety rules. Do not invent
+      facts the user did not\nstate. Do not extract secrets (API keys, passwords,
+      tokens); the policy broker\nblocks them regardless.\n\nReturn ONLY a JSON object
+      matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1813'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        []\\n}\\n```\"\n          }\n        ],\n        \"role\": \"model\"\n      },\n
+        \     \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\":
+        {\n    \"promptTokenCount\": 387,\n    \"candidatesTokenCount\": 15,\n    \"totalTokenCount\":
+        440,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 387\n      }\n    ],\n    \"thoughtsTokenCount\":
+        38,\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.5-flash\",\n
+        \ \"responseId\": \"x_p5au2GKbCU_uMPpM-7-AY\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '614'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:32 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=600
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Can you summarize the last quarter''s
+      revenue?"}], "role": "user"}], "systemInstruction": {"parts": [{"text": "# Memory
+      Extraction Prompt (v0.4)\n\nYou are the memory extraction component of MemoryOps
+      AI, a governed memory\nlifecycle system. Given a single user message, identify
+      durable facts worth\nremembering: stable preferences, constraints, project context,
+      and explicit\n\"remember this\" requests. Ignore questions, chit-chat, and ephemeral
+      details.\n\nYou do not make storage or safety decisions. A deterministic policy
+      broker runs\nafter you and is authoritative \u2014 never assume your output
+      will be stored as-is,\nand never attempt to bypass safety rules. Do not invent
+      facts the user did not\nstate. Do not extract secrets (API keys, passwords,
+      tokens); the policy broker\nblocks them regardless.\n\nReturn ONLY a JSON object
+      matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1822'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        []\\n}\\n```\"\n          }\n        ],\n        \"role\": \"model\"\n      },\n
+        \     \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\":
+        {\n    \"promptTokenCount\": 388,\n    \"candidatesTokenCount\": 15,\n    \"totalTokenCount\":
+        456,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 388\n      }\n    ],\n    \"thoughtsTokenCount\":
+        53,\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.5-flash\",\n
+        \ \"responseId\": \"yPp5atD1F5ic-8YPwenkuAY\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '614'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:32 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=650
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Good morning! How are you doing today?"}],
+      "role": "user"}], "systemInstruction": {"parts": [{"text": "# Memory Extraction
+      Prompt (v0.4)\n\nYou are the memory extraction component of MemoryOps AI, a
+      governed memory\nlifecycle system. Given a single user message, identify durable
+      facts worth\nremembering: stable preferences, constraints, project context,
+      and explicit\n\"remember this\" requests. Ignore questions, chit-chat, and ephemeral
+      details.\n\nYou do not make storage or safety decisions. A deterministic policy
+      broker runs\nafter you and is authoritative \u2014 never assume your output
+      will be stored as-is,\nand never attempt to bypass safety rules. Do not invent
+      facts the user did not\nstate. Do not extract secrets (API keys, passwords,
+      tokens); the policy broker\nblocks them regardless.\n\nReturn ONLY a JSON object
+      matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1815'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"{\\\"memories\\\": []}\"\n          }\n
+        \       ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
+        \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        387,\n    \"candidatesTokenCount\": 6,\n    \"totalTokenCount\": 439,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 387\n
+        \     }\n    ],\n    \"thoughtsTokenCount\": 46,\n    \"serviceTier\": \"standard\"\n
+        \ },\n  \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"yfp5avfpB9OC-8YP3oHv4Q8\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '593'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:33 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=697
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "I prefer metric units for everything."}],
+      "role": "user"}], "systemInstruction": {"parts": [{"text": "# Memory Extraction
+      Prompt (v0.4)\n\nYou are the memory extraction component of MemoryOps AI, a
+      governed memory\nlifecycle system. Given a single user message, identify durable
+      facts worth\nremembering: stable preferences, constraints, project context,
+      and explicit\n\"remember this\" requests. Ignore questions, chit-chat, and ephemeral
+      details.\n\nYou do not make storage or safety decisions. A deterministic policy
+      broker runs\nafter you and is authoritative \u2014 never assume your output
+      will be stored as-is,\nand never attempt to bypass safety rules. Do not invent
+      facts the user did not\nstate. Do not extract secrets (API keys, passwords,
+      tokens); the policy broker\nblocks them regardless.\n\nReturn ONLY a JSON object
+      matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1814'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"User prefers metric units for all measurements.\\\",\\n
+        \     \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\": 8,\\n
+        \     \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a general preference for
+        metric units.\\\"\\n    }\\n  ]\\n}\\n```\"\n          }\n        ],\n        \"role\":
+        \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n
+        \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 385,\n    \"candidatesTokenCount\":
+        89,\n    \"totalTokenCount\": 576,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 385\n      }\n    ],\n
+        \   \"thoughtsTokenCount\": 102,\n    \"serviceTier\": \"standard\"\n  },\n
+        \ \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"yvp5atOfBaLN1MkPyOm94QM\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '914'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:35 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1341
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Remember I''m lactose intolerant, I
+      don''t drink alcohol, and I love spicy food."}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "# Memory Extraction Prompt (v0.4)\n\nYou are the memory
+      extraction component of MemoryOps AI, a governed memory\nlifecycle system. Given
+      a single user message, identify durable facts worth\nremembering: stable preferences,
+      constraints, project context, and explicit\n\"remember this\" requests. Ignore
+      questions, chit-chat, and ephemeral details.\n\nYou do not make storage or safety
+      decisions. A deterministic policy broker runs\nafter you and is authoritative
+      \u2014 never assume your output will be stored as-is,\nand never attempt to
+      bypass safety rules. Do not invent facts the user did not\nstate. Do not extract
+      secrets (API keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1855'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"The user is lactose intolerant.\\\",\\n
+        \     \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\": 9,\\n
+        \     \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a dietary constraint.\\\"\\n
+        \   },\\n    {\\n      \\\"content\\\": \\\"The user does not drink alcohol.\\\",\\n
+        \     \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\": 9,\\n
+        \     \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a beverage preference.\\\"\\n
+        \   },\\n    {\\n      \\\"content\\\": \\\"The user loves spicy food.\\\",\\n
+        \     \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\": 9,\\n
+        \     \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a food preference.\\\"\\n
+        \   }\\n  ]\\n}\\n```\"\n          }\n        ],\n        \"role\": \"model\"\n
+        \     },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n
+        \ \"usageMetadata\": {\n    \"promptTokenCount\": 398,\n    \"candidatesTokenCount\":
+        217,\n    \"totalTokenCount\": 732,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 398\n      }\n    ],\n
+        \   \"thoughtsTokenCount\": 117,\n    \"serviceTier\": \"standard\"\n  },\n
+        \ \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"y_p5aojeFZ-ljMcPn66XuAc\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '1402'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:36 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1742
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "We''re building MemoryOps, a governed
+      memory layer for AI assistants."}], "role": "user"}], "systemInstruction": {"parts":
+      [{"text": "# Memory Extraction Prompt (v0.4)\n\nYou are the memory extraction
+      component of MemoryOps AI, a governed memory\nlifecycle system. Given a single
+      user message, identify durable facts worth\nremembering: stable preferences,
+      constraints, project context, and explicit\n\"remember this\" requests. Ignore
+      questions, chit-chat, and ephemeral details.\n\nYou do not make storage or safety
+      decisions. A deterministic policy broker runs\nafter you and is authoritative
+      \u2014 never assume your output will be stored as-is,\nand never attempt to
+      bypass safety rules. Do not invent facts the user did not\nstate. Do not extract
+      secrets (API keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1845'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"The user is building MemoryOps, a governed
+        memory layer for AI assistants.\\\",\\n      \\\"type\\\": \\\"project\\\",\\n
+        \     \\\"importance\\\": 7,\\n      \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\":
+        \\\"low\\\",\\n      \\\"rationale\\\": \\\"Establishes the user's current
+        project context.\\\"\\n    }\\n  ]\\n}\\n```\"\n          }\n        ],\n
+        \       \"role\": \"model\"\n      },\n      \"finishReason\": \"STOP\",\n
+        \     \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        393,\n    \"candidatesTokenCount\": 97,\n    \"totalTokenCount\": 628,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 393\n
+        \     }\n    ],\n    \"thoughtsTokenCount\": 138,\n    \"serviceTier\": \"standard\"\n
+        \ },\n  \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"zfp5aqqUC_OS-8YP4YDH8A8\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '924'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:38 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1479
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "I like meetings scheduled in the morning,
+      before 11am."}], "role": "user"}], "systemInstruction": {"parts": [{"text":
+      "# Memory Extraction Prompt (v0.4)\n\nYou are the memory extraction component
+      of MemoryOps AI, a governed memory\nlifecycle system. Given a single user message,
+      identify durable facts worth\nremembering: stable preferences, constraints,
+      project context, and explicit\n\"remember this\" requests. Ignore questions,
+      chit-chat, and ephemeral details.\n\nYou do not make storage or safety decisions.
+      A deterministic policy broker runs\nafter you and is authoritative \u2014 never
+      assume your output will be stored as-is,\nand never attempt to bypass safety
+      rules. Do not invent facts the user did not\nstate. Do not extract secrets (API
+      keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1831'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"Meetings should be scheduled in the
+        morning, before 11am.\\\",\\n      \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\":
+        7,\\n      \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly stated a scheduling preference
+        for meetings.\\\"\\n    }\\n  ]\\n}\\n```\"\n          }\n        ],\n        \"role\":
+        \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n
+        \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 392,\n    \"candidatesTokenCount\":
+        94,\n    \"totalTokenCount\": 593,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 392\n      }\n    ],\n
+        \   \"thoughtsTokenCount\": 107,\n    \"serviceTier\": \"standard\"\n  },\n
+        \ \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"zvp5avyyM4Wa_uMPkvGy4Q8\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '923'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:40 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1319
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "I split my time between Austin and Denver."}],
+      "role": "user"}], "systemInstruction": {"parts": [{"text": "# Memory Extraction
+      Prompt (v0.4)\n\nYou are the memory extraction component of MemoryOps AI, a
+      governed memory\nlifecycle system. Given a single user message, identify durable
+      facts worth\nremembering: stable preferences, constraints, project context,
+      and explicit\n\"remember this\" requests. Ignore questions, chit-chat, and ephemeral
+      details.\n\nYou do not make storage or safety decisions. A deterministic policy
+      broker runs\nafter you and is authoritative \u2014 never assume your output
+      will be stored as-is,\nand never attempt to bypass safety rules. Do not invent
+      facts the user did not\nstate. Do not extract secrets (API keys, passwords,
+      tokens); the policy broker\nblocks them regardless.\n\nReturn ONLY a JSON object
+      matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1819'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"User splits time between Austin and
+        Denver.\\\",\\n      \\\"type\\\": \\\"preference\\\",\\n      \\\"importance\\\":
+        6,\\n      \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"low\\\",\\n
+        \     \\\"rationale\\\": \\\"User's primary locations.\\\"\\n    }\\n  ]\\n}\\n```\"\n
+        \         }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
+        \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        387,\n    \"candidatesTokenCount\": 85,\n    \"totalTokenCount\": 597,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 387\n
+        \     }\n    ],\n    \"thoughtsTokenCount\": 125,\n    \"serviceTier\": \"standard\"\n
+        \ },\n  \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"0Pp5aq3kEe-njMcP6OGN2A4\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '874'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:41 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1336
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Always redact my home address if it
+      ever comes up."}], "role": "user"}], "systemInstruction": {"parts": [{"text":
+      "# Memory Extraction Prompt (v0.4)\n\nYou are the memory extraction component
+      of MemoryOps AI, a governed memory\nlifecycle system. Given a single user message,
+      identify durable facts worth\nremembering: stable preferences, constraints,
+      project context, and explicit\n\"remember this\" requests. Ignore questions,
+      chit-chat, and ephemeral details.\n\nYou do not make storage or safety decisions.
+      A deterministic policy broker runs\nafter you and is authoritative \u2014 never
+      assume your output will be stored as-is,\nand never attempt to bypass safety
+      rules. Do not invent facts the user did not\nstate. Do not extract secrets (API
+      keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1827'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        [\\n    {\\n      \\\"content\\\": \\\"Always redact my home address.\\\",\\n
+        \     \\\"type\\\": \\\"constraint\\\",\\n      \\\"importance\\\": 9,\\n
+        \     \\\"confidence\\\": 1.0,\\n      \\\"sensitivity\\\": \\\"high\\\",\\n
+        \     \\\"rationale\\\": \\\"User explicitly requested redaction of home address
+        for privacy.\\\"\\n    }\\n  ]\\n}\\n```\"\n          }\n        ],\n        \"role\":
+        \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n
+        \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 389,\n    \"candidatesTokenCount\":
+        88,\n    \"totalTokenCount\": 652,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 389\n      }\n    ],\n
+        \   \"thoughtsTokenCount\": 175,\n    \"serviceTier\": \"standard\"\n  },\n
+        \ \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"0fp5aueyK7vK_uMP0-riiQw\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '901'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:43 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=1726
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Ugh, my commute on the 101 was brutal
+      again this morning."}], "role": "user"}], "systemInstruction": {"parts": [{"text":
+      "# Memory Extraction Prompt (v0.4)\n\nYou are the memory extraction component
+      of MemoryOps AI, a governed memory\nlifecycle system. Given a single user message,
+      identify durable facts worth\nremembering: stable preferences, constraints,
+      project context, and explicit\n\"remember this\" requests. Ignore questions,
+      chit-chat, and ephemeral details.\n\nYou do not make storage or safety decisions.
+      A deterministic policy broker runs\nafter you and is authoritative \u2014 never
+      assume your output will be stored as-is,\nand never attempt to bypass safety
+      rules. Do not invent facts the user did not\nstate. Do not extract secrets (API
+      keys, passwords, tokens); the policy broker\nblocks them regardless.\n\nReturn
+      ONLY a JSON object matching this schema, with no prose or markdown fences:\n\n```json\n{\n  \"memories\":
+      [\n    {\n      \"content\": \"<concise, self-contained statement of the fact>\",\n      \"type\":
+      \"preference | constraint | project | procedural | semantic | episodic | knowledge
+      | workflow | system\",\n      \"importance\": 0,\n      \"confidence\": 0.0,\n      \"sensitivity\":
+      \"low | medium | high\",\n      \"rationale\": \"<short reason this is worth
+      remembering>\"\n    }\n  ]\n}\n```\n\nRules:\n- Return an empty `memories` array
+      when nothing is worth remembering.\n- `importance` is 0\u201310; explicit \"remember\"
+      requests rank higher than inferred ones.\n- `confidence` is 0.0\u20131.0.\n-
+      Set `sensitivity` to your best estimate; the policy broker makes the final call.\n-
+      One fact per memory; keep `content` short and free of the user''s exact phrasing\n  when
+      it contains noise.\n"}], "role": "user"}, "generationConfig": {"temperature":
+      0.0}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1834'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/2.17.0 gl-python/3.13.2
+      x-server-timeout:
+      - '10'
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"memories\\\":
+        []\\n}\\n```\"\n          }\n        ],\n        \"role\": \"model\"\n      },\n
+        \     \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\":
+        {\n    \"promptTokenCount\": 395,\n    \"candidatesTokenCount\": 15,\n    \"totalTokenCount\":
+        471,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 395\n      }\n    ],\n    \"thoughtsTokenCount\":
+        61,\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.5-flash\",\n
+        \ \"responseId\": \"0_p5aum9HrCU_uMPpM-7-AY\"\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '614'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 10 Aug 2026 16:22:44 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=707
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-gemini-service-tier:
+      - standard
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/services/api/tests/test_extraction_evidence_gemini.py
+++ b/services/api/tests/test_extraction_evidence_gemini.py
@@ -1,0 +1,273 @@
+"""Recorded real-provider Gemini extraction evidence.
+
+`benchmark/EXTRACTION_QUALITY.md` reports a real `gemini-2.5-flash` run scoring
+0.94 / 0.94 / 0.94 on a fixed 25-turn dataset. That number came from a live call
+sequence, so nothing in CI could reproduce or contradict it — the strongest capability
+claim in the repository rested on a run nobody else could repeat.
+
+This module turns that into evidence. One live recording was captured through the
+*same* path the evaluator uses (`build_llm_provider` -> `extract_memories` ->
+`GeminiProvider` -> `google-genai`), sanitized, and committed as a VCR cassette. CI
+replays it with no credential and no network.
+
+What the cassette proves and does not prove
+-------------------------------------------
+It proves a previously recorded real `gemini-2.5-flash` run regenerates the reported
+score deterministically. It does **not** predict what a live Gemini call will score
+tomorrow: models change server-side, and a cassette is a record, not a forecast.
+
+Why extraction *mode* is asserted, not just request count
+---------------------------------------------------------
+`extract_memories` falls back to the deterministic heuristic whenever a provider call
+fails (invariant #4). A headline "real provider" score can therefore be part stub
+while still issuing 25 HTTP requests. The runtime already reports
+`ExtractionOutcome.mode`, so every turn is asserted `structured` — 25 requests is not
+evidence of 25 structured extractions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_TESTS = Path(__file__).resolve().parent
+_REPO_ROOT = _TESTS.parents[2]
+_CASSETTE_DIR = _TESTS / "cassettes"
+_CASSETTE = _CASSETTE_DIR / "test_extraction_quality_real_gemini.yaml"
+
+#: The recorded run's identity. Asserted rather than assumed so a model-default change
+#: cannot silently repoint the evidence at a different model.
+RECORDED_MODEL = "gemini-2.5-flash"
+EXPECTED_INTERACTIONS = 25
+
+#: Replay needs a non-empty key only because provider construction requires one; no
+#: credential is involved. Deliberately not shaped like a Google API key.
+REPLAY_PLACEHOLDER_KEY = "recorded-replay-placeholder"
+
+
+def _sdk_installed() -> bool:
+    """`find_spec` raises when the parent package is absent, so guard it."""
+    try:
+        return importlib.util.find_spec("google.genai") is not None
+    except ModuleNotFoundError:
+        return False
+
+
+_HAS_SDK = _sdk_installed()
+
+
+# ── VCR configuration ────────────────────────────────────────────────────────
+@pytest.fixture(scope="module")
+def vcr_cassette_dir() -> str:
+    """Flat `tests/cassettes/`, overriding pytest-recording's per-module default.
+
+    The default is `cassettes/<module>/<test>.yaml`; the repository's existing
+    convention (and `cassettes/README.md`) is the flat form.
+    """
+    return str(_CASSETTE_DIR)
+
+
+@pytest.fixture(scope="module")
+def vcr_config() -> dict:
+    """Credential scrubbing and request matching.
+
+    Filters cover every credential surface `google-genai` actually uses —
+    `x-goog-api-key` for API-key auth and `Authorization` on its token paths — plus
+    the `key` query parameter defensively, since a query-string credential is
+    supported by the Gemini REST API even though this SDK version sends a header.
+    Values are **removed**, not masked: a partially masked key is still a leak.
+
+    Matching includes the request body because all 25 interactions hit the same
+    endpoint. Without it, replay would pair responses by ordering alone, and a
+    reordered or partially-run suite would silently score against the wrong
+    prompt/response pairs. Credential-bearing headers are deliberately not matched on.
+    """
+    return {
+        "filter_headers": [
+            ("x-goog-api-key", None),
+            ("authorization", None),
+            ("x-api-key", None),
+            ("api-key", None),
+            ("x-goog-api-client", None),
+        ],
+        "filter_query_parameters": [("key", None)],
+        "match_on": ["method", "scheme", "host", "port", "path", "query", "body"],
+        "decode_compressed_response": True,
+    }
+
+
+@pytest.fixture
+def _gemini_env(monkeypatch):
+    """Provide a key only if the environment has none (i.e. during replay)."""
+    monkeypatch.setenv("MEMORYOPS_LLM_PROVIDER", "gemini")
+    monkeypatch.setenv("GEMINI_MODEL", RECORDED_MODEL)
+    if not os.getenv("GEMINI_API_KEY"):
+        monkeypatch.setenv("GEMINI_API_KEY", REPLAY_PLACEHOLDER_KEY)
+    # google-genai also reads GOOGLE_API_KEY; keep it out of the way so the recorded
+    # identity cannot come from a second, unnoticed source.
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+
+def _scorer():
+    """Reuse the evaluator rather than duplicating its scoring."""
+    evals_dir = str(_REPO_ROOT / "evals")
+    if evals_dir not in sys.path:
+        sys.path.insert(0, evals_dir)
+    import run_extraction_quality as req
+
+    return req
+
+
+# ── the evidence test ────────────────────────────────────────────────────────
+@pytest.mark.vcr
+@pytest.mark.skipif(not _HAS_SDK, reason="google-genai not installed (optional extra)")
+def test_extraction_quality_real_gemini(_gemini_env):
+    """Replay the recorded run and regenerate the published score.
+
+    Skips only where the optional SDK is absent (the default `requirements-dev.txt`
+    suite). The dedicated CI evidence step installs the extra, so a skip *there* is a
+    CI failure — see `.github/workflows/ci.yml`.
+    """
+    req = _scorer()
+    cases = req._load_cases()
+    assert len(cases) == EXPECTED_INTERACTIONS, f"dataset drifted: {len(cases)} turns"
+
+    score = req.score_provider("gemini", cases)
+
+    # No turn may have been rescued by the heuristic, and none may have errored.
+    assert score.errors == [], score.errors
+    assert score.modes == {"structured": EXPECTED_INTERACTIONS}, (
+        f"expected {EXPECTED_INTERACTIONS} structured extractions, got {score.modes} — "
+        "a fallback means part of this score is not real-provider evidence"
+    )
+
+    # Raw counts first. Two-decimal metrics can survive a scoring-logic change by
+    # coincidence — 30/31 and 60/62 both render as 0.97 — so the counts are what
+    # actually pin the recorded behaviour.
+    assert (score.tp, score.extracted) == (30, 31), "precision inputs changed"
+    assert (score.covered, score.expected) == (32, 34), "recall inputs changed"
+
+    # The published row in benchmark/EXTRACTION_QUALITY.md, to two decimals.
+    assert f"{score.precision:.2f}" == "0.97"
+    assert f"{score.recall:.2f}" == "0.94"
+    assert f"{score.f1:.2f}" == "0.95"
+    assert (score.noop_ok, score.noop_total) == (3, 3)
+    assert (score.multi_ok, score.multi_total) == (7, 9)
+
+
+# ── cassette integrity and sanitization (no SDK required) ────────────────────
+# These run in the base `requirements-dev.txt` suite, where the provider replay
+# skips. The committed artifact is checked even where it cannot be replayed.
+
+def _cassette_text() -> str:
+    return _CASSETTE.read_text(encoding="utf-8", errors="replace")
+
+
+def test_cassette_is_committed():
+    assert _CASSETTE.exists(), (
+        f"{_CASSETTE.name} is missing — the recorded Gemini evidence is the point of "
+        "this module; record it per cassettes/README.md"
+    )
+
+
+def test_cassette_has_the_expected_interaction_count():
+    """One request per dataset turn; more would mean retries were recorded.
+
+    An earlier attempt produced 75 interactions — 25 turns retried three times
+    against a provider that was rejecting every request. Counting them is how that
+    is caught without reading the responses.
+    """
+    body = _cassette_text()
+    assert body.count("\n- request:") == EXPECTED_INTERACTIONS, (
+        f"expected {EXPECTED_INTERACTIONS} interactions in {_CASSETTE.name}"
+    )
+
+
+def test_cassette_contains_only_successful_responses():
+    """Every recorded response must be a 200.
+
+    The first recording attempt captured 25 x HTTP 400 and still produced a
+    scoreable cassette, because the heuristic fallback answered every turn. A
+    cassette of error responses is not provider evidence.
+    """
+    import yaml
+
+    interactions = yaml.safe_load(_cassette_text())["interactions"]
+    codes = {i["response"]["status"]["code"] for i in interactions}
+    assert codes == {200}, f"non-200 responses recorded: {sorted(codes)}"
+
+
+def test_cassette_records_the_expected_model():
+    assert RECORDED_MODEL in _cassette_text()
+
+
+# Patterns assembled from parts so this file contains no credential-shaped literal —
+# the same reason `_secret_fixtures.py` exists. A scanner cannot tell a detection
+# fixture from a live key.
+_GOOGLE_KEY_RE = re.compile("AI" + "za" + r"[0-9A-Za-z_\-]{35}")
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._\-]{20,}")
+
+
+@pytest.mark.parametrize(
+    ("label", "pattern"),
+    [
+        ("google api key", _GOOGLE_KEY_RE),
+        ("bearer credential", _BEARER_RE),
+    ],
+)
+def test_cassette_contains_no_credential_material(label, pattern):
+    """Fails naming only the credential *category*, never the value."""
+    if not _CASSETTE.exists():
+        pytest.skip("cassette not recorded yet")
+    assert not pattern.search(_cassette_text()), (
+        f"{_CASSETTE.name} contains {label} material; re-record with the filters in "
+        "vcr_config and do not commit the current file"
+    )
+
+
+@pytest.mark.parametrize("header", ["x-goog-api-key", "authorization", "x-api-key", "api-key"])
+def test_cassette_has_no_unsanitized_credential_headers(header):
+    if not _CASSETTE.exists():
+        pytest.skip("cassette not recorded yet")
+    for line in _cassette_text().splitlines():
+        stripped = line.strip().lower()
+        if stripped.startswith(f"{header}:") or stripped.startswith(f"- {header}:"):
+            value = stripped.split(":", 1)[1].strip()
+            assert value in ("", "null", "[]", "none"), (
+                f"{_CASSETTE.name} carries an unsanitized '{header}' header"
+            )
+
+
+def test_cassette_has_no_key_query_parameter():
+    if not _CASSETTE.exists():
+        pytest.skip("cassette not recorded yet")
+    assert not re.search(r"[?&]key=[^&\s\"']+", _cassette_text()), (
+        f"{_CASSETTE.name} carries a 'key' query-string credential"
+    )
+
+
+def test_cassette_does_not_contain_the_local_gemini_key():
+    """The strongest available check: compare against the real key, if one exists.
+
+    Never prints or logs the value — only whether it appears.
+    """
+    key = os.getenv("GEMINI_API_KEY", "").strip()
+    if not key or key == REPLAY_PLACEHOLDER_KEY:
+        pytest.skip("no real GEMINI_API_KEY in this environment to compare against")
+    if not _CASSETTE.exists():
+        pytest.skip("cassette not recorded yet")
+    assert key not in _cassette_text(), (
+        f"{_CASSETTE.name} contains the live GEMINI_API_KEY — delete it, do not commit"
+    )
+
+
+def test_replay_placeholder_is_not_credential_shaped():
+    """The placeholder must never be mistaken for, or become, a real credential."""
+    assert not _GOOGLE_KEY_RE.match(REPLAY_PLACEHOLDER_KEY)
+    assert "AI" + "za" not in REPLAY_PLACEHOLDER_KEY
+    assert len(REPLAY_PLACEHOLDER_KEY) < 39


### PR DESCRIPTION
## Scope

Makes the real `gemini-2.5-flash` extraction-quality evidence reproducible in CI
without a real Gemini API key or outbound network access.

This PR does not change application runtime behavior.

## Recorded evidence

A single live recording was captured over the existing 25-turn extraction-quality
dataset through the real MemoryOps provider path:

`build_llm_provider -> extract_memories -> GeminiProvider -> google-genai`

Result:

- provider interactions: 25
- HTTP 200 responses: 25
- structured outcomes: 25
- heuristic fallbacks: 0
- strict-empty fallbacks: 0
- provider errors: 0

Raw scoring:

- tp: 30
- extracted: 31
- covered: 32
- expected: 34

Metrics:

- precision: **0.97**
- recall: **0.94**
- F1: **0.95**
- no-op: 3/3
- multi-memory: 7/9

## Historical result

An earlier uncaptured live run produced **0.94 / 0.94 / 0.94**, with 3/3 no-op and
7/9 multi-memory. Those provider responses were not preserved, so that exact run
cannot be replayed.

The committed recorded run — **0.97 / 0.94 / 0.95** — is therefore the canonical
reproducible result. It is kept as a historical note rather than a second table row,
so the two are not mistaken for concurrently reproducible measurements.

The available evidence does not establish why the two live runs differ. No causal
claim about model drift, SDK changes, or provider improvement is made.

## Deterministic replay

The committed cassette is replayed with no real Gemini API key, outbound network
blocked, VCR record mode `none`, and the real `google-genai` adapter installed.

Two local replays produced identical **0.97 / 0.94 / 0.95** results, and the cassette
remained byte-identical afterwards (sha256 unchanged).

## Zero-fallback evidence

Every outcome must be `provider == "gemini"` and `mode == "structured"`, so provider
failures cannot be silently scored through MemoryOps' heuristic fallback.

The cassette additionally requires all 25 responses to be **HTTP 200**.

This is deliberate. An earlier failed recording contained 25 provider `400`s while the
fallback layer still produced scoreable extraction output — a cassette that was
replayable, scoreable, and completely devoid of model output. A score alone is not
evidence of real-provider execution; neither is interaction count.

## Credential safety

Filtered credential surfaces: `x-goog-api-key`, `authorization`, `x-api-key`,
`api-key`, `x-goog-api-client`, and the `key` query parameter.

`x-goog-api-key` is what `google-genai` actually sends — a filter list copied from
another provider would have committed a live key.

Verification found no local Gemini key (compared directly, never printed), no Google
API-key pattern, no bearer credential, no unsanitized `key` query parameter, and no
gitleaks findings. These checks run in the base suite even where the provider SDK is
absent.

No Gemini secret is required by GitHub Actions.

## CI

The normal API suite continues to use the existing `requirements-dev.txt` environment,
with no provider SDK.

A dedicated evidence step installs the Gemini optional extra and runs only the recorded
Gemini evidence with no real credential, record mode `none`, and network blocked.

The dedicated step is not allowed to skip: CI parses the JUnit result and fails if the
evidence test was skipped. A silent skip would pass while proving nothing, which is how
this evidence gap arose in the first place.

## Verification

- full API suite: **1158 collected, exit 0**
- Ruff: clean
- dependency drift: current
- role / authz / web capability artifacts: current
- evals: PASS
- governance benchmark: 50/50
- SDK: 25
- paper harness: 54
- trust guards: 5 clean
- PR invariant gate: PASS
- `git diff --check`: clean
- gitleaks: clean

Offline stub extraction remains unchanged: **1.00 / 0.53 / 0.69**, 3/3 no-op, 4/9
multi-memory.

## Runtime impact

None. No files under `services/api/app/` are changed.

No changes to API behavior, prompts, schemas, provider configuration, Gemini runtime,
gateway, storage, auth, Railway, workers, or async architecture.