### PR TITLE
benchmark: add reproducible Mem0 external baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,21 @@ jobs:
           print("wheel import ok; prompt assets loaded:", available_tasks())
           PY
 
+      # The `benchmark` extra exists only for the external-baseline comparison (S4
+      # Mem0) and is deliberately absent from every runtime requirement set.
+      - name: Benchmark dependencies stay out of the runtime images
+        working-directory: services/api
+        run: |
+          set -euo pipefail
+          for f in requirements.txt requirements-postgres.txt \
+                   requirements-providers.txt requirements-production.txt \
+                   requirements-dev.txt; do
+            if grep -qiE '^(mem0ai|langchain)' "$f"; then
+              echo "::error::$f contains a benchmark-only dependency"; exit 1
+            fi
+          done
+          echo "no benchmark-only dependency in any runtime requirement set"
+
       # The provider adapters import their SDKs lazily, so a missing SDK shows up only
       # at call time (as a silent stub degradation). Prove each advertised extra
       # actually resolves and exposes the module its adapter imports.
@@ -176,6 +191,94 @@ jobs:
 
       # A skip here is a failure. Without this the step could pass while proving
       # nothing — exactly how the evidence gap arose in the first place.
+      - name: Install the benchmark extra (external baselines only)
+        run: python -m pip install -r services/api/requirements-benchmark.txt
+
+      # Installing and importing the extra proves nothing about the comparison. The
+      # adapter tests must *execute*: without the extra they skip, and a skipped
+      # suite would leave this job green while the external baseline was never run —
+      # the same false-evidence shape the recorded-provider step guards against.
+      - name: Mem0 adapter tests execute (no provider keys, must not skip)
+        env:
+          MEMORYOPS_STORAGE: memory
+          MEM0_TELEMETRY: "False"
+        run: |
+          set -euo pipefail
+          unset OPENAI_API_KEY GEMINI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY || true
+          python -c "
+          import importlib.metadata as m
+          v = m.version('mem0ai')
+          assert v == '2.0.17', f'expected mem0ai==2.0.17, got {v}'
+          print('mem0ai', v, '| langchain', m.version('langchain'), '| langchain-core', m.version('langchain-core'))
+          "
+          PYTHONPATH=".:services/api" python -m pytest paper/harness/tests/test_mem0_adapter.py \
+            -rs -p no:cacheprovider --junitxml=/tmp/mem0-tests.xml
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+          root = ET.parse("/tmp/mem0-tests.xml").getroot()
+          cases = list(root.iter("testcase"))
+          skipped = [c.get("name") for c in cases if c.find("skipped") is not None]
+          assert cases, "no Mem0 adapter tests ran at all"
+          assert not skipped, (
+              f"{len(skipped)} Mem0 adapter test(s) SKIPPED — the benchmark extra must be "
+              f"installed here so the external baseline is actually exercised: {skipped}"
+          )
+          print(f"{len(cases)} Mem0 adapter tests executed, 0 skipped")
+          PY
+
+      # Run the real comparison and assert the published outcome, so COMPARISON.md
+      # cannot drift away from what the harness actually produces.
+      - name: External memory-system comparison executes with S4 present
+        env:
+          MEMORYOPS_STORAGE: memory
+          MEM0_TELEMETRY: "False"
+        run: |
+          set -euo pipefail
+          unset OPENAI_API_KEY GEMINI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY || true
+          PYTHONPATH=".:services/api" python - <<'PY'
+          from collections import Counter
+
+          from paper.harness import baselines as bl
+          from paper.harness import mem0_adapter as m4
+          from paper.harness import memoryops_adapter as moa
+          from paper.harness.cases import default_cases
+          from paper.harness.runner import run_suite
+          from paper.harness.types import Outcome
+
+          assert m4.available(), "Mem0 benchmark extra is not importable in this job"
+
+          cases = default_cases()
+          results = run_suite([moa.s0, moa.s0u, bl.s2, m4.s4], cases)
+
+          tally = {}
+          for r in results:
+              tally.setdefault(r.system, Counter())[r.outcome] += 1
+
+          for system in ("S0", "S0-U", "S2", "S4"):
+              assert system in tally, f"{system} missing from the comparison"
+              c = tally[system]
+              print(f"{system:6} pass={c[Outcome.PASS]} fail={c[Outcome.FAIL]} "
+                    f"unsupported={c[Outcome.UNSUPPORTED]} error={c[Outcome.ERROR]}")
+
+          # MemoryOps must never fail or error on a capability it claims.
+          for system in ("S0", "S0-U"):
+              assert tally[system][Outcome.FAIL] == 0, f"{system} FAILED a case"
+              assert tally[system][Outcome.ERROR] == 0, f"{system} ERRORED"
+
+          # The published COMPARISON.md numbers, asserted rather than trusted.
+          for system in ("S0", "S0-U", "S2", "S4"):
+              c = tally[system]
+              assert (c[Outcome.PASS], c[Outcome.FAIL], c[Outcome.ERROR]) == (len(cases), 0, 0), (
+                  f"{system} no longer matches the published result: {dict(c)}"
+              )
+          print("comparison matches benchmark/COMPARISON.md")
+          PY
+
+      - name: Audit the benchmark dependency graph
+        run: |
+          python -m pip install --quiet pip-audit
+          pip-audit --strict --progress-spinner off -r services/api/requirements-benchmark.txt
+
       - name: Recorded Gemini extraction evidence (no key, no network)
         working-directory: services/api
         env:

--- a/benchmark/COMPARISON.md
+++ b/benchmark/COMPARISON.md
@@ -1,0 +1,149 @@
+# External memory-system comparison
+
+## Purpose
+
+Run the repository's existing deterministic governance probes through MemoryOps *and*
+external memory systems, scored identically, so MemoryOps' behaviour can be compared
+against something other than itself.
+
+The benchmark is not designed for MemoryOps to win. Cases were fixed before the
+external systems were added and were not changed afterwards. The measured outcome
+below is reported as observed, including where it is unflattering.
+
+## Systems
+
+| Id | System | Configuration |
+|----|--------|---------------|
+| `S0` | MemoryOps, governed | full policy / retrieval / deletion path |
+| `S0-U` | MemoryOps, governance disabled | ablation twin |
+| `S1` | Full-context baseline | keeps raw history, no addressable memory |
+| `S2` | Plain vector baseline | embed → cosine top-k → compose |
+| `S3` | Rolling-summary baseline | single growing summary string |
+| `S4` | **Mem0** | `mem0ai==2.0.17`, real product API |
+
+### S4 (Mem0) configuration
+
+| Setting | Value |
+|---|---|
+| `mem0ai` | `2.0.17` |
+| `langchain` | `1.3.14` |
+| `langchain-core` | `1.5.3` |
+| Vector backend | local Qdrant, temporary directory, on-disk, no network |
+| Embedder | the repository's deterministic embedder — **the same one `S2` uses** |
+| LLM | `NeverCalledChatModel` — raises if invoked |
+| Ingestion | `infer=False` |
+| **Live provider calls** | **0** |
+
+The embedder is held constant across `S2` and `S4` on purpose: the intent is to compare
+*memory-system semantics*, not which embedding model is stronger.
+
+Mem0 defaults to OpenAI for both its LLM and its embedder, and constructs the LLM
+eagerly in `Memory.__init__` — so `infer=False` alone does not avoid a provider. Both
+model objects are injected through Mem0's sanctioned `langchain` provider. The chat
+model raises on invocation, which is what makes "0 provider calls" a checked property
+rather than an assertion.
+
+## Result semantics
+
+Four-valued, per `paper/protocol.md` §5:
+
+| Outcome | Meaning |
+|---|---|
+| `PASS` | supported capability, requirement met |
+| `FAIL` | supported capability, requirement violated |
+| `UNSUPPORTED` | the system has no such capability — a finding, never a failure |
+| `ERROR` | crash, timeout, or malformed integration result |
+
+`UNSUPPORTED` never enters the correctness denominator. `ERROR` stays visible.
+
+- **Coverage** = `(PASS + FAIL) / total cases`
+- **Conditional correctness** = `PASS / (PASS + FAIL)`
+
+## Cases
+
+Four deterministic invariant cases, scored from *retrieved memory* rather than model
+prose, so they are meaningful under a deterministic stub:
+
+| Suite | Case | Requirement |
+|---|---|---|
+| `tenant_isolation` | `iso-cross-tenant` | tenant B must not recall tenant A's fact |
+| `tenant_isolation` | `iso-cross-user` | user C must not recall user A's fact |
+| `deletion_leakage` | `del-exact-probe` | a deleted memory must not resurface on an exact probe |
+| `deletion_leakage` | `del-paraphrased-probe` | …nor on a paraphrased probe |
+
+## Raw results
+
+| System | Pass | Fail | Unsupported | Error | Coverage | Conditional correctness |
+|--------|-----:|-----:|------------:|------:|---------:|------------------------:|
+| S0 MemoryOps (governed) | 4 | 0 | 0 | 0 | 4/4 (100%) | 4/4 (100%) |
+| S0-U MemoryOps (ungoverned) | 4 | 0 | 0 | 0 | 4/4 (100%) | 4/4 (100%) |
+| S1 full-context | 2 | 0 | 2 | 0 | 2/4 (50%) | 2/2 (100%) |
+| S2 plain vector | 4 | 0 | 0 | 0 | 4/4 (100%) | 4/4 (100%) |
+| S3 rolling summary | 2 | 0 | 2 | 0 | 2/4 (50%) | 2/2 (100%) |
+| **S4 Mem0** | **4** | **0** | **0** | **0** | **4/4 (100%)** | **4/4 (100%)** |
+
+`S1` and `S3` are `UNSUPPORTED` on both deletion cases because neither has addressable
+memory to delete. That is a capability finding, not a failure.
+
+## What this shows
+
+**On the four current deterministic deletion/isolation probes, the plain vector
+baseline also passes all cases. These probes therefore do not, by themselves,
+demonstrate a governance advantage for MemoryOps.**
+
+Mem0 likewise passes all four. So do MemoryOps with governance enabled *and* with
+governance disabled (`S0-U`).
+
+The honest reading: at this probe resolution, four systems are tied. A simple
+embed-and-retrieve store scoped by key is sufficient to pass these particular cases,
+and nothing here distinguishes a governed memory layer from an ungoverned one.
+
+## Limitations
+
+1. **Only the current protocol cases were run.** Four deterministic invariant cases,
+   two suites. No case was added or altered after seeing results.
+
+2. **Mem0 runs with `infer=False`.** Ingestion stores the supplied fact verbatim.
+
+3. **Mem0's LLM-driven behaviour is therefore not evaluated** — extraction,
+   consolidation, deduction and memory rewriting are exactly the parts an LLM drives,
+   and all are out of scope here. Nothing in this document speaks to Mem0's product
+   quality.
+
+4. **A `PASS` for isolation does not imply an equivalent enforcement mechanism.**
+   MemoryOps enforces tenant isolation in the application *and* at the database via
+   Postgres `FORCE ROW LEVEL SECURITY`, verified separately by a fail-closed
+   behavioural probe. Mem0 is scoped here through its identity/filter semantics, with
+   the harness `Scope(tenant, user)` mapped to a compound `user_id` because Mem0 has no
+   tenant construct. The benchmark scores the externally observed requirement, not
+   architectural equivalence — these are different guarantees that happen to produce
+   the same observable outcome on these probes.
+
+5. **`S2` passing every current probe means these probes are insufficient to establish
+   overall governance superiority.** Capabilities the protocol defines but these cases
+   do not exercise — policy-before-storage, consent, retention, admission and output
+   gates, audit evidence, deletion lineage — remain unmeasured here. They are existing
+   protocol scope, not a response to this result, and were deliberately not added to
+   this run.
+
+6. **No paid LLM or provider calls were made.** 0 live calls across every system.
+
+## Reproduce
+
+The benchmark extra is optional and quarantined from every runtime image. Without it,
+`S4` is simply absent and the remaining five systems still run.
+
+```bash
+cd services/api && pip install -r requirements-dev.txt -r requirements-benchmark.txt
+cd ../.. && PYTHONPATH=".:services/api" MEMORYOPS_STORAGE=memory \
+  python paper/run_experiments.py
+```
+
+Adapter tests:
+
+```bash
+PYTHONPATH=".:services/api" python -m pytest paper/harness/tests/test_mem0_adapter.py
+```
+
+No provider credentials are required or used. Results were identical across two
+consecutive full runs.

--- a/paper/harness/mem0_adapter.py
+++ b/paper/harness/mem0_adapter.py
@@ -1,0 +1,251 @@
+"""S4 — Mem0, driven through its real API with no paid provider (protocol §3).
+
+Mem0 is a *comparison subject*, not a MemoryOps dependency. This adapter drives the
+real `mem0.Memory` object: storage, retrieval and deletion all go through Mem0's own
+API, and nothing here reaches past it into the underlying vector store.
+
+Running it for free
+-------------------
+Mem0 defaults to OpenAI for both its LLM and its embedder, and it constructs the LLM
+**eagerly in `Memory.__init__`** — so `infer=False` alone is not enough to avoid a
+provider. Both model objects are therefore injected through Mem0's sanctioned
+`langchain` provider:
+
+* **embedder** — the repository's own deterministic embedding function, the same one
+  the S2 plain-vector baseline uses. Holding the embedder constant is deliberate: the
+  benchmark is meant to compare *memory-system semantics*, not which embedding model
+  is better.
+* **LLM** — `NeverCalledChatModel`, which raises if Mem0 ever invokes it. Deterministic
+  ingestion uses `infer=False`, so no LLM call should occur; if one does, the run
+  fails loudly rather than silently reaching for a network provider.
+
+Vector state lives in a temporary directory, created per adapter instance and removed
+on `reset()`/`close()`, so nothing is written to the repository, the user's home, or
+any production store.
+
+What this measures, and what it does not
+----------------------------------------
+`infer=False` bypasses Mem0's LLM-driven memory deduction. This adapter therefore
+evaluates the deterministic behaviour the current invariant cases probe — storage,
+retrieval, deletion, and scope separation — and says nothing about Mem0's extraction,
+consolidation or memory-rewrite quality, which are the parts an LLM drives. Any
+comparison drawn from it must be limited accordingly; see `benchmark/COMPARISON.md`.
+
+Scope mapping
+-------------
+The harness `Scope(tenant_id, user_id)` is mapped onto Mem0's identity model as
+`user_id="{tenant_id}:{user_id}"`. Mem0 has no tenant construct, so a compound
+identity is the closest honest expression of the boundary the cases probe. That is
+API-level scoping, not database-enforced isolation — it is not equivalent to
+MemoryOps' Postgres `FORCE ROW LEVEL SECURITY`, and a PASS here must not be read as
+the same guarantee.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+from .types import (
+    Capability,
+    EvidenceResult,
+    ForgetResult,
+    IngestResult,
+    MemoryRef,
+    OpStatus,
+    QueryResult,
+    Scope,
+    UpdateResult,
+)
+
+_API = Path(__file__).resolve().parents[2] / "services" / "api"
+if str(_API) not in sys.path:
+    sys.path.insert(0, str(_API))
+
+#: Mem0's embedder config wants a fixed dimension; the repository's stub embedder
+#: produces this many components.
+_EMBED_DIMS = 1536
+
+
+def _deterministic_embeddings():
+    """LangChain ``Embeddings`` backed by the repository's stub embedder.
+
+    The same function S2 uses, so the two systems differ by memory semantics rather
+    than by embedding quality.
+    """
+    from langchain.embeddings.base import Embeddings
+
+    from app.embeddings import embed
+
+    class _RepoEmbeddings(Embeddings):
+        def embed_documents(self, texts: list[str]) -> list[list[float]]:
+            return [embed(t) for t in texts]
+
+        def embed_query(self, text: str) -> list[float]:
+            return embed(text)
+
+    return _RepoEmbeddings()
+
+
+def _build_never_called_model():
+    """A LangChain chat model that refuses to be used.
+
+    Mem0 requires an LLM object to construct even when every call site passes
+    ``infer=False``. Supplying one that raises turns "an unexpected LLM call" into a
+    loud failure instead of a silent network request — the difference between a
+    benchmark that is provider-free and one that merely looks it.
+
+    Built lazily so importing this module does not require LangChain.
+    """
+    from langchain_core.language_models.chat_models import BaseChatModel
+    from langchain_core.outputs import ChatResult
+
+    class _NeverCalled(BaseChatModel):
+        @property
+        def _llm_type(self) -> str:
+            return "never-called"
+
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+            raise AssertionError(
+                "Mem0 invoked the LLM during a deterministic benchmark run; this run is "
+                "not provider-free. Ingestion must use infer=False."
+            )
+
+    return _NeverCalled()
+
+
+def available() -> bool:
+    """Whether the benchmark extra is installed. Keeps S4 optional for normal runs."""
+    try:
+        import langchain  # noqa: F401
+        import langchain_core  # noqa: F401
+        import mem0  # noqa: F401
+    except Exception:  # noqa: BLE001 — absence is a configuration state, not an error
+        return False
+    return True
+
+
+def mem0_version() -> str:
+    import importlib.metadata as md
+
+    try:
+        return md.version("mem0ai")
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+class Mem0Adapter:
+    """S4 — the real Mem0, configured to run offline."""
+
+    name = "S4"
+
+    def __init__(self) -> None:
+        self._dir: str | None = None
+        self._memory = None
+        self._build()
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+    def _build(self) -> None:
+        from mem0 import Memory
+
+        self._dir = tempfile.mkdtemp(prefix="memoryops-bench-mem0-")
+        config = {
+            "llm": {"provider": "langchain", "config": {"model": _build_never_called_model()}},
+            "embedder": {
+                "provider": "langchain",
+                "config": {"model": _deterministic_embeddings()},
+            },
+            "vector_store": {
+                "provider": "qdrant",
+                "config": {
+                    "collection_name": "memoryops_benchmark",
+                    "embedding_model_dims": _EMBED_DIMS,
+                    "path": self._dir,
+                },
+            },
+        }
+        self._memory = Memory.from_config(config)
+
+    def close(self) -> None:
+        """Drop the on-disk vector state. Idempotent."""
+        self._memory = None
+        if self._dir:
+            shutil.rmtree(self._dir, ignore_errors=True)
+            self._dir = None
+
+    def reset(self) -> None:
+        """Rebuild from empty. A fresh directory guarantees no case inherits state."""
+        self.close()
+        self._build()
+
+    # ── contract ─────────────────────────────────────────────────────────────
+    def capabilities(self) -> set[Capability]:
+        # No governance/audit export: Mem0 is not a governance product, and claiming
+        # otherwise would turn a legitimate `unsupported` into a false comparison.
+        return {Capability.INGEST, Capability.QUERY, Capability.FORGET, Capability.UPDATE}
+
+    @staticmethod
+    def _identity(scope: Scope) -> str:
+        """Mem0 has no tenant concept; a compound id is the closest honest mapping."""
+        return f"{scope.tenant_id}:{scope.user_id}"
+
+    def ingest(self, scope: Scope, message: str) -> IngestResult:
+        try:
+            # infer=False: store the supplied fact verbatim, no LLM deduction.
+            result = self._memory.add(message, user_id=self._identity(scope), infer=False)
+        except Exception as exc:  # noqa: BLE001 — integration failure, not "unsupported"
+            return IngestResult(status=OpStatus.ERROR, detail=f"{type(exc).__name__}: {exc}")
+        ids = [r["id"] for r in (result or {}).get("results", []) if r.get("id")]
+        return IngestResult(status=OpStatus.OK, memory_ids=ids)
+
+    def query(self, scope: Scope, question: str) -> QueryResult:
+        try:
+            found = self._memory.search(
+                question, filters={"user_id": self._identity(scope)}
+            )
+        except Exception as exc:  # noqa: BLE001
+            return QueryResult(status=OpStatus.ERROR, detail=f"{type(exc).__name__}: {exc}")
+
+        rows = (found or {}).get("results", [])
+        refs = [
+            MemoryRef(
+                memory_id=r.get("id", ""),
+                content=r.get("memory", ""),
+                score=r.get("score"),
+            )
+            for r in rows
+        ]
+        # The runner scores retrieved memory, not answer prose, so the context is
+        # returned directly rather than spending an LLM call to phrase it.
+        return QueryResult(
+            status=OpStatus.OK,
+            answer="\n".join(r.content or "" for r in refs),
+            used_memory_ids=[r.memory_id for r in refs],
+            retrieved=refs,
+        )
+
+    def forget(self, scope: Scope, memory_id: str) -> ForgetResult:
+        try:
+            # Mem0's own delete API — never the vector store underneath it.
+            self._memory.delete(memory_id=memory_id)
+        except Exception as exc:  # noqa: BLE001
+            return ForgetResult(status=OpStatus.ERROR, detail=f"{type(exc).__name__}: {exc}")
+        return ForgetResult(status=OpStatus.OK)
+
+    def update(self, scope: Scope, memory_id: str, content: str) -> UpdateResult:
+        try:
+            self._memory.update(memory_id=memory_id, data=content)
+        except Exception as exc:  # noqa: BLE001
+            return UpdateResult(status=OpStatus.ERROR, detail=f"{type(exc).__name__}: {exc}")
+        return UpdateResult(status=OpStatus.OK)
+
+    def export_evidence(self, scope: Scope) -> EvidenceResult:
+        return EvidenceResult(
+            status=OpStatus.UNSUPPORTED, detail="Mem0 exports no governance evidence"
+        )
+
+
+def s4() -> Mem0Adapter:
+    return Mem0Adapter()

--- a/paper/harness/tests/test_mem0_adapter.py
+++ b/paper/harness/tests/test_mem0_adapter.py
@@ -1,0 +1,158 @@
+"""S4 Mem0 adapter — real product API, no paid provider, no leaked state.
+
+Skipped wholesale when the `benchmark` extra is absent, which is the default for the
+ordinary test environment. The comparison is optional; the guarantees below are not.
+
+The load-bearing assertion is `test_no_llm_call_occurs_during_ingest_or_query`: Mem0
+constructs an LLM eagerly in `Memory.__init__`, so "we passed infer=False" is not by
+itself evidence that nothing was invoked. The injected model raises if called, and
+that is what makes "0 provider calls" a checked property rather than a claim.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from paper.harness import mem0_adapter as m4
+from paper.harness.adapter import MemorySystemAdapter
+from paper.harness.cases import default_cases
+from paper.harness.runner import run_suite
+from paper.harness.types import Capability, OpStatus, Outcome, Scope
+
+pytestmark = pytest.mark.skipif(
+    not m4.available(), reason="benchmark extra not installed (mem0ai/langchain)"
+)
+
+_A = Scope("acme", "alice")
+_B = Scope("beta", "bob")
+
+
+@pytest.fixture
+def adapter():
+    a = m4.s4()
+    try:
+        yield a
+    finally:
+        a.close()
+
+
+# ── contract ─────────────────────────────────────────────────────────────────
+def test_satisfies_the_adapter_protocol(adapter):
+    assert isinstance(adapter, MemorySystemAdapter)
+    assert adapter.name == "S4"
+
+
+def test_declares_only_capabilities_it_has(adapter):
+    caps = adapter.capabilities()
+    assert {Capability.INGEST, Capability.QUERY, Capability.FORGET} <= caps
+    # Mem0 is not a governance product; claiming evidence export would fabricate a
+    # capability and turn a legitimate `unsupported` into a false comparison.
+    assert Capability.EXPORT_EVIDENCE not in caps
+    assert adapter.export_evidence(_A).status is OpStatus.UNSUPPORTED
+
+
+# ── provider-free guarantee ──────────────────────────────────────────────────
+def test_no_llm_call_occurs_during_ingest_or_query(adapter):
+    """The injected chat model raises if invoked; reaching the asserts means it wasn't."""
+    ing = adapter.ingest(_A, "my badge number is 7788 for building access")
+    assert ing.status is OpStatus.OK, ing.detail
+    q = adapter.query(_A, "what is my badge number")
+    assert q.status is OpStatus.OK, q.detail
+
+
+def test_runs_without_any_provider_credentials(monkeypatch):
+    for var in ("OPENAI_API_KEY", "GEMINI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    a = m4.s4()
+    try:
+        assert a.ingest(_A, "my employee id is E-4471").status is OpStatus.OK
+    finally:
+        a.close()
+
+
+def test_ingest_uses_infer_false(adapter, monkeypatch):
+    """Deduction off is what keeps the LLM out of the path; pin it explicitly."""
+    seen = {}
+    real_add = adapter._memory.add
+
+    def spy(*args, **kwargs):
+        seen.update(kwargs)
+        return real_add(*args, **kwargs)
+
+    monkeypatch.setattr(adapter._memory, "add", spy)
+    adapter.ingest(_A, "my desk locker is on floor 4 row C")
+    assert seen.get("infer") is False
+
+
+# ── scope mapping ────────────────────────────────────────────────────────────
+def test_scope_is_mapped_to_a_compound_identity():
+    """Mem0 has no tenant concept; the compound id is the closest honest mapping."""
+    assert m4.Mem0Adapter._identity(_A) == "acme:alice"
+    assert m4.Mem0Adapter._identity(_A) != m4.Mem0Adapter._identity(_B)
+
+
+def test_one_scope_does_not_see_another(adapter):
+    adapter.ingest(_A, "my badge number is 7788 for building access")
+    result = adapter.query(_B, "what is my badge number")
+    assert result.status is OpStatus.OK
+    joined = " ".join((r.content or "") for r in result.retrieved).lower()
+    assert "7788" not in joined
+
+
+# ── deletion goes through Mem0's API ─────────────────────────────────────────
+def test_delete_uses_the_product_api_and_removes_the_memory(adapter):
+    ing = adapter.ingest(_A, "my employee id is E-4471")
+    assert ing.memory_ids, "no memory id returned"
+    assert adapter.forget(_A, ing.memory_ids[0]).status is OpStatus.OK
+    after = adapter.query(_A, "what is my employee id")
+    joined = " ".join((r.content or "") for r in after.retrieved).lower()
+    assert "e-4471" not in joined
+
+
+def test_deleting_an_unknown_id_is_an_error_not_unsupported(adapter):
+    """A broken integration must never masquerade as a missing capability."""
+    result = adapter.forget(_A, "00000000-0000-4000-8000-000000000000")
+    assert result.status is not OpStatus.UNSUPPORTED
+
+
+# ── isolation of state ───────────────────────────────────────────────────────
+def test_vector_state_is_temporary_and_outside_the_repository(adapter):
+    repo = Path(__file__).resolve().parents[3]
+    path = Path(adapter._dir)
+    assert path.exists()
+    assert repo not in path.parents, "benchmark state must not be written into the repo"
+    assert str(path).startswith(os.path.realpath("/") + "private") or "/tmp" in str(path) \
+        or str(path).startswith("/var"), f"expected a temp dir, got {path}"
+
+
+def test_close_removes_state_and_is_idempotent(adapter):
+    path = Path(adapter._dir)
+    adapter.close()
+    assert not path.exists()
+    adapter.close()  # must not raise
+
+
+def test_reset_yields_an_empty_store(adapter):
+    adapter.ingest(_A, "my assigned parking spot is level 3 bay 22")
+    adapter.reset()
+    after = adapter.query(_A, "where do I park my car")
+    joined = " ".join((r.content or "") for r in after.retrieved).lower()
+    assert "level 3 bay 22" not in joined
+
+
+# ── outcomes ─────────────────────────────────────────────────────────────────
+def test_runs_the_real_cases_deterministically():
+    """Two full passes must agree; a second run inheriting state would show here."""
+    first = {r.case_id: r.outcome for r in run_suite([m4.s4], default_cases())}
+    second = {r.case_id: r.outcome for r in run_suite([m4.s4], default_cases())}
+    assert first == second, (first, second)
+    assert set(first) == {c.id for c in default_cases()}
+    for case_id, outcome in first.items():
+        assert outcome is not Outcome.ERROR, f"{case_id} errored"
+
+
+def test_version_metadata_is_reported():
+    assert m4.mem0_version() != "unknown"

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -97,6 +97,30 @@ dev = [
   "pytest-recording==0.13.2",
 ]
 
+# ── External-baseline benchmark only (protocol §3, system S4) ────────────────
+# Mem0 is a *comparison subject*, not a MemoryOps dependency. It is deliberately
+# absent from `production`, `providers`, `postgres`, the base dependencies, and the
+# worker/web images: nothing MemoryOps ships at runtime may import it, and Railway
+# must never install it.
+#
+# `langchain` is here only because it is Mem0's sanctioned injection point for
+# supplying model objects. That is what lets the benchmark run Mem0 with a local
+# vector store, the repository's deterministic embedder, and a chat model that raises
+# if invoked — so the comparison costs nothing and needs no provider key. Without it
+# Mem0 constructs an OpenAI client in `Memory.__init__` and the benchmark could not
+# run offline at all.
+#
+# This extra pulls a materially larger transitive graph (~53 packages) than anything
+# else here. That is acceptable *because* it is quarantined to the benchmark; keeping
+# it out of the runtime images is the whole point of separating it.
+benchmark = [
+  "mem0ai==2.0.17",
+  "langchain==1.3.14",
+  # Imported directly by the adapter for `BaseChatModel`, so pinned explicitly rather
+  # than inherited as a transitive of `langchain`.
+  "langchain-core==1.5.3",
+]
+
 # ── Packaging ────────────────────────────────────────────────────────────────
 # Explicit, so `tests` can never be auto-discovered into the distribution.
 [tool.setuptools.packages.find]
@@ -146,3 +170,9 @@ extras = ["production"]
 include_base = false
 extras = ["dev"]
 requires = ["requirements.txt"]
+
+# External-baseline benchmark only. Deliberately standalone — no `requires` line, so
+# installing it never drags Mem0/LangChain into a runtime requirement set.
+[tool.memoryops.requirements."requirements-benchmark.txt"]
+include_base = false
+extras = ["benchmark"]

--- a/services/api/requirements-benchmark.txt
+++ b/services/api/requirements-benchmark.txt
@@ -1,0 +1,13 @@
+# ─────────────────────────────────────────────────────────────────────────
+# GENERATED FILE — DO NOT EDIT BY HAND.
+#
+# Source of truth: services/api/pyproject.toml
+# Regenerate:      python scripts/sync_dependencies.py
+# Verify:          python scripts/sync_dependencies.py --check   (CI gate)
+#
+# Hand-edits are reverted by the next regeneration and fail the CI drift gate.
+# ─────────────────────────────────────────────────────────────────────────
+# [project.optional-dependencies].benchmark
+mem0ai==2.0.17
+langchain==1.3.14
+langchain-core==1.5.3


### PR DESCRIPTION
## Scope

Adds the missing real Mem0 `S4` adapter to the existing neutral paper harness and
publishes the resulting external memory-system comparison.

The repository already contained `MemorySystemAdapter`, four-valued
PASS/FAIL/UNSUPPORTED/ERROR semantics, the MemoryOps `S0`/`S0-U` adapters, the plain
vector `S2` baseline, the deletion-leakage and isolation cases, and the runner. This
PR fills the missing `S4` implementation and makes it reproducible in CI.

No application runtime behavior is changed.

## Systems

- **S0** — MemoryOps, governed (existing)
- **S0-U** — MemoryOps, governance-disabled ablation (existing)
- **S2** — plain vector memory: embed → cosine top-k → compose (existing)
- **S4** — **Mem0**, `mem0ai==2.0.17`, real product API

### S4 configuration

Local Qdrant in isolated temporary storage · the repository's deterministic embedder
(**the same one S2 uses**) · direct import with `infer=False` · an injected chat model
that **raises if called** · **zero provider calls**.

Mem0 defaults to OpenAI for both LLM and embedder and constructs the LLM *eagerly* in
`Memory.__init__`, so `infer=False` alone does not avoid a provider. Both model objects
are injected through Mem0's sanctioned `langchain` provider. Holding the embedder
constant across S2 and S4 is deliberate: the comparison is of memory-system semantics,
not embedding quality.

Benchmark-only dependencies: `mem0ai==2.0.17`, `langchain==1.3.14`,
`langchain-core==1.5.3` — isolated from every runtime requirement set.

## Results

| System | Pass | Fail | Unsupported | Error | Coverage | Conditional correctness |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| S0 MemoryOps governed | 4 | 0 | 0 | 0 | 100% | 100% |
| S0-U MemoryOps ungoverned | 4 | 0 | 0 | 0 | 100% | 100% |
| S2 plain vector | 4 | 0 | 0 | 0 | 100% | 100% |
| S4 Mem0 | 4 | 0 | 0 | 0 | 100% | 100% |

Existing `S1`/`S3` each report 2 pass / 0 fail / 2 unsupported / 0 error for operations
they cannot represent — a capability finding, not a failure.

## Important interpretation

**These four deterministic deletion/isolation probes do NOT demonstrate a governance
advantage for MemoryOps.** S0, S0-U, S2 and S4 all pass every current case.

That result is preserved intentionally. A scoped plain vector store satisfies these
specific observable deletion/isolation requirements, and MemoryOps' own *ungoverned*
ablation passes them too. This benchmark should therefore not be read as evidence that
the broader governance architecture is superior on the basis of these four cases.

Capabilities that would differentiate — policy-before-storage, consent, retention,
admission and output gates, audit evidence, deletion lineage — are existing protocol
scope and were deliberately **not** added here in response to the tie.

## Mem0 scope

Mem0 runs with `infer=False`, so this evaluates deterministic storage, retrieval,
deletion and supported identity/scoping behavior. It does **not** evaluate Mem0's
LLM-driven memory extraction, deduction or consolidation, nor its end-to-end product
quality.

Mem0's isolation result reflects its supported identity/filter semantics, with the
harness `Scope(tenant, user)` mapped to a compound `user_id` because Mem0 has no tenant
construct. It does **not** imply an enforcement mechanism equivalent to MemoryOps'
application controls plus PostgreSQL `FORCE ROW LEVEL SECURITY`.

## CI proves the comparison ran — importing is not evidence

An earlier draft of this change only installed the benchmark extra and imported it.
That would have left the job green while the external baseline never executed. The
benchmark CI now:

- verifies the runtime requirement sets contain **no** `mem0ai` / `langchain` / `langchain-core`
- installs the benchmark-only dependency extra
- asserts `mem0ai==2.0.17` exactly
- runs **all 14** Mem0 adapter tests
- emits JUnit evidence and **fails if any of those tests skip**
- executes the real four-system external comparison in-process
- **asserts the published result**, so `COMPARISON.md` cannot drift from what the harness produces
- `pip-audit`s the benchmark dependency environment

A skipped Mem0 suite is a CI failure, not a pass.

## No paid provider calls

Local Qdrant, deterministic local embeddings, and a chat model that raises if invoked.
**Live provider calls: 0.** No GitHub secret is required by the benchmark job.

## State isolation

Mem0 state lives in a temporary directory per adapter instance, removed on
`close()`/`reset()`, asserted to be outside the repository. Cleanup, reset and
repeatability are tested; two complete executions produced identical semantic outcomes.

## Dependency isolation

Direct additions: **3**. Installed/transitive graph: **53** packages. `pip-audit`
reports no known vulnerabilities. The production API and worker dependency sets do not
gain Mem0 or LangChain, and Railway configuration is unchanged.

## Verification

- Mem0 adapter tests: **14 executed, 0 skipped, 0 failed** (with the extra); 14 skipped without it
- full API: **1175, exit 0**
- paper harness: 54 passed
- evals: PASS · governance benchmark: 50/50 · SDK: 25
- dependency mirrors: 6/6 current · authz matrix / web capabilities / role map: current
- trust guards: 5 clean · invariant gate: PASS
- Ruff: clean · `git diff --check`: clean · gitleaks: clean

## Runtime impact

None. No files under `services/api/app/` are changed.