### PR TITLE
fix(llm): retry only transient provider failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,71 @@ jobs:
           print("recorded Gemini evidence executed (not skipped)")
           PY
 
+      # ── Provider retry classification against the REAL SDK exception shapes ───
+      # The classifier decides what may be retried by reading attributes the SDKs
+      # expose (`.status_code` for openai/anthropic, `.code` for google-genai). The
+      # suite reconstructs those shapes locally so it runs with no extra installed —
+      # which means that on its own it verifies the rules against *our model* of the
+      # SDKs, not the SDKs.
+      #
+      # This step closes that gap: install the pinned providers and assert the same
+      # classification against the genuine exception classes. Deliberately last in
+      # the job, after `pytest -q` has already proved the suite runs with no provider
+      # SDK at all — installing these earlier would destroy that evidence.
+      #
+      # A skip here is a failure. Without the guard the step would pass while proving
+      # nothing, since every real-SDK case is `importorskip`-gated.
+      - name: Install the provider SDK extras (real exception shapes)
+        working-directory: services/api
+        run: python -m pip install ".[providers]"
+
+      - name: Provider retry-classification runs against the real SDKs (must not skip)
+        working-directory: services/api
+        env:
+          MEMORYOPS_STORAGE: memory
+        run: |
+          set -euo pipefail
+          # No credential is needed or wanted: every case builds an exception object.
+          unset OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY GOOGLE_API_KEY || true
+          python - <<'PY'
+          import importlib.metadata as m
+          for pkg, want in (("openai", "2.52.0"), ("anthropic", "0.120.2"),
+                            ("google-genai", "2.17.0")):
+              got = m.version(pkg)
+              assert got == want, f"expected {pkg}=={want}, got {got}"
+              print(f"{pkg} {got}")
+          PY
+          python -m pytest tests/test_llm_provider_retry_classification.py \
+            -p no:cacheprovider -rs --strict-markers \
+            --junitxml=/tmp/retry-classification.xml
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+          cases = list(ET.parse("/tmp/retry-classification.xml").getroot().iter("testcase"))
+          assert cases, "no retry-classification tests ran at all"
+          skipped = [c.get("name") for c in cases if c.find("skipped") is not None]
+          assert not skipped, (
+              f"{len(skipped)} retry-classification test(s) SKIPPED — the providers extra "
+              f"must be installed here so the real SDK exception shapes are actually "
+              f"exercised: {skipped}"
+          )
+          real = [c.get("name", "") for c in cases if c.get("name", "").startswith("test_real_")]
+          assert len(real) >= 23, f"expected >= 23 real-SDK cases, saw {len(real)}"
+          # Each provider must contribute, so a missing SDK cannot hide behind the
+          # others. Parametrised ids end in `-openai]` / `-anthropic]`; the Gemini
+          # cases live in their own test because google-genai has no per-status
+          # exception subclasses.
+          for marker, label, least in (("openai]", "OpenAI", 8),
+                                       ("anthropic]", "Anthropic", 8),
+                                       ("genai", "Gemini", 7)):
+              hits = [n for n in real if marker in n]
+              assert len(hits) >= least, (
+                  f"expected >= {least} real-SDK cases for {label}, saw {len(hits)}"
+              )
+              print(f"{label} real-SDK retry cases: EXECUTED ({len(hits)})")
+          print(f"{len(cases)} retry-classification tests executed, 0 skipped "
+                f"({len(real)} against real provider SDKs)")
+          PY
+
   api-postgres:
     name: API — full suite + evals + benchmark + enforced RLS on Postgres + pgvector
     runs-on: ubuntu-latest

--- a/docs/provider-llm-adapters.md
+++ b/docs/provider-llm-adapters.md
@@ -59,6 +59,39 @@ GEMINI_API_KEY=        GEMINI_MODEL=gemini-2.5-flash   # 1.5-flash retired
   extraction and stays authoritative — a model can never override policy, and
   secret-like content is still blocked (ADR-003/008).
 
+### Retries are classified
+
+`MEMORYOPS_LLM_MAX_RETRIES` is the budget for failures that could plausibly
+succeed on an **identical retry**. It is not spent on failures that cannot.
+
+| Outcome | Retried? | Attempts (`MAX_RETRIES=2`) |
+|---|---|---|
+| Connection / timeout (no response) | yes | up to 3 |
+| `408` request timeout, `409` lock timeout | yes | up to 3 |
+| `429` rate limit | yes | up to 3 |
+| `5xx` server error | yes | up to 3 |
+| `400` invalid request / `INVALID_ARGUMENT` | **no** | 1 |
+| `401` authentication, `403` authorization | **no** | 1 |
+| `404`, `413`, `422` | **no** | 1 |
+| Local `ValueError` / `TypeError` / unknown | **no** | 1 |
+
+The retryable status set is taken from the OpenAI and Anthropic SDKs' own
+`_should_retry`, which is also why `408` and `409` are on it — both SDKs document
+them as request timeout and lock timeout. `google-genai` retries a subset
+(`429/500/502/503/504`).
+
+Unknown exceptions **fail fast**. Retrying an unrecognised error is what this
+rule exists to prevent: a recorded Gemini run configured below the API's minimum
+deadline was rejected with a deterministic `400 INVALID_ARGUMENT`, and the old
+retry-everything envelope turned 25 logical calls into 75 identical rejections
+before degrading to the heuristic.
+
+Classification changes only **how many attempts a failure costs**. Every failure
+still normalises to `LLMUnavailableError` and still degrades to the deterministic
+heuristic, so fallback behaviour is unchanged (invariant #4). Rules live in
+`app/llm/errors.py`; `core.reliability.with_retry` takes the predicate and holds
+no provider-specific knowledge.
+
 ## Observability
 
 Events emitted through the redacting JSON logger (no secrets / keys / full user
@@ -70,4 +103,10 @@ messages): `llm_provider_call`, `llm_provider_failure`,
 
 `test_llm_provider_registry.py`, `test_stub_llm_provider.py`,
 `test_structured_memory_extraction.py`, `test_structured_output_validation.py`,
-`test_llm_fallback.py`, `test_conflict_detection.py` — none require an API key.
+`test_llm_fallback.py`, `test_conflict_detection.py`,
+`test_llm_provider_retry_classification.py` — none require an API key.
+
+The retry-classification suite reconstructs each SDK's exception *shape* so it
+runs with no provider extra installed, and additionally asserts the same
+classification against the real `openai` / `anthropic` / `google-genai` exception
+classes wherever those extras are present.

--- a/services/api/app/core/reliability.py
+++ b/services/api/app/core/reliability.py
@@ -12,7 +12,7 @@ import time
 from collections.abc import Callable
 from typing import TypeVar
 
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 T = TypeVar("T")
 
@@ -65,12 +65,31 @@ class CircuitBreaker:
         return result
 
 
-def with_retry(fn: Callable[[], T], attempts: int = 3) -> T:
-    """Retry a callable with exponential backoff on any exception."""
+def with_retry(
+    fn: Callable[[], T],
+    attempts: int = 3,
+    *,
+    retry_if: Callable[[BaseException], bool] | None = None,
+) -> T:
+    """Retry a callable with exponential backoff.
+
+    ``retry_if`` decides whether a raised exception is worth another identical
+    attempt. Callers wrapping a dependency that can fail *permanently* must supply
+    one: without it every exception is retried, so a deterministic error costs
+    ``attempts`` round trips and still fails. The classification itself belongs to
+    the caller — this module stays free of any dependency-specific knowledge (see
+    ``app.llm.errors.is_retryable_provider_error`` for the provider rules).
+
+    ``attempts`` is the total number of tries, not the number of retries. Whatever
+    the outcome, the original exception is re-raised — a non-retryable failure
+    surfaces immediately, after exactly one attempt.
+    """
+    predicate = retry_if if retry_if is not None else (lambda _exc: True)
 
     @retry(
         stop=stop_after_attempt(attempts),
         wait=wait_exponential(multiplier=0.1, max=2.0),
+        retry=retry_if_exception(predicate),
         reraise=True,
     )
     def _runner() -> T:

--- a/services/api/app/llm/errors.py
+++ b/services/api/app/llm/errors.py
@@ -1,0 +1,114 @@
+"""Retry classification for networked LLM providers.
+
+Retry only failures that could plausibly succeed on a **subsequent identical
+request**. Everything else fails fast.
+
+Why this exists
+---------------
+The shared retry envelope in ``core.reliability.with_retry`` originally retried on
+*any* exception. A deterministic ``400 INVALID_ARGUMENT`` is not a transient fault —
+the identical request will be rejected identically — so retrying it only multiplies
+load and latency before the same failure. That is not hypothetical: a Gemini
+evidence run whose deadline was below the API's 10-second floor turned 25 logical
+calls into 75 HTTP requests, three rejections per call, before degrading to the
+heuristic. The wasted attempts changed nothing except how long the failure took.
+
+Classification rules (derived from the SDKs, not assumed)
+---------------------------------------------------------
+1. **An HTTP status, when present, is authoritative.** Retryable statuses are
+   ``408`` (request timeout), ``409`` (lock timeout), ``429`` (rate limit) and any
+   ``5xx``. This set is not invented here: it is exactly what the OpenAI and
+   Anthropic SDKs implement in their own ``_base_client._should_retry`` — including
+   the two that look permanent at a glance. 408 and 409 are documented *in those
+   SDKs* as request timeout and lock timeout respectively, both of which do resolve
+   on an identical retry. ``google-genai`` uses a narrower list
+   (``429/500/502/503/504``), which is a subset, so the union stays consistent with
+   all three.
+2. **Otherwise, transport failures are retryable** — connection and timeout errors,
+   which carry no status because no response was received.
+3. **Otherwise, fail fast.** An unrecognised exception is treated as permanent.
+
+Rule 3 is the deliberate part. Defaulting the unknown case to "retry" is precisely
+what produced the original defect: a local ``TypeError`` or a malformed request is
+deterministic, and retrying it three times only delays the fallback. Fail-fast on
+unknown loses nothing that matters — the caller degrades to the deterministic
+heuristic either way (invariant #4) — while retry-on-unknown costs real time on
+every programming or configuration error.
+
+No SDK imports
+--------------
+Provider SDKs are optional extras; the API package must import and its suite must
+collect with none of them installed. So classification is duck-typed over attributes
+the SDKs actually expose (verified against the pinned versions) rather than by
+``isinstance`` against imported types:
+
+===============  =========================  ==============================
+SDK              status attribute           transport errors
+===============  =========================  ==============================
+``openai``       ``.status_code`` (int)     ``APIConnectionError`` /
+                                            ``APITimeoutError``
+``anthropic``    ``.status_code`` (int)     ``APIConnectionError`` /
+                                            ``APITimeoutError``
+``google-genai`` ``.code`` (int)            raw ``httpx.ConnectError`` /
+                                            ``httpx.TimeoutException``
+===============  =========================  ==============================
+
+``google-genai`` raises no per-status exception subclasses — a 400 and a 429 are
+both ``ClientError`` — so classifying Gemini by exception *type* is not possible.
+Reading the numeric code is what makes Gemini's rate limit retryable and its
+invalid-argument permanent.
+"""
+
+from __future__ import annotations
+
+#: Statuses worth a second identical attempt. Mirrors OpenAI's and Anthropic's own
+#: ``_should_retry``; 5xx is handled separately as a range.
+RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({408, 409, 429})
+
+#: Substrings that identify a transport failure by class name, used only when no
+#: HTTP status is available. Matched against the exception's whole MRO so SDK
+#: wrappers (``openai.APITimeoutError``) and the raw httpx errors that
+#: ``google-genai`` propagates (``ConnectTimeout``, ``ReadTimeout``,
+#: ``ConnectError``) are both recognised, as are the builtins ``TimeoutError`` and
+#: ``ConnectionResetError``.
+_TRANSPORT_MARKERS: tuple[str, ...] = ("timeout", "connect", "retryable")
+
+
+def status_code_of(exc: BaseException) -> int | None:
+    """Best-effort HTTP status for a provider exception, or ``None``.
+
+    ``status_code`` (OpenAI/Anthropic) is preferred over ``code`` (google-genai)
+    because OpenAI's ``APIError`` also carries a ``code`` attribute holding a
+    *string* error slug. The ``int`` check keeps that slug from being mistaken for
+    a status; the range check keeps unrelated ``code`` attributes (``SystemExit``)
+    out.
+    """
+    for attr in ("status_code", "code"):
+        value = getattr(exc, attr, None)
+        # bool is an int subclass; a True here would otherwise read as status 1.
+        if isinstance(value, int) and not isinstance(value, bool) and 100 <= value <= 599:
+            return value
+    response = getattr(exc, "response", None)
+    value = getattr(response, "status_code", None)
+    if isinstance(value, int) and not isinstance(value, bool) and 100 <= value <= 599:
+        return value
+    return None
+
+
+def _looks_like_transport_failure(exc: BaseException) -> bool:
+    names = " ".join(cls.__name__.lower() for cls in type(exc).__mro__)
+    return any(marker in names for marker in _TRANSPORT_MARKERS)
+
+
+def is_retryable_provider_error(exc: BaseException) -> bool:
+    """Whether an identical retry of the failed provider call could succeed.
+
+    Fails fast on anything unrecognised — see the module docstring for why the
+    unknown case must not default to retrying.
+    """
+    status = status_code_of(exc)
+    if status is not None:
+        # Authoritative: a 400 stays permanent even if the class name happens to
+        # contain a transport-ish word.
+        return status in RETRYABLE_STATUS_CODES or status >= 500
+    return _looks_like_transport_failure(exc)

--- a/services/api/app/llm/providers.py
+++ b/services/api/app/llm/providers.py
@@ -6,6 +6,12 @@ into an ``LLMUnavailableError`` so the structured-intelligence orchestrator fall
 back to the deterministic heuristic instead of crashing the chat path
 (invariant #4). SDKs are imported lazily inside ``_invoke`` so the package
 imports cleanly without them installed.
+
+Retries are **classified**: only failures that could succeed on an identical retry
+are tried again (see ``app.llm.errors``). A deterministic rejection — a bad
+request, a bad key, an unknown local error — fails after a single attempt and
+degrades to the heuristic immediately, instead of spending the full retry budget
+to arrive at the same result.
 """
 
 from __future__ import annotations
@@ -15,6 +21,7 @@ from abc import ABC, abstractmethod
 from ..core.logging import get_logger
 from ..core.reliability import with_retry
 from .base import LLMUnavailableError
+from .errors import is_retryable_provider_error, status_code_of
 
 logger = get_logger("memoryops.llm")
 
@@ -39,11 +46,22 @@ class BaseNetworkProvider(ABC):
             return self._invoke(system=system, user=user, task=task)
 
         try:
-            return with_retry(_call, attempts=self._attempts)
+            return with_retry(
+                _call, attempts=self._attempts, retry_if=is_retryable_provider_error
+            )
         except Exception as exc:  # noqa: BLE001 — normalize to a fallback signal
             logger.warning(
                 "llm provider call failed",
-                extra={"event": "llm_provider_failure", "provider": self.name, "task": task},
+                extra={
+                    "event": "llm_provider_failure",
+                    "provider": self.name,
+                    "task": task,
+                    # Content-free: whether the failure was worth retrying, and the
+                    # status class if the SDK reported one. Never the request, the
+                    # prompt, the response body, or the key.
+                    "retryable": is_retryable_provider_error(exc),
+                    "status": status_code_of(exc),
+                },
             )
             raise LLMUnavailableError(f"{self.name} call failed: {exc}") from exc
 

--- a/services/api/tests/test_gemini_provider.py
+++ b/services/api/tests/test_gemini_provider.py
@@ -55,16 +55,39 @@ class _Recorder(dict):
     calls: int = 0
 
 
+class _ApiError(Exception):
+    """Stands in for `google.genai.errors.APIError`.
+
+    Mirrors the real SDK's shape, which is what the retry classifier reads: an
+    integer `.code` and a string `.status`. `google-genai` raises no per-status
+    exception subclasses — a 400 and a 429 are both `ClientError` — so the numeric
+    code is the only thing distinguishing a permanent rejection from a rate limit.
+    """
+
+    def __init__(self, code: int, status: str) -> None:
+        super().__init__(f"{code} {status}.")
+        self.code = code
+        self.status = status
+
+
 @pytest.fixture
 def gemini_sdk(monkeypatch):
     """Install a fake `google.genai`; return the recorder.
 
     Behaviour is driven by attributes set on the returned recorder *before* the call:
-    ``text`` (response text), ``fail_times`` (raise N times, then succeed).
+    ``text`` (response text), ``fail_times`` (raise N times, then succeed), and
+    ``fail_error`` (the exception to raise, defaulting to a transient 503).
+
+    ``fail_error`` defaults to a *genuinely* transient error rather than a bare
+    ``RuntimeError``, because retries are now classified: a plain ``RuntimeError``
+    carries no status and no transport marker, so it is permanent by design and
+    would never be retried. A fixture raising one could not honestly test retry
+    behaviour.
     """
     rec = _Recorder()
     rec["text"] = "ok"
     rec["fail_times"] = 0
+    rec["fail_error"] = lambda: _ApiError(503, "UNAVAILABLE")
 
     class _Response:
         def __init__(self, text):
@@ -75,7 +98,7 @@ def gemini_sdk(monkeypatch):
             rec["generate_content"] = kwargs
             rec.calls += 1
             if rec.calls <= rec["fail_times"]:
-                raise RuntimeError("transient upstream failure")
+                raise rec["fail_error"]()
             return _Response(rec["text"])
 
     class _Client:
@@ -257,6 +280,41 @@ def test_retries_are_bounded(gemini_sdk):
     gemini_sdk["fail_times"] = 99
     with pytest.raises(LLMUnavailableError):
         _provider(max_retries=1).complete(system="S", user="U")
+    assert gemini_sdk.calls == 2
+
+
+# ── retry classification (regression) ───────────────────────────────────────
+def test_invalid_argument_is_not_retried(gemini_sdk):
+    """The observed defect, pinned.
+
+    A recorded evidence run configured Gemini with an 8-second deadline, below the
+    REST API's 10-second floor. Every call was rejected with a deterministic
+    `400 INVALID_ARGUMENT` — and the shared retry envelope, which retried on *any*
+    exception, tried each one three times. 25 logical calls became 75 HTTP
+    requests, all rejected identically, before degrading to the heuristic.
+
+    An identical request cannot stop being invalid, so it must be attempted once.
+    """
+    gemini_sdk["fail_times"] = 99
+    gemini_sdk["fail_error"] = lambda: _ApiError(400, "INVALID_ARGUMENT")
+
+    with pytest.raises(LLMUnavailableError):
+        _provider(max_retries=2).complete(system="S", user="U")
+
+    assert gemini_sdk.calls == 1, "a deterministic 400 must not be retried"
+
+
+def test_rate_limit_is_still_retried_despite_being_a_4xx(gemini_sdk):
+    """Gemini reports 429 through the same `APIError` type as 400.
+
+    Classifying by exception type would make these two indistinguishable; reading
+    the numeric code is what keeps a rate limit retryable while an invalid argument
+    fails fast.
+    """
+    gemini_sdk["fail_times"] = 1
+    gemini_sdk["fail_error"] = lambda: _ApiError(429, "RESOURCE_EXHAUSTED")
+
+    assert _provider(max_retries=2).complete(system="S", user="U") == "ok"
     assert gemini_sdk.calls == 2
 
 

--- a/services/api/tests/test_llm_fallback.py
+++ b/services/api/tests/test_llm_fallback.py
@@ -7,6 +7,7 @@ from app.core.config import Settings
 from app.db.memory_repo import InMemoryRepository
 from app.llm import extract_memories
 from app.llm.base import LLMUnavailableError
+from app.llm.providers import BaseNetworkProvider
 from app.schemas.memory import ChatRequest, Decision, Source
 from app.services.extractor import Extractor
 from app.services.gateway import Gateway
@@ -100,3 +101,75 @@ def test_extractor_keeps_provenance_on_fallback() -> None:
     src = Source(kind="chat", excerpt="orig")
     cands = ex.extract("Remember I prefer dark mode.", src)
     assert cands and cands[0].source.excerpt == "orig"
+
+
+# ── retry classification does not change what the orchestrator sees ──────────
+class _CountingNetworkProvider(BaseNetworkProvider):
+    """A real networked provider whose SDK call always fails with a scripted error.
+
+    Uses `BaseNetworkProvider` rather than a hand-rolled double so the retry
+    envelope under test is the one production actually runs.
+    """
+
+    name = "counting"
+
+    def __init__(self, error: Exception) -> None:
+        super().__init__(
+            api_key="unit" + "-test-" + "placeholder",
+            model="m",
+            timeout=1.0,
+            max_retries=2,
+        )
+        self._error = error
+        self.calls = 0
+
+    def _invoke(self, *, system: str, user: str, task: str) -> str:
+        self.calls += 1
+        raise self._error
+
+
+class _PermanentError(Exception):
+    """Provider-SDK shape for a deterministic rejection (HTTP 400)."""
+
+    status_code = 400
+
+
+class _TransientError(Exception):
+    """Provider-SDK shape for a retryable fault (HTTP 503)."""
+
+    status_code = 503
+
+
+def test_a_permanent_provider_failure_falls_back_after_a_single_attempt() -> None:
+    """Fail-fast changes the cost of the failure, not the outcome.
+
+    The heuristic still answers, exactly as it does for a transient outage — but a
+    deterministic rejection no longer spends the whole retry budget first.
+    """
+    provider = _CountingNetworkProvider(_PermanentError())
+    outcome = extract_memories(provider, "Remember that I prefer dark mode.")
+    assert outcome.mode == "heuristic"
+    assert "dark mode" in outcome.memories[0].content.lower()
+    assert provider.calls == 1
+
+
+def test_a_transient_provider_failure_still_uses_the_full_retry_budget() -> None:
+    provider = _CountingNetworkProvider(_TransientError())
+    outcome = extract_memories(provider, "Remember that I prefer dark mode.")
+    assert outcome.mode == "heuristic"
+    assert provider.calls == 3
+
+
+def test_a_permanent_provider_failure_never_blocks_chat() -> None:
+    """Invariant #4 end to end, with the fail-fast path in the chat request."""
+    repo = InMemoryRepository()
+    provider = _CountingNetworkProvider(_PermanentError())
+    gw = Gateway(repo)
+    gw._extractor = Extractor(provider=provider)
+    resp = gw.handle_chat(
+        ChatRequest(tenant_id="t", user_id="u", message="Remember I prefer dark mode."),
+        trace_id="test",
+    )
+    assert resp.assistant_message
+    assert any(c.decision == Decision.SAVE for c in resp.candidate_memories)
+    assert provider.calls == 1

--- a/services/api/tests/test_llm_provider_retry_classification.py
+++ b/services/api/tests/test_llm_provider_retry_classification.py
@@ -1,0 +1,370 @@
+"""Retry classification for networked LLM providers.
+
+Two layers are covered:
+
+1. **The classifier** (`app.llm.errors`) — is a given failure worth an identical
+   retry? Exercised against the exception *shapes* the three pinned SDKs actually
+   raise, plus (when the optional extras happen to be installed) the real SDK
+   exception classes themselves.
+2. **The envelope** (`BaseNetworkProvider.complete`) — does the attempt count that
+   reaches the provider match the classification, and does every failure still
+   normalise to `LLMUnavailableError` so the caller degrades to the heuristic
+   (invariant #4)?
+
+The second layer is the one that matters operationally: a correct classifier wired
+in wrongly would still burn three round trips on a deterministic rejection.
+
+Provider SDKs are optional extras and absent from `requirements-dev.txt`, so the
+exception shapes below are reconstructed locally rather than imported. They are not
+guesses — each mirrors what the pinned SDK exposes:
+
+* `openai==2.52.0` / `anthropic==0.120.2` — `APIStatusError` subclasses carrying an
+  integer `.status_code`; transport failures are `APIConnectionError` /
+  `APITimeoutError`, which carry no status at all.
+* `google-genai==2.17.0` — a single `APIError` (`ClientError` / `ServerError`)
+  carrying an integer `.code` and a string `.status`, with no per-status subclasses;
+  transport failures propagate as raw `httpx` errors.
+
+No test here makes a network call or needs a key.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.llm.base import LLMUnavailableError
+from app.llm.errors import is_retryable_provider_error, status_code_of
+from app.llm.providers import BaseNetworkProvider
+
+#: The envelope refuses to call a provider with an empty key, so the fake needs a
+#: non-empty one. Assembled at runtime rather than written inline: a literal
+#: `api_key=<value>` is the shape secret scanners match, and the repository's own
+#: trust guard rejects it (see `tests/_secret_fixtures.py`). No credential involved.
+_PLACEHOLDER_KEY = "unit" + "-test-" + "placeholder"
+
+
+# ── SDK-shaped exception doubles ─────────────────────────────────────────────
+class _StatusError(Exception):
+    """OpenAI/Anthropic shape: an integer `.status_code`."""
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"status {status_code}")
+        self.status_code = status_code
+
+
+class _GenaiError(Exception):
+    """google-genai shape: an integer `.code` and a string `.status`."""
+
+    def __init__(self, code: int, status: str = "ERROR") -> None:
+        super().__init__(f"{code} {status}.")
+        self.code = code
+        self.status = status
+
+
+class _Response:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+class _ResponseError(Exception):
+    """httpx `HTTPStatusError` shape: the status hangs off `.response`."""
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__("http status error")
+        self.response = _Response(status_code)
+
+
+class APIConnectionError(Exception):
+    """Name-shaped like the SDK class; carries no status because no response came."""
+
+
+class APITimeoutError(APIConnectionError):
+    pass
+
+
+class ConnectError(Exception):
+    pass
+
+
+class ReadTimeout(Exception):
+    pass
+
+
+# ── the classifier ───────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    ("status", "retryable"),
+    [
+        # Permanent: the identical request is rejected identically.
+        (400, False),  # invalid request / INVALID_ARGUMENT
+        (401, False),  # authentication
+        (403, False),  # authorization
+        (404, False),  # deterministic not-found
+        (413, False),  # request too large
+        (422, False),  # semantic validation
+        # Retryable. 408 and 409 are *not* an oversight: OpenAI and Anthropic both
+        # retry them in their own `_should_retry`, documenting them as request
+        # timeout and lock timeout — conditions an identical retry does clear.
+        (408, True),
+        (409, True),
+        (429, True),
+        (500, True),
+        (502, True),
+        (503, True),
+        (504, True),
+        (529, True),  # Anthropic overloaded
+    ],
+)
+def test_status_decides_retryability(status, retryable):
+    assert is_retryable_provider_error(_StatusError(status)) is retryable
+    assert is_retryable_provider_error(_GenaiError(status)) is retryable
+    assert is_retryable_provider_error(_ResponseError(status)) is retryable
+
+
+@pytest.mark.parametrize(
+    "exc", [APIConnectionError(), APITimeoutError(), ConnectError(), ReadTimeout()]
+)
+def test_transport_failures_are_retryable(exc):
+    """No response arrived, so there is no status — and a retry may well connect."""
+    assert status_code_of(exc) is None
+    assert is_retryable_provider_error(exc) is True
+
+
+@pytest.mark.parametrize("exc", [TimeoutError(), ConnectionResetError()])
+def test_builtin_transport_failures_are_retryable(exc):
+    assert is_retryable_provider_error(exc) is True
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ValueError("bad value"),
+        TypeError("bad type"),
+        KeyError("missing"),
+        AttributeError("nope"),
+        RuntimeError("something local"),
+        Exception("unclassified"),
+    ],
+)
+def test_unknown_and_local_errors_fail_fast(exc):
+    """The deliberate default.
+
+    Retrying an unrecognised exception is what produced the original defect: a
+    programming or configuration error is deterministic, so extra attempts only
+    delay the fallback that was going to happen anyway.
+    """
+    assert is_retryable_provider_error(exc) is False
+
+
+def test_status_beats_a_transport_sounding_class_name():
+    """A 400 stays permanent even when the class name contains a transport marker."""
+
+    class ConnectionBadRequestError(Exception):
+        def __init__(self) -> None:
+            super().__init__("400")
+            self.status_code = 400
+
+    assert is_retryable_provider_error(ConnectionBadRequestError()) is False
+
+
+# ── status extraction edge cases ─────────────────────────────────────────────
+def test_string_error_codes_are_not_mistaken_for_a_status():
+    """OpenAI's `APIError.code` is a *string* slug alongside the integer status."""
+
+    class _Both(Exception):
+        status_code = 400
+        code = "invalid_api_key"
+
+    assert status_code_of(_Both()) == 400
+
+
+def test_a_non_http_code_attribute_is_ignored():
+    class _Exit(Exception):
+        code = 2  # outside 100..599
+
+    assert status_code_of(_Exit()) is None
+    assert is_retryable_provider_error(_Exit()) is False
+
+
+def test_boolean_code_is_not_read_as_a_status():
+    class _Flag(Exception):
+        code = True  # bool is an int subclass
+
+    assert status_code_of(_Flag()) is None
+
+
+# ── the envelope ─────────────────────────────────────────────────────────────
+class _CountingProvider(BaseNetworkProvider):
+    """Counts `_invoke` calls; raises a scripted error N times, then succeeds."""
+
+    name = "counting"
+
+    def __init__(self, *, error: Exception, fail_times: int = 99, max_retries: int = 2) -> None:
+        super().__init__(
+            api_key=_PLACEHOLDER_KEY, model="m", timeout=1.0, max_retries=max_retries
+        )
+        self._error = error
+        self._fail_times = fail_times
+        self.calls = 0
+
+    def _invoke(self, *, system: str, user: str, task: str) -> str:
+        self.calls += 1
+        if self.calls <= self._fail_times:
+            raise self._error
+        return "ok"
+
+
+def _run(provider: _CountingProvider):
+    return provider.complete(system="S", user="U")
+
+
+@pytest.mark.parametrize(
+    ("label", "error"),
+    [
+        ("400 invalid argument", _StatusError(400)),
+        ("401 authentication", _StatusError(401)),
+        ("403 authorization", _StatusError(403)),
+        ("404 not found", _StatusError(404)),
+        ("gemini 400 INVALID_ARGUMENT", _GenaiError(400, "INVALID_ARGUMENT")),
+        ("ValueError", ValueError("bad value")),
+        ("TypeError", TypeError("bad type")),
+        ("unknown exception", Exception("unclassified")),
+    ],
+)
+def test_permanent_failures_are_attempted_exactly_once(label, error):
+    provider = _CountingProvider(error=error, max_retries=2)
+    with pytest.raises(LLMUnavailableError):
+        _run(provider)
+    assert provider.calls == 1, f"{label} was retried"
+
+
+@pytest.mark.parametrize(
+    ("label", "error"),
+    [
+        ("connection failure", APIConnectionError()),
+        ("timeout", APITimeoutError()),
+        ("429 rate limit", _StatusError(429)),
+        ("500 internal", _StatusError(500)),
+        ("502 bad gateway", _StatusError(502)),
+        ("503 unavailable", _StatusError(503)),
+        ("gemini 429", _GenaiError(429, "RESOURCE_EXHAUSTED")),
+    ],
+)
+def test_a_transient_failure_is_retried_and_the_call_succeeds(label, error):
+    provider = _CountingProvider(error=error, fail_times=1, max_retries=2)
+    assert _run(provider) == "ok"
+    assert provider.calls == 2, f"{label} did not retry exactly once"
+
+
+def test_transient_exhaustion_uses_the_full_budget_then_degrades():
+    """`max_retries` is *additional* attempts, so 2 means at most 3 calls."""
+    provider = _CountingProvider(error=_StatusError(503), max_retries=2)
+    with pytest.raises(LLMUnavailableError):
+        _run(provider)
+    assert provider.calls == 3
+
+
+def test_configured_retry_count_is_unchanged_by_classification():
+    provider = _CountingProvider(error=_StatusError(503), max_retries=1)
+    with pytest.raises(LLMUnavailableError):
+        _run(provider)
+    assert provider.calls == 2
+
+    provider = _CountingProvider(error=_StatusError(503), max_retries=0)
+    with pytest.raises(LLMUnavailableError):
+        _run(provider)
+    assert provider.calls == 1
+
+
+def test_a_successful_call_is_made_exactly_once():
+    provider = _CountingProvider(error=_StatusError(503), fail_times=0)
+    assert _run(provider) == "ok"
+    assert provider.calls == 1
+
+
+def test_both_failure_modes_normalise_to_the_same_fallback_signal():
+    """Invariant #4 is unchanged: the caller still sees one error type either way.
+
+    Classification changes *how many attempts* a failure costs, never what the
+    orchestrator observes — so the deterministic heuristic fallback is untouched.
+    """
+    permanent = _CountingProvider(error=_StatusError(400))
+    transient = _CountingProvider(error=_StatusError(503))
+    for provider in (permanent, transient):
+        with pytest.raises(LLMUnavailableError):
+            _run(provider)
+    assert (permanent.calls, transient.calls) == (1, 3)
+
+
+def test_a_missing_api_key_still_fails_before_any_attempt():
+    provider = _CountingProvider(error=_StatusError(503))
+    provider._api_key = ""
+    with pytest.raises(LLMUnavailableError):
+        _run(provider)
+    assert provider.calls == 0
+
+
+# ── the real SDK classes, when the optional extras are installed ─────────────
+# `requirements-dev.txt` carries no provider SDK, so these skip in the default
+# environment. They exist so the shapes reconstructed above can be checked against
+# the genuine article wherever the extras are present.
+def _sdk(name: str):
+    return pytest.importorskip(name, reason=f"optional extra {name!r} not installed")
+
+
+@pytest.mark.parametrize("sdk_name", ["openai", "anthropic"])
+@pytest.mark.parametrize(
+    ("cls_name", "status", "retryable"),
+    [
+        ("BadRequestError", 400, False),
+        ("AuthenticationError", 401, False),
+        ("PermissionDeniedError", 403, False),
+        ("NotFoundError", 404, False),
+        ("ConflictError", 409, True),
+        ("RateLimitError", 429, True),
+        ("InternalServerError", 500, True),
+    ],
+)
+def test_real_openai_and_anthropic_status_errors(sdk_name, cls_name, status, retryable):
+    sdk = _sdk(sdk_name)
+    httpx = _sdk("httpx")
+    cls = getattr(sdk, cls_name, None)
+    if cls is None:  # pragma: no cover — SDK surface drift
+        pytest.skip(f"{sdk_name} has no {cls_name}")
+    request = httpx.Request("POST", "https://api.example/v1/x")
+    response = httpx.Response(status, request=request, json={"error": {"message": "m"}})
+    exc = cls("m", response=response, body=None)
+    assert status_code_of(exc) == status
+    assert is_retryable_provider_error(exc) is retryable
+
+
+@pytest.mark.parametrize("sdk_name", ["openai", "anthropic"])
+def test_real_transport_errors_are_retryable(sdk_name):
+    sdk = _sdk(sdk_name)
+    httpx = _sdk("httpx")
+    request = httpx.Request("POST", "https://api.example/v1/x")
+    for cls_name in ("APIConnectionError", "APITimeoutError"):
+        exc = getattr(sdk, cls_name)(request=request)
+        assert status_code_of(exc) is None
+        assert is_retryable_provider_error(exc) is True, cls_name
+
+
+@pytest.mark.parametrize(
+    ("code", "status", "retryable"),
+    [
+        (400, "INVALID_ARGUMENT", False),
+        (401, "UNAUTHENTICATED", False),
+        (403, "PERMISSION_DENIED", False),
+        (404, "NOT_FOUND", False),
+        (429, "RESOURCE_EXHAUSTED", True),
+        (500, "INTERNAL", True),
+        (503, "UNAVAILABLE", True),
+    ],
+)
+def test_real_genai_errors(code, status, retryable):
+    _sdk("google.genai")
+    from google.genai import errors as genai_errors
+
+    cls = genai_errors.ClientError if code < 500 else genai_errors.ServerError
+    exc = cls(code, {"error": {"code": code, "message": "m", "status": status}})
+    assert status_code_of(exc) == code
+    assert is_retryable_provider_error(exc) is retryable


### PR DESCRIPTION
## Problem

The shared LLM-provider retry envelope retried **every** exception — including deterministic permanent provider errors.

This was observed, not theorised. During Gemini evidence recording:

**25 logical calls → 75 HTTP requests**

because Gemini returned `400 INVALID_ARGUMENT` and the same invalid request was retried three times.

This inflates provider traffic, delays graceful fallback, and makes performance/cost measurement misleading.

## Fix

- add explicit transient/permanent provider-error classification (`app/llm/errors.py`)
- keep the generic reliability helper provider-agnostic
- allow `with_retry` to accept a retry predicate (`retry_if`, default backward compatible)
- retry recognized transient transport/status failures
- fail fast on permanent request/auth/config/local errors
- preserve final `LLMUnavailableError` normalization
- preserve gateway/extraction fallback behavior
- keep provider SDK imports optional/lazy — the classifier imports **no** SDK

The retryable status set is not invented here: it is what `openai` and `anthropic` implement in their own `_base_client._should_retry`, which is also why `408`/`409` are on it — both SDKs document them as request timeout and lock timeout. `google-genai` retries a subset (`429/500/502/503/504`).

`google-genai` raises no per-status subclasses — a 400 and a 429 are both `ClientError` — so classification reads the numeric code rather than the exception type.

## Retry behavior

Permanent — `400` / `401` / `403` / `404`, local validation/config/programming errors → **one attempt**

Transient — connection errors, timeouts, `429`, retryable `5xx` → **retry up to configured maximum**

`max_retries=2` continues to mean at most three MemoryOps-level attempts. Missing API key → 0 provider attempts.

## Regression

Gemini `400 INVALID_ARGUMENT` now performs **1 request** instead of **3** before graceful fallback.

## Verification

- dev-only environment: **1217 passed / 30 skipped**
- provider-SDK environment: **1243 passed / 10 skipped**
- recorded Gemini evidence: 25 structured, 0 heuristic, 0 errors, **0.97 / 0.94 / 0.95**
- cassette unchanged
- evals PASS
- governance benchmark 50/50
- external comparison unchanged (S0/S0-U/S2/S4 all 4/0/0/0)
- SDK 25
- Ruff clean
- dependency drift 6/6
- trust guards clean
- invariant gate PASS
- gitleaks clean
- diff check clean

**Live provider calls: 0**

## Runtime contract

No HTTP/API contract change. Provider failures still normalize to `LLMUnavailableError`, preserving graceful degradation (invariant #4).

## Follow-up tracked for Phase C (not changed here)

The adapters do not override the OpenAI/Anthropic SDKs' own `DEFAULT_MAX_RETRIES = 2`, so a transient logical call has a worst-case physical multiplier of **3 outer × 3 SDK = 9 HTTP requests**. `google-genai` defaults to no internal retry. Phase C must budget the actual worst case rather than assume 3.