### PR TITLE
fix(security): make RLS behavioral verification fail closed

### DIFF
--- a/scripts/check_rls_policies.py
+++ b/scripts/check_rls_policies.py
@@ -7,9 +7,20 @@ Proves the database-level tenant isolation guarantee (ADR-006, invariant #1):
   2. A tenant-isolation policy exists on each.
   3. With app.tenant_id set to tenant A, a query never returns tenant B's rows.
 
-Designed to be CI-safe: if no database is reachable (or the driver isn't
-installed) it prints SKIP and exits 0, so it never blocks a no-infra pipeline.
-A genuine policy gap (DB reachable but RLS missing/leaking) exits 1.
+Two modes, deliberately different:
+
+**No-infra mode** — SQLAlchemy missing, or no database reachable. Prints SKIP and
+exits 0 so a laptop or a no-infra pipeline is never blocked.
+
+**Real-DB mode** — the database answered. The behavioral probe is then *mandatory*:
+if it cannot be provisioned, cannot authenticate, or cannot run, that is a FAIL, not
+a warning. A job that reaches a real Postgres and prints PASS must have actually
+proven cross-tenant isolation.
+
+That distinction was previously missing. The probe raised, the script printed
+``[WARN] behavioral probe skipped`` and returned 0, and the Postgres CI job went
+green while proving only that the *structural* policies exist — the leak test itself
+never ran. Structure without behaviour is not the guarantee this file claims to make.
 
 Usage:
     python scripts/check_rls_policies.py
@@ -45,12 +56,24 @@ def _probe_url(admin_url: str) -> str:
     RLS is bypassed by superusers/BYPASSRLS roles, so probing on the admin
     connection would be meaningless. Prefer an explicit MEMORYOPS_RLS_PROBE_URL;
     otherwise derive a non-superuser role on the same database.
+
+    ``render_as_string(hide_password=False)`` is required. ``str(URL)`` and the
+    default ``render_as_string()`` mask the password as ``***``, so the DSN carries
+    the literal three characters and the probe authenticates with them. Under
+    ``trust`` auth that silently works; under ``scram``/``md5`` — i.e. CI — it fails
+    with ``password authentication failed for user "rls_probe_role"``, which is
+    exactly what the Postgres job was reporting while still passing.
+    ``tests/test_rls.py`` had already hit this and documented it; this script had not.
     """
     if (override := os.getenv("MEMORYOPS_RLS_PROBE_URL")):
         return override
     from sqlalchemy.engine import make_url
 
-    return str(make_url(admin_url).set(username=_PROBE_ROLE, password=_PROBE_PW))
+    return (
+        make_url(admin_url)
+        .set(username=_PROBE_ROLE, password=_PROBE_PW)
+        .render_as_string(hide_password=False)
+    )
 
 
 def _is_superuser(engine) -> bool:
@@ -75,10 +98,42 @@ def _ensure_probe_engine(engine, url: str, is_super: bool):
         ).scalar()
         if not exists:
             conn.execute(text(f"create role {_PROBE_ROLE} login password '{_PROBE_PW}'"))
+        else:
+            # Existing is not the same as correct. A role left over from an earlier
+            # run may have a different password, or no LOGIN, and the probe would
+            # fail to authenticate for a reason that looks like an RLS problem.
+            conn.execute(text(f"alter role {_PROBE_ROLE} login password '{_PROBE_PW}'"))
+        # Never grant BYPASSRLS or superuser: the probe is only meaningful as a role
+        # that RLS actually applies to.
+        conn.execute(text(f"alter role {_PROBE_ROLE} nosuperuser nobypassrls"))
         conn.execute(text(f"grant usage on schema public to {_PROBE_ROLE}"))
         for table in _PROTECTED:
             conn.execute(text(f"grant select, insert on {table} to {_PROBE_ROLE}"))
     return create_engine(_probe_url(url), future=True)
+
+
+def _assert_probe_is_unprivileged(probe_engine) -> None:
+    """The probe must run as a role RLS applies to, or it proves nothing.
+
+    A superuser or BYPASSRLS role would read across tenants and be reported as a
+    leak — so this cannot mask a real failure. It exists to make the *reason*
+    explicit rather than surfacing as a confusing cross-tenant leak.
+    """
+    from sqlalchemy import text
+
+    with probe_engine.connect() as conn:
+        is_super = conn.execute(
+            text("select current_setting('is_superuser')")
+        ).scalar_one() == "on"
+        bypass = conn.execute(
+            text("select coalesce(bool_or(rolbypassrls), false) from pg_roles "
+                 "where rolname = current_user")
+        ).scalar_one()
+    if is_super or bypass:
+        raise RuntimeError(
+            "probe role is privileged (superuser or BYPASSRLS); RLS would be bypassed "
+            "and the behavioral proof would be meaningless"
+        )
 
 
 def _seed_probe_row(engine) -> None:
@@ -193,9 +248,11 @@ def main() -> int:
     #    Seed a foreign-tenant row as admin, then confirm a probe role scoped to a
     #    different tenant cannot see it.
     is_super = _is_superuser(engine)
+    probe_ran = False
     try:
         _seed_probe_row(engine)
         probe_engine = _ensure_probe_engine(engine, url, is_super)
+        _assert_probe_is_unprivileged(probe_engine)
         with probe_engine.connect() as pconn:
             pconn.execute(text("select set_config('app.tenant_id', 'rls_probe_a', true)"))
             leak_checks = {
@@ -212,15 +269,26 @@ def main() -> int:
                     text("select count(*) from worker_runs where tenant_id = 'rls_probe_b'")
                 ).scalar_one(),
             }
+        probe_ran = True
         leaked = {table: count for table, count in leak_checks.items() if count}
         if leaked:
             failures.append(f"cross-tenant leak under RLS: {leaked}")
         else:
             print("[OK]   behavioral probe: no cross-tenant rows visible (non-superuser role)")
-    except Exception as exc:  # noqa: BLE001
-        print(f"[WARN] behavioral probe skipped ({type(exc).__name__}: {exc})")
+    except Exception as exc:  # noqa: BLE001 — reachable DB: inability to probe IS a failure
+        # Fail closed. The database answered, so "could not prove isolation" is a
+        # result, not an excuse — this is the branch that used to print a warning and
+        # return 0 while the leak test never executed.
+        failures.append(
+            f"behavioral probe did not execute ({type(exc).__name__}: {exc})"
+        )
     finally:
         _cleanup_probe_row(engine)
+
+    if not probe_ran and not failures:
+        # Defensive: a future edit must not be able to reach a green result without
+        # the probe having run.
+        failures.append("behavioral probe did not execute (no result recorded)")
 
     print()
     if failures:

--- a/services/api/tests/test_rls_verifier.py
+++ b/services/api/tests/test_rls_verifier.py
@@ -1,0 +1,273 @@
+"""`scripts/check_rls_policies.py` must fail closed once a database is reachable.
+
+The verifier has two legitimate modes and one illegitimate outcome:
+
+* **no-infra** — no SQLAlchemy, or nothing listening. SKIP + exit 0 keeps laptops and
+  no-infra pipelines usable.
+* **real-DB** — the database answered. The behavioral probe is then mandatory.
+* **illegitimate** — a reachable database, a probe that never ran, and a green exit.
+
+That third case was real. The Postgres CI job printed
+``[WARN] behavioral probe skipped (... password authentication failed for user
+"rls_probe_role")`` and passed, so it verified only that the RLS *policies exist* —
+the cross-tenant leak test itself never executed for as long as that warning was
+present.
+
+These tests drive `main()` with a fake SQLAlchemy so they need no database, and
+assert **exit codes**, not log text: a message can be reworded, an exit code is the
+contract CI actually consumes.
+"""
+
+from __future__ import annotations
+
+import sys
+import types as pytypes
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import check_rls_policies as rls  # noqa: E402
+
+
+# ── fake SQLAlchemy surface ──────────────────────────────────────────────────
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __iter__(self):
+        return iter(self._rows)
+
+    def scalar_one(self):
+        first = self._rows[0]
+        return first[0] if isinstance(first, tuple) else first
+
+    def scalar(self):
+        if not self._rows:
+            return None
+        return self._rows[0][0] if isinstance(self._rows[0], tuple) else self._rows[0]
+
+
+class _Conn:
+    """Answers the handful of queries the verifier makes.
+
+    `is_probe` matters for `is_superuser`: the admin connection is a superuser (which
+    is what makes the script provision a dedicated role), while the probe connection
+    must not be. Conflating the two made a probe-connection test pass on the
+    privileged-role assertion instead of the failure it claimed to exercise.
+    """
+
+    def __init__(self, cfg, is_probe=False):
+        self.cfg = cfg
+        self.is_probe = is_probe
+
+    def execute(self, stmt, params=None):
+        q = " ".join(str(stmt).lower().split())
+        if "relrowsecurity" in q:
+            return _Result([(t, self.cfg["enabled"], self.cfg["forced"]) for t in rls._PROTECTED])
+        if "pg_policies" in q:
+            return _Result([(t,) for t in rls._PROTECTED] if self.cfg["policies"] else [])
+        if "is_superuser" in q:
+            super_here = (
+                self.cfg.get("probe_is_super", False) if self.is_probe else self.cfg["is_super"]
+            )
+            return _Result([("on" if super_here else "off",)])
+        if "rolbypassrls" in q:
+            return _Result([(self.cfg.get("probe_bypassrls", False),)])
+        if "from pg_roles" in q:
+            return _Result([(1,)] if self.cfg.get("role_exists") else [])
+        if q.startswith("select count(*)"):
+            return _Result([(1 if self.cfg["leak"] else 0,)])
+        return _Result([])
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+class _Engine:
+    """`is_probe` matters: the admin connection must stay usable.
+
+    An earlier version of this fake raised on *every* connect, so `main()` took the
+    "cannot reach database" path and skipped — testing the no-infra branch while
+    claiming to test the probe branch.
+    """
+
+    def __init__(self, cfg, is_probe=False):
+        self.cfg = cfg
+        self.is_probe = is_probe
+
+    def connect(self):
+        if self.is_probe and self.cfg.get("probe_connect_raises"):
+            raise RuntimeError('password authentication failed for user "rls_probe_role"')
+        return _Conn(self.cfg, is_probe=self.is_probe)
+
+    def begin(self):
+        return _Conn(self.cfg, is_probe=self.is_probe)
+
+
+def _install_fake_sqlalchemy(monkeypatch, cfg):
+    """Make `from sqlalchemy import ...` inside the script resolve to the fake."""
+    sa = pytypes.ModuleType("sqlalchemy")
+    sa.text = lambda s: s
+
+    def create_engine(url, **kw):
+        if cfg.get("create_engine_raises"):
+            raise RuntimeError("boom")
+        # The probe engine is the one built from the derived probe URL.
+        return _Engine(cfg, is_probe=rls._PROBE_ROLE in str(url))
+
+    sa.create_engine = create_engine
+
+    engine_mod = pytypes.ModuleType("sqlalchemy.engine")
+
+    class _URL:
+        """Faithful enough that the derived probe DSN really names the probe role.
+
+        A no-op `set()` made `_probe_url()` return the admin DSN, so the fake could
+        not tell the probe engine from the admin one.
+        """
+
+        def __init__(self, s, username="u", password="pw"):
+            self.s = s
+            self.username = username
+            self.password = password
+
+        def set(self, username=None, password=None, **kw):
+            return _URL(self.s, username or self.username, password or self.password)
+
+        def render_as_string(self, hide_password=True):
+            pw = "***" if hide_password else self.password
+            return f"postgresql+psycopg://{self.username}:{pw}@localhost:5432/d"
+
+    engine_mod.make_url = _URL
+    sa.engine = engine_mod
+
+    monkeypatch.setitem(sys.modules, "sqlalchemy", sa)
+    monkeypatch.setitem(sys.modules, "sqlalchemy.engine", engine_mod)
+
+
+def _cfg(**over):
+    base = {
+        "enabled": True, "forced": True, "policies": True,
+        "is_super": False, "leak": False, "role_exists": False,
+    }
+    base.update(over)
+    return base
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("MEMORYOPS_RLS_PROBE_URL", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://u:pw@localhost:5432/d")
+
+
+# ── no-infra mode may skip ───────────────────────────────────────────────────
+def test_missing_sqlalchemy_skips_and_exits_zero(monkeypatch, capsys):
+    monkeypatch.setitem(sys.modules, "sqlalchemy", None)
+
+    def _raise(*a, **k):
+        raise ImportError("no sqlalchemy")
+
+    monkeypatch.setattr(rls, "main", rls.main)  # keep reference
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "sqlalchemy":
+            raise ImportError("no sqlalchemy")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert rls.main() == 0
+    assert "SKIP" in capsys.readouterr().out
+
+
+def test_unreachable_database_skips_and_exits_zero(monkeypatch, capsys):
+    _install_fake_sqlalchemy(monkeypatch, _cfg(create_engine_raises=True))
+    assert rls.main() == 0
+    assert "SKIP" in capsys.readouterr().out
+
+
+# ── real-DB mode must fail closed ────────────────────────────────────────────
+def test_structural_gap_fails(monkeypatch):
+    """RLS enabled but not FORCED is a policy gap, not a warning."""
+    _install_fake_sqlalchemy(monkeypatch, _cfg(forced=False))
+    assert rls.main() == 1
+
+
+def test_missing_policy_fails(monkeypatch):
+    _install_fake_sqlalchemy(monkeypatch, _cfg(policies=False))
+    assert rls.main() == 1
+
+
+def test_probe_that_cannot_connect_fails(monkeypatch, capsys):
+    """The regression this file exists for.
+
+    A reachable database plus an unauthenticable probe role used to print
+    `[WARN] behavioral probe skipped` and return 0.
+    """
+    _install_fake_sqlalchemy(monkeypatch, _cfg(is_super=True, probe_connect_raises=True))
+    rc = rls.main()
+    out = capsys.readouterr().out
+    assert rc == 1, "a probe that never ran must not pass"
+    assert "behavioral probe did not execute" in out
+    assert "WARN" not in out, "a reachable DB must not downgrade this to a warning"
+
+
+def test_cross_tenant_leak_fails(monkeypatch, capsys):
+    _install_fake_sqlalchemy(monkeypatch, _cfg(leak=True))
+    assert rls.main() == 1
+    assert "cross-tenant leak" in capsys.readouterr().out
+
+
+def test_privileged_probe_role_fails(monkeypatch, capsys):
+    """A BYPASSRLS probe proves nothing; say so explicitly."""
+    _install_fake_sqlalchemy(monkeypatch, _cfg(probe_bypassrls=True))
+    assert rls.main() == 1
+    assert "behavioral probe did not execute" in capsys.readouterr().out
+
+
+# ── the healthy path ─────────────────────────────────────────────────────────
+def test_valid_non_superuser_probe_passes(monkeypatch, capsys):
+    _install_fake_sqlalchemy(monkeypatch, _cfg())
+    rc = rls.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "behavioral probe: no cross-tenant rows visible" in out
+    assert "RESULT: PASS" in out
+
+
+# ── the root cause, pinned ───────────────────────────────────────────────────
+def test_probe_url_preserves_the_password():
+    """`str(URL)` masks the password as `***`; the probe then authenticates with it.
+
+    Harmless under `trust`, a hard failure under `scram`/`md5` — i.e. CI, where it
+    produced `password authentication failed for user "rls_probe_role"` while the
+    job still passed. Verified against real SQLAlchemy, not the fake.
+    """
+    pytest.importorskip("sqlalchemy")
+    from sqlalchemy.engine import make_url
+
+    admin = "postgresql+psycopg://admin:adminpw@localhost:5432/db"
+    derived = rls._probe_url(admin)
+    assert make_url(derived).password == rls._PROBE_PW
+    assert "***" not in derived
+    assert make_url(derived).username == rls._PROBE_ROLE
+    # The old construction, for contrast — this is what regressed.
+    masked = str(make_url(admin).set(username=rls._PROBE_ROLE, password=rls._PROBE_PW))
+    assert make_url(masked).password == "***"
+
+
+def test_probe_role_constants_are_unprivileged_by_contract():
+    """The provisioning SQL must never grant superuser or BYPASSRLS."""
+    source = (REPO_ROOT / "scripts" / "check_rls_policies.py").read_text(encoding="utf-8")
+    lowered = source.lower()
+    assert "nosuperuser nobypassrls" in lowered
+    for forbidden in ("create role rls_probe_role login superuser", "with bypassrls"):
+        assert forbidden not in lowered


### PR DESCRIPTION
## Scope

Makes the real PostgreSQL RLS behavioral verifier fail closed when the database is
reachable but the non-superuser cross-tenant probe cannot execute.

No application runtime behavior is changed.

## Root cause

The behavioral probe constructed its non-superuser connection URL using SQLAlchemy
`str(URL)`. SQLAlchemy masks passwords in that representation, so the probe role's
real password was replaced with the literal masked value when building the connection
string — and the probe then authenticated with those characters.

This passed unnoticed locally, where PostgreSQL uses `trust` authentication, and
failed under password-authenticated CI. The verifier caught the exception, emitted a
warning, and still returned PASS:

```
[WARN] behavioral probe skipped (OperationalError: ... FATAL: password
authentication failed for user "rls_probe_role")
RESULT: PASS — RLS enforced on all protected tables.
```

So the Postgres job proved the RLS *policies exist* while the cross-tenant leak test
— the part that actually demonstrates tenant isolation — never ran. Structure without
behaviour is not the guarantee this script claims to make.

`tests/test_rls.py` had already hit this exact SQLAlchemy footgun and documented it in
a docstring; the verifier never received the same fix.

## Fix

- construct the probe URL without SQLAlchemy password masking
- reconcile an existing probe role rather than assuming its password/state is correct
- require the probe role to remain LOGIN, non-superuser, no BYPASSRLS — asserted
  explicitly, so a privileged probe reports *why* rather than surfacing as a
  confusing cross-tenant leak
- fail when a reachable database cannot execute the behavioral probe
- retain no-infrastructure SKIP behavior when no database is available
- guard against future false PASS results with explicit probe-executed state

## Verified behavior

The local Homebrew server uses `trust` and **cannot** reproduce this, so verification
used an isolated `scram-sha-256` PostgreSQL instance.

**Normal case:** behavioral probe executes · non-superuser role authenticates ·
tenant A cannot see tenant B rows · cross-tenant leak = 0 · verifier exits 0

**Broken probe authentication:** pre-fix script exits **0** (fail-open); fixed script
exits **1**

**Existing role with stale password:** role state reconciled, probe executes
successfully — confirmed against the role left behind by the failing pre-fix run

## Verification

- focused verifier tests: **10 passed**
- full API suite: **1175 collected, exit 0** (main is 1165 in the same environment;
  +10 is exactly the new test file)
- evals: PASS
- governance benchmark: 50/50
- SDK: 25
- paper harness: 54
- trust guards: 5 clean
- PR invariant gate: PASS
- Ruff: clean
- gitleaks: clean
- `git diff --check`: clean

Tests drive `main()` with a fake SQLAlchemy and assert **exit codes** rather than log
text — a message can be reworded, an exit code is what CI consumes. Writing them
surfaced two defects in the fake itself (raising on every connect tested the no-infra
branch while claiming to test the probe; a shared `is_super` flag made the
connect-failure case pass on the privileged-role assertion). Each failure case was
then confirmed to fail for its own stated reason.

## Runtime impact

None. Only `scripts/check_rls_policies.py` and its tests change. No files under
`services/api/app/` are modified.