### PR TITLE
perf: record real request-path characterization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,12 +643,15 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
 
-      # The harness decides what counts as valid evidence, so its own rules need
-      # tests: success-only percentiles, split attempted/successful throughput, and
-      # 429 failing closed. Without this step they would live in the repository
-      # without ever running — `services/api` pytest does not collect this path.
-      - name: Load-harness evidence rules
-        run: python -m pytest benchmark/perf/tests/test_run_perf.py -q
+      # The perf tooling decides what counts as valid evidence, so its own rules need
+      # tests: success-only percentiles, split attempted/successful throughput, 429
+      # failing closed, SQL-shape normalization (which must never capture tenant,
+      # user, content or credential values), and the guard that stops a stubbed run
+      # being published as live-provider evidence. Without this step they would live
+      # in the repository without ever running — `services/api` pytest does not
+      # collect this path.
+      - name: Perf tooling evidence rules
+        run: python -m pytest benchmark/perf/tests/ -q
 
       # Boots the real app (in-memory, stub providers, rate-limit off) and drives a
       # small concurrency sweep. --max-error-rate 0 makes this a zero-tolerance

--- a/benchmark/perf/provider_accounting.py
+++ b/benchmark/perf/provider_accounting.py
@@ -1,0 +1,167 @@
+"""Benchmark-only provider call accounting for live-provider experiments (Phase C).
+
+Separates the two counts a live experiment must never conflate:
+
+* **logical calls** — how many times the system asked the provider for a completion
+* **physical attempts** — how many HTTP requests actually went out
+
+They differ whenever the retry envelope re-attempts a call, so a budget expressed in
+one is not a budget in the other. Both are enforced *before* an attempt leaves, so a
+ceiling cannot be crossed and then noticed.
+
+The wiring assertion
+--------------------
+`assert_live_provider_wired` exists because of a real failure during Phase C. The app
+resolves its provider through `deps.gateway()`, which is `@lru_cache`d, so the Gateway
+captures its provider on first use; rebinding the registry afterwards left the cached
+instance on the previous provider. A run then completed with clean latency numbers,
+zero errors — and zero provider calls, having measured the stub while claiming to
+measure the provider. Silence looked exactly like success.
+
+So a live run must *prove* the provider is wired before spending budget: issue one
+request and require the call counter to move. If live evidence is requested and the
+runtime is stubbed, this raises. It never silently continues.
+
+Content safety
+--------------
+Only counts, token totals and exception *class names* are recorded. API keys, prompts,
+memory content, embeddings and raw provider responses are never captured, so a
+serialized artifact carries no secret and no user data.
+"""
+
+from __future__ import annotations
+
+import threading
+
+
+class LiveProviderNotWired(RuntimeError):
+    """Live evidence was requested but the runtime did not call the provider."""
+
+
+class BudgetExceeded(RuntimeError):
+    """An attempt was refused because it would breach an approved ceiling."""
+
+
+class ProviderAccount:
+    """Counts calls/attempts/tokens and enforces hard ceilings.
+
+    ``max_attempts`` and ``max_cost_usd`` are abort thresholds, not targets.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_attempts: int,
+        max_cost_usd: float,
+        price_input_per_m: float,
+        price_output_per_m: float,
+    ) -> None:
+        self._lock = threading.Lock()
+        self.max_attempts = max_attempts
+        self.max_cost_usd = max_cost_usd
+        self.price_input_per_m = price_input_per_m
+        self.price_output_per_m = price_output_per_m
+        self.logical_calls = 0
+        self.physical_attempts = 0
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.thinking_tokens = 0
+        self.error_classes: list[str] = []
+        self.aborted: str | None = None
+
+    # ── accounting ───────────────────────────────────────────────────────────
+    @property
+    def retries(self) -> int:
+        return self.physical_attempts - self.logical_calls
+
+    @property
+    def estimated_cost_usd(self) -> float:
+        """Thinking tokens bill as output on Gemini 2.5 Flash, so they are priced
+        as output rather than ignored — visible response text understates billing."""
+        billed_output = self.output_tokens + self.thinking_tokens
+        return (
+            self.input_tokens / 1_000_000 * self.price_input_per_m
+            + billed_output / 1_000_000 * self.price_output_per_m
+        )
+
+    def record_logical_call(self) -> None:
+        with self._lock:
+            self.logical_calls += 1
+
+    def reserve_attempt(self) -> None:
+        """Account for one outgoing HTTP attempt, or refuse it.
+
+        Called *before* the request is sent so a ceiling is enforced rather than
+        merely observed after the fact.
+        """
+        with self._lock:
+            if self.aborted:
+                raise BudgetExceeded(self.aborted)
+            if self.physical_attempts + 1 > self.max_attempts:
+                self.aborted = f"physical attempts would exceed {self.max_attempts}"
+                raise BudgetExceeded(self.aborted)
+            if self._cost_locked() >= self.max_cost_usd:
+                self.aborted = (
+                    f"estimated cost {self._cost_locked():.4f} reached "
+                    f"ceiling {self.max_cost_usd}"
+                )
+                raise BudgetExceeded(self.aborted)
+            self.physical_attempts += 1
+
+    def _cost_locked(self) -> float:
+        billed_output = self.output_tokens + self.thinking_tokens
+        return (
+            self.input_tokens / 1_000_000 * self.price_input_per_m
+            + billed_output / 1_000_000 * self.price_output_per_m
+        )
+
+    def record_usage(self, usage) -> None:
+        """Read token counts off a provider usage object. Missing fields count 0."""
+        if usage is None:
+            return
+        with self._lock:
+            self.input_tokens += int(getattr(usage, "prompt_token_count", 0) or 0)
+            self.output_tokens += int(getattr(usage, "candidates_token_count", 0) or 0)
+            self.thinking_tokens += int(getattr(usage, "thoughts_token_count", 0) or 0)
+
+    def record_error(self, exc: BaseException) -> None:
+        """Record the exception *class*; never its message, which may echo a request."""
+        with self._lock:
+            self.error_classes.append(type(exc).__name__)
+
+    # ── serialization ────────────────────────────────────────────────────────
+    def as_dict(self) -> dict:
+        return {
+            "logical_calls": self.logical_calls,
+            "physical_attempts": self.physical_attempts,
+            "retries": self.retries,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "thinking_tokens": self.thinking_tokens,
+            "total_tokens": self.input_tokens + self.output_tokens + self.thinking_tokens,
+            "estimated_cost_usd": round(self.estimated_cost_usd, 4),
+            "price_input_per_m_usd": self.price_input_per_m,
+            "price_output_per_m_usd": self.price_output_per_m,
+            "max_attempts": self.max_attempts,
+            "max_cost_usd": self.max_cost_usd,
+            "aborted": self.aborted,
+            "error_classes": sorted(set(self.error_classes)),
+        }
+
+
+def assert_live_provider_wired(account: ProviderAccount, issue_one_request) -> None:
+    """Prove the live provider is reachable from the request path before spending.
+
+    ``issue_one_request`` performs a single ordinary request. If the account's call
+    counter does not move, the runtime is not calling the provider — most likely a
+    cached gateway still holding a stub — and this raises rather than letting a
+    stubbed run be published as live evidence.
+    """
+    before = account.logical_calls
+    issue_one_request()
+    if account.logical_calls <= before:
+        raise LiveProviderNotWired(
+            "live provider evidence was requested but the runtime made no provider "
+            "call. The gateway is likely cached with a different provider "
+            "(deps.gateway is lru_cached) — clear it after rebinding."
+        )

--- a/benchmark/perf/results/gemini-2.5-flash_phase-c.json
+++ b/benchmark/perf/results/gemini-2.5-flash_phase-c.json
@@ -1,0 +1,150 @@
+{
+  "base_sha": "0190bcda53ee9178e1c59f729483bfa12f1d272c",
+  "date": "2026-08-12",
+  "python": "3.13.2",
+  "postgres": "17.10",
+  "pgvector": "0.8.5",
+  "note": "Local single-node laptop measurement. Not a Railway or production figure.",
+  "artifact": "gemini-2.5-flash_phase-c",
+  "provider": "gemini",
+  "model": "gemini-2.5-flash",
+  "other_providers_called": [],
+  "storage": "postgres",
+  "embedding_provider": "stub (local, not a provider call)",
+  "retry_ownership": {
+    "memoryops_max_attempts_per_logical_call": 3,
+    "gemini_sdk_internal_default_retries": 0,
+    "note": "OpenAI/Anthropic nest their own retries; neither was called here"
+  },
+  "workloads": [
+    {
+      "label": "A read-dominant/no-candidate chat",
+      "concurrency": 1,
+      "requests": 25,
+      "successes": 25,
+      "errors": 0,
+      "status_counts": {
+        "200": 25
+      },
+      "successful_rps": 1.15,
+      "attempted_rps": 1.15,
+      "p50_ms": 820.36,
+      "p95_ms": 996.77,
+      "p99_ms": 1752.63,
+      "logical_provider_calls": 25,
+      "physical_provider_attempts": 25,
+      "retries": 0
+    },
+    {
+      "label": "A read-dominant/no-candidate chat",
+      "concurrency": 5,
+      "requests": 25,
+      "successes": 25,
+      "errors": 0,
+      "status_counts": {
+        "200": 25
+      },
+      "successful_rps": 5.81,
+      "attempted_rps": 5.81,
+      "p50_ms": 833.35,
+      "p95_ms": 994.23,
+      "p99_ms": 1147.5,
+      "logical_provider_calls": 25,
+      "physical_provider_attempts": 25,
+      "retries": 0
+    },
+    {
+      "label": "B single-candidate write",
+      "concurrency": 1,
+      "requests": 25,
+      "successes": 25,
+      "errors": 0,
+      "status_counts": {
+        "200": 25
+      },
+      "successful_rps": 0.46,
+      "attempted_rps": 0.46,
+      "p50_ms": 2196.45,
+      "p95_ms": 2564.67,
+      "p99_ms": 2675.47,
+      "logical_provider_calls": 50,
+      "physical_provider_attempts": 50,
+      "retries": 0
+    },
+    {
+      "label": "B single-candidate write",
+      "concurrency": 5,
+      "requests": 25,
+      "successes": 25,
+      "errors": 0,
+      "status_counts": {
+        "200": 25
+      },
+      "successful_rps": 2.01,
+      "attempted_rps": 2.01,
+      "p50_ms": 2230.2,
+      "p95_ms": 3011.64,
+      "p99_ms": 3267.85,
+      "logical_provider_calls": 50,
+      "physical_provider_attempts": 50,
+      "retries": 0
+    }
+  ],
+  "call_shape_verified": {
+    "A read-dominant/no-candidate chat": {
+      "extraction": 1.0,
+      "conflict_detection": 0.0,
+      "embedding_local": 1.0,
+      "candidates": 0
+    },
+    "B single-candidate write": {
+      "extraction": 1.0,
+      "conflict_detection": 1.0,
+      "embedding_local": 1.2,
+      "candidates": 1
+    }
+  },
+  "accepted_workload_totals": {
+    "user_level_requests": 100,
+    "logical_provider_calls": 150,
+    "physical_provider_attempts": 150,
+    "retries": 0,
+    "errors": 0,
+    "rate_limited": 0
+  },
+  "token_accounting": {
+    "scope": "SESSION-LEVEL \u2014 includes the 2 positive wiring-assertion calls, so these are NOT workload-only totals",
+    "calls_covered": 152,
+    "input_tokens": 54898,
+    "output_tokens": 6423,
+    "thinking_tokens": 10483,
+    "total_tokens": 71804,
+    "estimated_cost_usd": 0.0587,
+    "pricing_assumption_usd_per_m": {
+      "input": 0.3,
+      "output": 2.5,
+      "note": "thinking tokens bill as output"
+    },
+    "thinking_share_of_billed_output_pct": 62
+  },
+  "session_accounting": {
+    "note": "includes the wiring probe, a 1-request smoke, and calls spent by an aborted setup run whose provider patch missed app/services/extractor.py",
+    "physical_attempts_upper_bound": 174,
+    "estimated_cost_usd_upper_bound": 0.07,
+    "approved_ceiling_attempts": 450,
+    "approved_ceiling_usd": 2.0,
+    "budget_respected": true
+  },
+  "async_verdict": {
+    "conclusion": "Blanket async migration is not justified by the current measurements.",
+    "evidence": "Workload A c=1 -> c=5: throughput 1.15 -> 5.81 rps while p50 held at 820.4 -> 833.4 ms; the synchronous path overlapped provider waiting through the tested concurrency",
+    "limitations": [
+      "only gemini-2.5-flash tested",
+      "provider-backed concurrency only through c=5",
+      "other providers may differ",
+      "higher concurrency not measured",
+      "Railway-scale behaviour not measured"
+    ],
+    "disallowed_claim": "async can never help"
+  }
+}

--- a/benchmark/perf/results/postgres_pgvector_phase-c.json
+++ b/benchmark/perf/results/postgres_pgvector_phase-c.json
@@ -1,0 +1,113 @@
+{
+  "base_sha": "0190bcda53ee9178e1c59f729483bfa12f1d272c",
+  "date": "2026-08-12",
+  "python": "3.13.2",
+  "postgres": "17.10",
+  "pgvector": "0.8.5",
+  "note": "Local single-node laptop measurement. Not a Railway or production figure.",
+  "artifact": "postgres_pgvector_phase-c",
+  "harness": "benchmark/perf/run_perf.py",
+  "storage": "postgres",
+  "llm_provider": "stub",
+  "embedding_provider": "stub",
+  "rate_limit_enabled": false,
+  "latency_basis": "successful (2xx) requests only",
+  "dataset": {
+    "total_rows": 100001,
+    "target_tenant_rows": 10000,
+    "note": "scenarios use fresh scopes seeded with 20 seed requests; the 10k tenant is the scale dataset"
+  },
+  "scenarios": [
+    {
+      "operation": "retrieval",
+      "concurrency": 1,
+      "repetitions": 2,
+      "valid_repetitions": 2,
+      "successful_rps_median": 42.3,
+      "attempted_rps_median": 42.3,
+      "p50_ms_median": 21.639,
+      "p95_ms_median": 28.797,
+      "p99_ms_median": 30.95,
+      "error_rate_max": 0.0,
+      "rate_limited_total": 0
+    },
+    {
+      "operation": "retrieval",
+      "concurrency": 5,
+      "repetitions": 2,
+      "valid_repetitions": 2,
+      "successful_rps_median": 45.65,
+      "attempted_rps_median": 45.65,
+      "p50_ms_median": 105.528,
+      "p95_ms_median": 131.477,
+      "p99_ms_median": 155.625,
+      "error_rate_max": 0.0,
+      "rate_limited_total": 0
+    },
+    {
+      "operation": "retrieval",
+      "concurrency": 25,
+      "repetitions": 2,
+      "valid_repetitions": 2,
+      "successful_rps_median": 41.8,
+      "attempted_rps_median": 41.8,
+      "p50_ms_median": 553.448,
+      "p95_ms_median": 737.214,
+      "p99_ms_median": 788.29,
+      "error_rate_max": 0.0,
+      "rate_limited_total": 0
+    },
+    {
+      "operation": "retrieval",
+      "concurrency": 50,
+      "repetitions": 2,
+      "valid_repetitions": 2,
+      "successful_rps_median": 40.7,
+      "attempted_rps_median": 40.7,
+      "p50_ms_median": 1010.067,
+      "p95_ms_median": 1456.645,
+      "p99_ms_median": 1467.285,
+      "error_rate_max": 0.0,
+      "rate_limited_total": 0
+    }
+  ],
+  "retrieval_scale_p50_ms": {
+    "100": 26.0,
+    "1000": 31.0,
+    "10000": 87.2
+  },
+  "retrieval_scale_p95_ms": {
+    "100": 29.8,
+    "1000": 32.5,
+    "10000": 94.2
+  },
+  "query_plan": {
+    "at_100k_total_rows_10k_tenant": "Bitmap Index Scan idx_memory_user_status -> Bitmap Heap Scan (10000 rows) -> top-N exact vector sort; IVFFlat NOT chosen",
+    "at_10k_single_tenant": "Index Scan using idx_memory_embedding (IVFFlat), 49/50 recall at ivfflat.probes=1",
+    "conclusion": "index presence does not imply ANN execution; the planner's choice is data- and query-dependent"
+  },
+  "db_pool_experiment": {
+    "default_pool_size": 5,
+    "default_max_overflow": 10,
+    "observed_peak_connections_default": 15,
+    "widened_pool_size": 50,
+    "widened_max_overflow": 50,
+    "observed_peak_connections_widened": 45,
+    "successful_rps_default": {
+      "1": 31.9,
+      "5": 43.7,
+      "10": 39.8,
+      "25": 40.4,
+      "50": 39.8
+    },
+    "successful_rps_widened": {
+      "1": 32.5,
+      "5": 44.2,
+      "10": 40.6,
+      "25": 40.5,
+      "50": 38.8
+    },
+    "conclusion": "pool saturation observed at default; widening did not materially improve throughput, so pool capacity was not the primary local bottleneck",
+    "committed": false
+  }
+}

--- a/benchmark/perf/results/postgres_sql_profile_phase-c.json
+++ b/benchmark/perf/results/postgres_sql_profile_phase-c.json
@@ -1,0 +1,87 @@
+{
+  "base_sha": "0190bcda53ee9178e1c59f729483bfa12f1d272c",
+  "date": "2026-08-12",
+  "python": "3.13.2",
+  "postgres": "17.10",
+  "pgvector": "0.8.5",
+  "note": "Local single-node laptop measurement. Not a Railway or production figure.",
+  "artifact": "postgres_sql_profile_phase-c",
+  "tool": "benchmark/perf/sqlprofile.py",
+  "method": "SQLAlchemy before/after_cursor_execute; bound parameters never captured; statements normalized before recording",
+  "read_dominant_request": {
+    "statements_per_request": {
+      "median": 117,
+      "min": 117,
+      "max": 117
+    },
+    "transactions_per_request": 73.4,
+    "db_execution_ms_per_request": 63.3,
+    "top_shapes_per_request": [
+      {
+        "count": 66.0,
+        "ms": 5.25,
+        "shape": "select set_config(?, ?, true)"
+      },
+      {
+        "count": 15.0,
+        "ms": 1.17,
+        "shape": "SELECT loop_runs ..."
+      },
+      {
+        "count": 13.0,
+        "ms": 1.59,
+        "shape": "SELECT loop_events ..."
+      },
+      {
+        "count": 13.0,
+        "ms": 1.28,
+        "shape": "INSERT INTO loop_events ..."
+      },
+      {
+        "count": 2.0,
+        "ms": 0.18,
+        "shape": "INSERT INTO loop_runs ..."
+      },
+      {
+        "count": 2.0,
+        "ms": 0.21,
+        "shape": "UPDATE loop_runs ..."
+      },
+      {
+        "count": 1.0,
+        "ms": 53.13,
+        "shape": "SELECT memory_records ... ORDER BY embedding <=> <vector> LIMIT ?"
+      },
+      {
+        "count": 1.0,
+        "ms": 0.08,
+        "shape": "SELECT memory_settings ..."
+      },
+      {
+        "count": 4.0,
+        "ms": 0.41,
+        "shape": "audit chain head read/write + memory_audit_logs insert"
+      }
+    ]
+  },
+  "single_candidate_write_request": {
+    "statements_per_request": {
+      "median": 130,
+      "min": 130,
+      "max": 130
+    }
+  },
+  "driver_wait_interpretation": {
+    "observed_connection_wait_per_request": 282,
+    "measured_sql_statements_per_request": 117,
+    "conclusion": "the request path is genuinely chatty, but driver waits are not SQL statements and not network round trips; ~2.4 waits per statement",
+    "disallowed_claim": "282 DB round trips per request"
+  },
+  "structural_cause": {
+    "location": "PostgresRepository._scoped()",
+    "behaviour": "opens a new Session/transaction for repository operations outside an explicit transaction(), re-establishing RLS context with 2 set_config statements each",
+    "amplifier": "the loop-engineering layer performs many repository calls per request",
+    "status": "measured, NOT changed in Phase C \u2014 transaction consolidation moves the RLS boundary and needs its own FORCE-RLS cross-tenant evidence"
+  },
+  "gil_claim": "NOT PROVEN \u2014 not separately measured"
+}

--- a/benchmark/perf/sqlprofile.py
+++ b/benchmark/perf/sqlprofile.py
@@ -1,0 +1,132 @@
+"""Benchmark-only SQL statement profiling (Phase C).
+
+Counts what a request actually asks the database to do — statement count, normalized
+query shapes, per-shape time — by attaching to SQLAlchemy's cursor-execute events.
+
+Why this exists
+---------------
+A CPU profile of the request path showed ~282 `psycopg` `connection.wait` calls per
+request. That is a driver-level count, not a statement count, and the two are easy to
+conflate: a wait is not a round trip and a round trip is not a statement. Answering
+"how chatty is the request path, really?" needs the statements themselves, which is
+what this module records.
+
+Not production instrumentation
+------------------------------
+This is a benchmark tool. It attaches to an engine you hand it, adds a small constant
+cost per statement, and is never imported by `services/api`.
+
+Content safety
+--------------
+Bound parameters are **never** captured — only the statement text, and only after
+normalization. `normalize()` strips quoted strings, numbers and placeholders before
+anything is stored, so tenant ids, user ids, memory content, embedding vectors and
+credentials cannot reach a recorded shape or a serialized artifact. Vector literals
+are collapsed first, so a 1536-element embedding becomes one `'<vector>'` token
+rather than 1536 separate ones.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import time
+from collections import Counter, defaultdict
+
+#: Applied in order. Vector/array literals go first: collapsing them afterwards would
+#: leave the numeric scrubber to expand one embedding into a thousand tokens.
+_SCRUBBERS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"'\[[^\]]*\]'"), "'<vector>'"),
+    (re.compile(r"\[[-0-9.eE,\s]{40,}\]"), "<vector>"),
+    (re.compile(r"'[^']*'"), "?"),
+    (re.compile(r"\b\d+\.\d+\b"), "?"),
+    (re.compile(r"\b\d+\b"), "?"),
+    (re.compile(r"\$\d+"), "?"),
+    (re.compile(r"%\(\w+\)s"), "?"),
+    (re.compile(r"%s"), "?"),
+    (re.compile(r"\s+"), " "),
+)
+
+#: Shapes are truncated so a very long projection list cannot dominate an artifact.
+MAX_SHAPE_CHARS = 180
+
+
+def normalize(sql: str) -> str:
+    """Reduce a statement to a parameter-free shape safe to record and group by."""
+    text = sql or ""
+    for pattern, replacement in _SCRUBBERS:
+        text = pattern.sub(replacement, text)
+    return text.strip()[:MAX_SHAPE_CHARS]
+
+
+class SqlProfile:
+    """Accumulates statement counts, shapes and timings. Thread-safe."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.statements = 0
+        self.total_ms = 0.0
+        self.by_shape: Counter[str] = Counter()
+        self.ms_by_shape: defaultdict[str, float] = defaultdict(float)
+
+    def record(self, sql: str, elapsed_ms: float) -> None:
+        shape = normalize(sql)
+        with self._lock:
+            self.statements += 1
+            self.total_ms += elapsed_ms
+            self.by_shape[shape] += 1
+            self.ms_by_shape[shape] += elapsed_ms
+
+    def reset(self) -> None:
+        with self._lock:
+            self.statements = 0
+            self.total_ms = 0.0
+            self.by_shape.clear()
+            self.ms_by_shape.clear()
+
+    def top_shapes(self, limit: int = 15) -> list[dict]:
+        with self._lock:
+            items = sorted(self.by_shape.items(), key=lambda kv: -kv[1])[:limit]
+            return [
+                {"count": n, "total_ms": round(self.ms_by_shape[s], 3), "shape": s}
+                for s, n in items
+            ]
+
+    def as_dict(self, *, requests: int = 1, top: int = 15) -> dict:
+        """Serializable summary. ``requests`` divides the totals into per-request
+        figures, which is the unit the evidence is reported in."""
+        with self._lock:
+            statements, total_ms = self.statements, self.total_ms
+        divisor = requests or 1
+        return {
+            "requests": requests,
+            "statements_total": statements,
+            "statements_per_request": round(statements / divisor, 2),
+            "db_execution_ms_total": round(total_ms, 3),
+            "db_execution_ms_per_request": round(total_ms / divisor, 3),
+            "top_shapes": [
+                {**s, "count_per_request": round(s["count"] / divisor, 2)}
+                for s in self.top_shapes(top)
+            ],
+        }
+
+
+def attach(engine, profile: SqlProfile | None = None) -> SqlProfile:
+    """Record every statement executed on ``engine``. Returns the profile."""
+    from sqlalchemy import event
+
+    profile = profile or SqlProfile()
+    state = threading.local()
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def _before(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
+        state.started = time.perf_counter()
+
+    @event.listens_for(engine, "after_cursor_execute")
+    def _after(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
+        started = getattr(state, "started", None)
+        elapsed_ms = (time.perf_counter() - started) * 1000.0 if started else 0.0
+        # `parameters` is deliberately ignored — see the module docstring.
+        profile.record(statement, elapsed_ms)
+
+    return profile

--- a/benchmark/perf/tests/test_provider_accounting.py
+++ b/benchmark/perf/tests/test_provider_accounting.py
@@ -1,0 +1,182 @@
+"""Provider accounting must be exact, capped, and impossible to fake.
+
+The load-bearing case is `test_a_stubbed_runtime_cannot_pass_as_live_evidence`: during
+Phase C a run finished with clean latency, zero errors and zero provider calls,
+because the cached gateway still held a stub. That artifact was indistinguishable from
+a successful live run except for the call counter. These tests pin the guard that
+turns it into a failure.
+
+No network, no provider SDK, no credentials.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from provider_accounting import (  # noqa: E402
+    BudgetExceeded,
+    LiveProviderNotWired,
+    ProviderAccount,
+    assert_live_provider_wired,
+)
+
+
+def _account(max_attempts=450, max_cost=2.00):
+    return ProviderAccount(
+        max_attempts=max_attempts,
+        max_cost_usd=max_cost,
+        price_input_per_m=0.30,
+        price_output_per_m=2.50,
+    )
+
+
+class _Usage:
+    def __init__(self, prompt=0, candidates=0, thoughts=0):
+        self.prompt_token_count = prompt
+        self.candidates_token_count = candidates
+        self.thoughts_token_count = thoughts
+
+
+# ── logical vs physical ──────────────────────────────────────────────────────
+def test_logical_and_physical_counts_are_separate():
+    a = _account()
+    a.record_logical_call()
+    a.reserve_attempt()
+    a.reserve_attempt()  # a retry of the same logical call
+    assert a.logical_calls == 1
+    assert a.physical_attempts == 2
+    assert a.retries == 1
+
+
+def test_a_clean_run_records_no_retries():
+    a = _account()
+    for _ in range(150):
+        a.record_logical_call()
+        a.reserve_attempt()
+    assert (a.logical_calls, a.physical_attempts, a.retries) == (150, 150, 0)
+
+
+# ── hard ceilings are enforced before the request goes out ───────────────────
+def test_the_attempt_ceiling_refuses_rather_than_reports():
+    a = _account(max_attempts=3)
+    for _ in range(3):
+        a.reserve_attempt()
+    with pytest.raises(BudgetExceeded):
+        a.reserve_attempt()
+    assert a.physical_attempts == 3, "the refused attempt must not be counted"
+
+
+def test_the_cost_ceiling_aborts():
+    a = _account(max_cost=0.01)
+    a.record_usage(_Usage(prompt=1_000_000, candidates=1_000_000))  # far over
+    with pytest.raises(BudgetExceeded):
+        a.reserve_attempt()
+    assert a.aborted
+
+
+def test_once_aborted_further_attempts_stay_refused():
+    a = _account(max_attempts=1)
+    a.reserve_attempt()
+    with pytest.raises(BudgetExceeded):
+        a.reserve_attempt()
+    with pytest.raises(BudgetExceeded):
+        a.reserve_attempt()
+    assert a.physical_attempts == 1
+
+
+# ── token and cost accounting ────────────────────────────────────────────────
+def test_usage_accumulates_across_calls():
+    a = _account()
+    a.record_usage(_Usage(prompt=688, candidates=109, thoughts=200))
+    a.record_usage(_Usage(prompt=100, candidates=10, thoughts=20))
+    assert a.input_tokens == 788
+    assert a.output_tokens == 119
+    assert a.thinking_tokens == 220
+
+
+def test_thinking_tokens_are_billed_as_output():
+    """Visible response text understates billing on Gemini 2.5 Flash."""
+    without = _account()
+    without.record_usage(_Usage(prompt=1000, candidates=1000, thoughts=0))
+    with_thinking = _account()
+    with_thinking.record_usage(_Usage(prompt=1000, candidates=1000, thoughts=1000))
+    assert with_thinking.estimated_cost_usd > without.estimated_cost_usd
+    assert with_thinking.estimated_cost_usd == pytest.approx(
+        1000 / 1e6 * 0.30 + 2000 / 1e6 * 2.50
+    )
+
+
+def test_missing_usage_is_tolerated():
+    """A provider that reports no usage must not crash the run or invent tokens."""
+    a = _account()
+    a.record_usage(None)
+    a.record_usage(_Usage())
+    assert (a.input_tokens, a.output_tokens, a.thinking_tokens) == (0, 0, 0)
+    assert a.estimated_cost_usd == 0.0
+
+
+# ── the wiring guard ─────────────────────────────────────────────────────────
+def test_a_stubbed_runtime_cannot_pass_as_live_evidence():
+    """The Phase C failure, pinned: clean run, zero calls, published as live."""
+    a = _account()
+
+    def stubbed_request():
+        return None  # never touches the provider
+
+    with pytest.raises(LiveProviderNotWired):
+        assert_live_provider_wired(a, stubbed_request)
+
+
+def test_a_wired_runtime_passes_the_guard():
+    a = _account()
+
+    def live_request():
+        a.record_logical_call()
+        a.reserve_attempt()
+
+    assert_live_provider_wired(a, live_request)
+    assert a.logical_calls == 1
+
+
+def test_the_guard_reports_the_cached_gateway_cause():
+    a = _account()
+    with pytest.raises(LiveProviderNotWired, match="lru_cached"):
+        assert_live_provider_wired(a, lambda: None)
+
+
+# ── serialization excludes secrets and user data ─────────────────────────────
+def test_serialized_account_carries_only_counts():
+    a = _account()
+    a.record_logical_call()
+    a.reserve_attempt()
+    a.record_usage(_Usage(prompt=361, candidates=42, thoughts=69))
+    out = a.as_dict()
+    assert out["logical_calls"] == 1 and out["physical_attempts"] == 1
+    assert out["total_tokens"] == 472
+    assert set(out) == {
+        "logical_calls", "physical_attempts", "retries", "input_tokens",
+        "output_tokens", "thinking_tokens", "total_tokens", "estimated_cost_usd",
+        "price_input_per_m_usd", "price_output_per_m_usd", "max_attempts",
+        "max_cost_usd", "aborted", "error_classes",
+    }
+
+
+def test_errors_record_the_class_not_the_message():
+    """A provider error message can echo the request; the class name cannot."""
+    a = _account()
+    secret = "sk" + "-" + "live" + "0123456789abcdef"
+    a.record_error(ValueError(f"rejected request containing {secret}"))
+    out = a.as_dict()
+    assert out["error_classes"] == ["ValueError"]
+    assert secret not in repr(out)
+
+
+def test_serialized_account_has_no_credential_or_scope_fields():
+    blob = repr(_account().as_dict()).lower()
+    for forbidden in ("api_key", "authorization", "password", "tenant", "user_id", "prompt"):
+        assert forbidden not in blob

--- a/benchmark/perf/tests/test_sqlprofile.py
+++ b/benchmark/perf/tests/test_sqlprofile.py
@@ -1,0 +1,135 @@
+"""SQL profiling must count statements without ever capturing their data.
+
+The profiler exists to answer a counting question, so the counting has to be right;
+but it runs against a real database holding real tenant data, so the safety property
+matters more. Both are pinned here. No database is required.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlprofile import MAX_SHAPE_CHARS, SqlProfile, normalize  # noqa: E402
+
+
+# ── normalization removes data, not structure ────────────────────────────────
+def test_string_literals_are_stripped():
+    out = normalize("SELECT * FROM memory_records WHERE tenant_id = 'acme_corp'")
+    assert "acme_corp" not in out
+    assert "SELECT" in out and "memory_records" in out
+
+
+def test_tenant_and_user_values_cannot_survive():
+    sql = "SELECT id FROM memory_records WHERE tenant_id = 'acme' AND user_id = 'alice'"
+    out = normalize(sql)
+    assert "acme" not in out and "alice" not in out
+
+
+def test_memory_content_cannot_survive():
+    sql = "INSERT INTO memory_records (content) VALUES ('my badge number is 7788')"
+    out = normalize(sql)
+    assert "badge" not in out and "7788" not in out
+
+
+def test_a_credential_shaped_literal_cannot_survive():
+    secret = "sk" + "-" + "live" + "0123456789abcdef"
+    out = normalize(f"INSERT INTO memory_records (content) VALUES ('{secret}')")
+    assert secret not in out
+
+
+def test_embedding_vectors_collapse_to_a_single_token():
+    """A 1536-element literal must not become 1536 separate placeholders."""
+    vector = "[" + ",".join(f"{i / 1000:.6f}" for i in range(1536)) + "]"
+    out = normalize(f"SELECT id FROM memory_records ORDER BY embedding <=> '{vector}'")
+    assert "0.001" not in out
+    assert out.count("?") <= 2
+    assert len(out) <= MAX_SHAPE_CHARS
+
+
+def test_numbers_and_placeholders_are_stripped():
+    out = normalize("SELECT * FROM t WHERE a = 42 AND b = 3.5 AND c = $1 AND d = %(x)s")
+    assert "42" not in out and "3.5" not in out
+
+
+def test_shape_is_truncated():
+    assert len(normalize("SELECT " + ", ".join(f"col_{i}" for i in range(500)))) <= MAX_SHAPE_CHARS
+
+
+def test_normalization_is_stable_across_differing_values():
+    """Grouping only works if two equivalent statements normalize identically."""
+    a = normalize("SELECT id FROM memory_records WHERE tenant_id = 'acme'")
+    b = normalize("SELECT id FROM memory_records WHERE tenant_id = 'globex'")
+    assert a == b
+
+
+def test_different_statements_do_not_collapse_together():
+    a = normalize("SELECT id FROM memory_records WHERE tenant_id = 'acme'")
+    b = normalize("SELECT id FROM loop_events WHERE tenant_id = 'acme'")
+    assert a != b
+
+
+def test_empty_statement_is_handled():
+    assert normalize("") == ""
+
+
+# ── counting and grouping ────────────────────────────────────────────────────
+def test_statements_are_counted_and_grouped():
+    p = SqlProfile()
+    for tenant in ("acme", "globex", "initech"):
+        p.record(f"SELECT id FROM memory_records WHERE tenant_id = '{tenant}'", 1.0)
+    p.record("select set_config('app.tenant_id', 'acme', true)", 0.5)
+    assert p.statements == 4
+    assert len(p.by_shape) == 2, "equivalent statements must group into one shape"
+    assert max(p.by_shape.values()) == 3
+
+
+def test_per_shape_timing_accumulates():
+    p = SqlProfile()
+    p.record("SELECT 1 FROM t WHERE a = 'x'", 10.0)
+    p.record("SELECT 1 FROM t WHERE a = 'y'", 5.0)
+    assert p.total_ms == pytest.approx(15.0)
+    assert p.top_shapes()[0]["total_ms"] == pytest.approx(15.0)
+    assert p.top_shapes()[0]["count"] == 2
+
+
+def test_top_shapes_are_ordered_by_frequency():
+    p = SqlProfile()
+    for _ in range(5):
+        p.record("select set_config('a', 'b', true)", 0.1)
+    p.record("SELECT id FROM memory_records WHERE tenant_id = 'acme'", 50.0)
+    assert p.top_shapes()[0]["count"] == 5
+
+
+def test_reset_clears_everything():
+    p = SqlProfile()
+    p.record("SELECT 1", 1.0)
+    p.reset()
+    assert p.statements == 0 and p.total_ms == 0.0 and not p.by_shape
+
+
+# ── serialization ────────────────────────────────────────────────────────────
+def test_summary_reports_per_request_figures():
+    p = SqlProfile()
+    for _ in range(234):
+        p.record("SELECT id FROM memory_records WHERE tenant_id = 'acme'", 0.5)
+    out = p.as_dict(requests=2)
+    assert out["statements_total"] == 234
+    assert out["statements_per_request"] == 117.0
+    assert out["db_execution_ms_per_request"] == pytest.approx(58.5)
+
+
+def test_serialized_summary_contains_no_parameter_values():
+    p = SqlProfile()
+    secret = "sk" + "-" + "live" + "0123456789abcdef"
+    p.record(f"SELECT id FROM memory_records WHERE tenant_id = 'acme' AND k = '{secret}'", 1.0)
+    blob = repr(p.as_dict(requests=1))
+    assert secret not in blob and "acme" not in blob
+
+
+def test_summary_survives_zero_requests():
+    assert SqlProfile().as_dict(requests=0)["statements_per_request"] == 0.0

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,9 +1,14 @@
 # Performance (P4.3)
 
-> **Status: first pass — in-memory + stub providers, single process.**
-> This is a starting observation, not a tuned result and not a root-cause analysis.
-> Postgres/pgvector, real providers, and per-stage CPU/pool instrumentation are the
-> follow-ups that would let us attribute *cause* (see the end).
+> **Status: characterized on real Postgres + pgvector and a real provider (Phase C).**
+> The follow-ups the first pass called for — Postgres/pgvector, a real provider,
+> SQL-statement and pool instrumentation — have been run. Their results are in
+> [Phase C](#phase-c--real-request-path-characterization) below, with machine-readable
+> artifacts in [`benchmark/perf/results/`](../benchmark/perf/results/).
+>
+> **Everything measured here is a single-node laptop measurement.** It is not a
+> Railway figure, not a production throughput number, and not a claim about
+> providers other than the one tested.
 
 > **⚠️ Read the numbers below as observations, not proofs.** The tables in this
 > document were produced by an **earlier version of the harness** that created a
@@ -96,6 +101,26 @@ Operations map to the three user-facing paths:
 Raw JSON for every run below lives in
 [`benchmark/perf/results/`](../benchmark/perf/results/).
 
+### Reproducing the Phase C measurements
+
+Point the same harness at a Postgres-backed server (`MEMORYOPS_STORAGE=postgres`,
+`MEMORYOPS_DATABASE_URL=…`) with pgvector installed and the migrations applied.
+
+Two benchmark-only tools support the deeper measurements, both under
+`benchmark/perf/` and never imported by `services/api`:
+
+| tool | what it gives you |
+|---|---|
+| [`sqlprofile.py`](../benchmark/perf/sqlprofile.py) | statements/request, normalized query shapes, per-shape time. Attach with `attach(repo._engine)`. Bound parameters are never captured, so shapes carry no tenant, user, content, embedding or credential. |
+| [`provider_accounting.py`](../benchmark/perf/provider_accounting.py) | logical calls vs physical attempts, token/cost accounting, and hard ceilings enforced *before* a request is sent. |
+
+Any live-provider run must call `assert_live_provider_wired()` first. It issues one
+request and fails if the provider was not actually called — because `deps.gateway()`
+is `lru_cache`d, a rebind after the gateway is built leaves the cached instance on the
+old provider, and a stubbed run then produces clean latency numbers and zero provider
+calls that look exactly like a successful live run. That happened during Phase C; the
+guard exists so it fails loudly instead.
+
 ## Environment & honesty caveats
 
 - Measured on a laptop (macOS, Apple Silicon), **single uvicorn worker**, Python
@@ -112,7 +137,13 @@ Raw JSON for every run below lives in
 
 ## Results
 
-### 1. Concurrency sweep — in-memory / stub / rate-limit off / hybrid ranker
+> **⚠️ Sections 1–3 are HISTORICAL and SUPERSEDED.** They were produced by the
+> earlier harness and the in-memory backend, and their `rps` counted failed requests
+> while their percentiles mixed failure latency into success latency. They are kept
+> for provenance. For current evidence use
+> [Phase C](#phase-c--real-request-path-characterization).
+
+### 1. Concurrency sweep — in-memory / stub / rate-limit off / hybrid ranker *(historical)*
 
 400 requests per scenario. `rps` = requests/sec (higher better); latency in ms.
 
@@ -148,7 +179,7 @@ cost charged to every latency sample) and let the store grow across the sweep, s
 client overhead, thread-pool limits, CPU work, and store growth are all still on the
 table. See the caveat at the top.
 
-### 2. Latency vs store size — retrieval, in-memory (linear scan)
+### 2. Latency vs store size — retrieval, in-memory (linear scan) *(historical)*
 
 Retrieval p50 as the store grows (single client):
 
@@ -161,19 +192,28 @@ Retrieval p50 as the store grows (single client):
 the HTTP write path is **O(n²)** (every seed write also runs a read over the
 growing store), so the 5 k / 10 k points were not driven locally — but the trend
 above already shows the shape. The in-memory repository scans **O(n)** candidates
-per query, so retrieval cost grows with the store. This is a property of the **dev/default** backend, not of
-MemoryOps as designed: on Postgres, retrieval goes through the **pgvector ANN
-index** (and the `VectorIndex` abstraction, ADR-021), which is sub-linear.
-Postgres + pgvector **is** available and is exercised locally and in CI (the
-`api-postgres` job); quantifying the ANN-vs-linear retrieval curve on it is the
-tracked follow-up below. Store **memory** also grows with row count — RSS rose from
+per query, so retrieval cost grows with the store. This is a property of the
+**dev/default** backend, not of MemoryOps as designed.
+
+> **Correction (Phase C).** An earlier version of this paragraph stated that on
+> Postgres "retrieval goes through the pgvector ANN index … which is sub-linear."
+> That claim was not measured, and **measurement contradicts it as a general
+> statement**. At 100 k total rows with a 10 k-row tenant, the planner did **not**
+> choose the IVFFlat index: it used the tenant/status btree, bitmap-heap-scanned all
+> 10 000 tenant rows, and top-N sorted them by exact vector distance. IVFFlat *was*
+> chosen on a smaller single-tenant dataset. **An index existing is not an index
+> being used**, and retrieval on Postgres is not universally ANN or sub-linear —
+> the plan is data- and query-dependent. See
+> [Phase C](#phase-c--real-request-path-characterization).
+
+Store **memory** also grows with row count — RSS rose from
 **37 MB → 234 MB** over the concurrency sweep — but the harness did not record the
 exact memory count for those runs, so **no reliable per-memory byte figure can be
 derived** from them. (An earlier draft's "~33 KB/memory" divided RSS by an *assumed*
 row count and has been removed.) The corrected harness now records actual before/
 after memory counts, so a defensible per-memory figure can be measured on the re-run.
 
-### 3. Rate limiter — per-process, fail-fast
+### 3. Rate limiter — per-process, fail-fast *(historical)*
 
 `MEMORYOPS_RATE_LIMIT_ENABLED=true`, defaults (chat = 30/min per tenant/IP). A
 burst of 100 chat requests (concurrency 10) from one tenant/IP:
@@ -191,7 +231,158 @@ Each replica has its own 30/min budget, and a restart resets it. It is **local
 process protection, not distributed rate enforcement.** A Redis-backed limiter is
 the fix for a real multi-replica limit (follow-up).
 
+## Phase C — real request-path characterization
+
+Measured on **PostgreSQL 17.10 + pgvector 0.8.5** (isolated local cluster, Python
+3.13.2), base `0190bcd`. Artifacts:
+[`postgres_pgvector_phase-c.json`](../benchmark/perf/results/postgres_pgvector_phase-c.json),
+[`postgres_sql_profile_phase-c.json`](../benchmark/perf/results/postgres_sql_profile_phase-c.json),
+[`gemini-2.5-flash_phase-c.json`](../benchmark/perf/results/gemini-2.5-flash_phase-c.json).
+
+All numbers below come from the corrected harness: latency is success-only,
+throughput is `successful_rps`, and every scenario was valid (0 errors, 0 × 429).
+
+### C1. Local ceiling — Postgres + stub provider
+
+| conc | successful_rps | p50 | p95 | p99 | errors |
+|-----:|---------------:|----:|----:|----:|:------:|
+| 1  | 42.3 | 21.6 ms   | 28.8 ms   | 31.0 ms   | 0 |
+| 5  | 45.7 | 105.5 ms  | 131.5 ms  | 155.6 ms  | 0 |
+| 25 | 41.8 | 553.4 ms  | 737.2 ms  | 788.3 ms  | 0 |
+| 50 | 40.7 | 1010.1 ms | 1456.6 ms | 1467.3 ms | 0 |
+
+`attempted_rps == successful_rps` throughout. Throughput is flat at ~40 rps from
+concurrency 5 upward while latency grows linearly — added concurrency queues rather
+than parallelizes. **This ceiling appears with small scopes too**, so it is not
+caused by retrieval store size.
+
+### C2. Retrieval latency vs tenant store size
+
+| tenant memories | p50 | p95 |
+|----------------:|----:|----:|
+| 100    | 26.0 ms | 29.8 ms |
+| 1 000  | 31.0 ms | 32.5 ms |
+| 10 000 | 87.2 ms | 94.2 ms |
+
+Latency grows with the **tenant's** row count, consistent with the exact top-N sort
+in the plan below.
+
+### C3. Query plan — an index existing is not an index being used
+
+At **100 k total rows / 10 k tenant rows**, Postgres did **not** choose IVFFlat:
+
+```
+Limit → Sort (top-N heapsort)
+  → Bitmap Heap Scan on memory_records (rows=10000)
+    → Bitmap Index Scan on idx_memory_user_status
+```
+
+That is exact brute-force KNN over the tenant's memories. On a smaller 10 k
+single-tenant dataset the same query *did* use `idx_memory_embedding` (IVFFlat),
+returning 49/50 rows at the default `ivfflat.probes=1`. The planner's choice is
+data- and query-dependent, so **no universal ANN or sub-linear claim holds**.
+
+### C4. SQL statement profile
+
+Measured with [`sqlprofile.py`](../benchmark/perf/sqlprofile.py) via SQLAlchemy
+cursor events. Bound parameters are never captured.
+
+| request | statements/request | transactions/request | DB execution/request |
+|---|---:|---:|---:|
+| read-dominant | **117** (min 117, max 117) | ~73 | 63.3 ms |
+| single-candidate write | **130** (min 130, max 130) | — | — |
+
+Per read-dominant request:
+
+| count | ms | shape |
+|------:|---:|---|
+| **66** | 5.25 | `select set_config(?, ?, true)` |
+| 15 | 1.17 | `SELECT loop_runs …` |
+| 13 | 1.59 | `SELECT loop_events …` |
+| 13 | 1.28 | `INSERT INTO loop_events …` |
+| 4 | 0.39 | `INSERT`/`UPDATE loop_runs` |
+| **1** | **53.13** | `SELECT memory_records … ORDER BY embedding <=> … LIMIT ?` |
+| 4 | 0.41 | audit chain head + `memory_audit_logs` |
+
+Two different things, which must not be conflated: **statement count** is dominated
+by `set_config` and loop engineering; **DB time** is dominated by the single
+retrieval query (53 ms of 63 ms).
+
+> **On the ~282 `psycopg` `connection.wait` calls per request** seen in an earlier
+> CPU profile: the request path is genuinely chatty, but a driver wait is not a SQL
+> statement and not a network round trip. The measured figure is **117 statements**,
+> i.e. roughly 2.4 waits per statement. *"282 DB round trips per request" is not a
+> supported claim.* **GIL causality is likewise NOT PROVEN** — it was never
+> separately measured.
+
+**Structural cause (measured, deliberately not changed here).**
+`PostgresRepository._scoped()` opens a new `Session` — and therefore a new
+transaction — for repository operations outside an explicit `transaction()`,
+re-establishing RLS context with two `set_config` statements each. The
+loop-engineering layer makes many such calls per request. Consolidating transactions
+moves the boundary around RLS context and needs its own Postgres + `FORCE ROW LEVEL
+SECURITY` cross-tenant evidence, so it is tracked as a follow-up rather than done
+opportunistically.
+
+### C5. DB pool — saturated, but not the bottleneck
+
+Defaults are `pool_size=5` + `max_overflow=10` (15 connections), and peak
+connections did reach 15 at high concurrency. A **measurement-only** widening to
+~100 raised peak connections to 45 and changed throughput not at all:
+
+| conc | successful_rps @ 15 | successful_rps @ 100 |
+|-----:|--------------------:|---------------------:|
+| 5  | 43.7 | 44.2 |
+| 10 | 39.8 | 40.6 |
+| 25 | 40.4 | 40.5 |
+| 50 | 39.8 | 38.8 |
+
+Pool saturation was therefore a *symptom*, not the cause. **The widened pool is not
+committed.**
+
+### C6. Live provider — Gemini 2.5 Flash
+
+Call shape was verified before spending budget. Workload A is *not* "retrieval-only":
+a question still runs extraction.
+
+| workload | conc | requests | successful_rps | p50 | p95 | p99 | logical | physical | retries | errors |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--:|
+| A read-dominant / no-candidate chat | 1 | 25 | 1.15 | 820.4 ms | 996.8 ms | 1752.6 ms | 25 | 25 | 0 | 0 |
+| A read-dominant / no-candidate chat | 5 | 25 | 5.81 | 833.4 ms | 994.2 ms | 1147.5 ms | 25 | 25 | 0 | 0 |
+| B single-candidate write | 1 | 25 | 0.46 | 2196.5 ms | 2564.7 ms | 2675.5 ms | 50 | 50 | 0 | 0 |
+| B single-candidate write | 5 | 25 | 2.01 | 2230.2 ms | 3011.6 ms | 3267.9 ms | 50 | 50 | 0 | 0 |
+
+Accepted workload: **100 user-level requests, 150 logical calls, 150 physical
+attempts, 0 retries, 0 errors.** Workload B issues two sequential provider calls per
+request (extraction + conflict detection), which is why its latency is ~2.7× A's.
+
+**Token accounting is session-level**, covering 152 calls — the 150 workload calls
+plus 2 positive wiring-assertion calls. It is not split into a workload-only figure
+because the counters were not partitioned at the time:
+
+| | tokens |
+|---|---:|
+| input | 54 898 |
+| output | 6 423 |
+| thinking | 10 483 |
+| **total** | **71 804** |
+
+Estimated **$0.0587** at assumed rates of $0.30/1M input and $2.50/1M output.
+**Thinking tokens are 62 % of billed output** — visible response text badly
+understates output billing on this model.
+
+Provider latency dominates: ~820 ms for one call versus 63 ms of DB work per request.
+
 ## The async decision (P2.1) — verdict: **defer the blanket migration; tune and measure the synchronous path first**
+
+> **Phase C update — blanket async migration is not justified by the current
+> measurements.** Going from concurrency 1 → 5 on the provider-backed path took
+> throughput from **1.15 → 5.81 rps while p50 held at 820.4 → 833.4 ms**: the
+> synchronous path overlapped provider waiting effectively through the tested
+> concurrency. Limitations, stated plainly: only `gemini-2.5-flash` was tested,
+> provider-backed concurrency only reached **5**, other providers may behave
+> differently, higher concurrency was not measured, and Railway-scale behaviour was
+> not measured at all. This is **not** a claim that async can never help.
 
 `POST /api/chat` is a **synchronous** FastAPI route. Starlette executes sync routes
 through AnyIO's threadpool, so requests **already overlap** their network and database
@@ -240,14 +431,29 @@ Until that evidence exists, a blanket async rewrite is **not** justified.
 
 ## Follow-ups (measured next, tracked separately)
 
-- [ ] **Corrected-harness re-run** of the full sweep (reused clients, fresh scope +
-      fixed seed per scenario, repetitions, randomized order) to replace the
-      confounded tables above with numbers that isolate concurrency.
-- [ ] **Postgres + pgvector** run of the same sweep. pgvector is available and
-      CI-exercised (`api-postgres`); this run quantifies In-memory-vs-Postgres and
-      ANN-vs-linear retrieval.
-- [ ] **Real providers** (OpenAI / Anthropic) latency + fallback frequency in the
-      hot path — the I/O-bound numbers that gate the async decision.
+Phase C closed the first three of these; each remaining item is a **separate,
+measured** change, not an opportunistic edit. In particular, nothing in Phase C
+changed runtime application code.
+
+- [x] **Corrected-harness re-run** — done, see [C1](#c1-local-ceiling--postgres--stub-provider).
+- [x] **Postgres + pgvector** run — done, see [C1–C4](#phase-c--real-request-path-characterization).
+      It also corrected the ANN assumption ([C3](#c3-query-plan--an-index-existing-is-not-an-index-being-used)).
+- [x] **Real provider** latency in the hot path — done for `gemini-2.5-flash`
+      ([C6](#c6-live-provider--gemini-25-flash)). OpenAI/Anthropic remain unmeasured.
+
+Opened by Phase C, each needing its own evidence:
+
+- [ ] **Repository transaction consolidation** — ~73 transactions and 66 `set_config`
+      statements per request. Moves the RLS context boundary, so it requires Postgres
+      + `FORCE ROW LEVEL SECURITY` cross-tenant proof before it can land.
+- [ ] **Retrieval candidate bounding / query redesign** — one query is 53 ms of the
+      63 ms DB time and scales with tenant row count; IVFFlat is not chosen under the
+      tenant filter at scale.
+- [ ] **Conflict-detection context bounding** — `detect_conflicts` sends *all*
+      existing memories untruncated, so write-path prompt size and provider cost grow
+      linearly with scope size. This is a cost-correctness issue as much as a
+      performance one.
+- [ ] **Loop-engineering write volume** — ~43 of the 117 statements per request.
 - [ ] **Retrieval quality** comparison vector-only vs BM25-only vs hybrid
       (Recall@5 / MRR / nDCG). Ranker mode is a *quality* lever with negligible
       latency impact (latency is dominated by the O(n) candidate scan), so it lives


### PR DESCRIPTION
## Purpose

Record the Phase C real request-path performance characterization and make the measurements reproducible.

This PR changes benchmark evidence/tooling and documentation only. **No production runtime behavior changes.**

## What was measured

PostgreSQL 17.10 + pgvector 0.8.5 (isolated local cluster), Python 3.13.2, base `0190bcd`:

- corrected HTTP harness under Postgres/pgvector
- retrieval latency vs tenant working-set size
- PostgreSQL query-plan / index behaviour
- actual SQL statement and transaction counts
- DB-pool control experiment
- live Gemini 2.5 Flash request-path latency and concurrency
- provider / token / retry accounting

## Key findings

### SQL path

| request | SQL statements/request | transactions/request | DB execution/request |
|---|---:|---:|---:|
| read-dominant | **117** (min 117, max 117) | ~73 | 63.3 ms |
| single-candidate write | **130** (min 130, max 130) | — | — |

Repeated RLS context setup (66 × `set_config`) and loop-engineering repository operations are the major contributors to fixed local/stub overhead. DB *time*, separately, is dominated by one retrieval query at 53 ms.

The earlier ~282 `psycopg` `connection.wait` observations are **not** presented as 282 SQL round trips — a driver wait is neither a statement nor a round trip. The directly measured figure is 117/130 depending on workload, roughly 2.4 waits per statement. **GIL causality is recorded as NOT PROVEN**; it was never separately measured.

### Retrieval

Retrieval latency grows with tenant working-set size (p50 26.0 → 31.0 → 87.2 ms at 100 / 1 000 / 10 000 tenant memories).

An IVFFlat index exists, but index *use* is planner- and data-dependent. At the measured 100k-table / 10k-tenant case PostgreSQL chose tenant filtering plus an exact top-N vector-distance sort instead of IVFFlat; IVFFlat *was* chosen on a smaller single-tenant dataset. This PR therefore removes the stale assumption that pgvector retrieval is always ANN or sub-linear.

### Pool

Widening the pool from 15 to ~100 raised peak connections from 15 to 45 and did not improve throughput (≈40 rps at every concurrency, both configurations). Pool saturation was therefore **not** the primary measured throughput limit. The widened pool is a measurement artifact and is **not committed**.

### Real provider — Gemini 2.5 Flash

| workload | conc | successful_rps | p50 |
|---|---:|---:|---:|
| read-dominant / no-candidate chat | 1 | 1.15 | 820.4 ms |
| read-dominant / no-candidate chat | 5 | 5.81 | 833.4 ms |
| single-candidate write | 1 | 0.46 | 2196.5 ms |
| single-candidate write | 5 | 2.01 | 2230.2 ms |

Accepted workload: **100 requests, 150 logical provider calls, 150 physical attempts, 0 retries, 0 errors.**

Token totals in the artifact are labelled **session-level** — they cover 152 calls (the 150-call workload plus 2 wiring-assertion calls) and are deliberately not split into a workload-only figure the counters cannot support. Thinking tokens are 62% of billed output.

### Async decision

The synchronous FastAPI/AnyIO path overlapped provider waiting effectively through the tested c=5 workload (throughput 1.15 → 5.81 rps while p50 held at 820.4 → 833.4 ms).

**A blanket async migration is therefore not justified by the current measurements.** Only Gemini 2.5 Flash was tested, provider-backed concurrency only reached 5, other providers may differ, higher concurrency was not measured, and Railway-scale behaviour was not measured. **This is not a claim that async can never help.**

## Reproducibility

Benchmark-only tooling under `benchmark/perf/`, never imported by `services/api`:

- SQL statement counting and grouping
- sanitized query-shape normalization
- positive live-provider wiring assertion
- logical vs physical provider call accounting
- token / cost accounting

`assert_live_provider_wired` exists because a Phase C run completed with clean latency, zero errors and zero provider calls: `deps.gateway()` is `lru_cache`d, so rebinding the registry left the cached gateway on a stub, and the artifact was indistinguishable from a successful live run. The guard makes that fail instead of passing silently.

Three sanitized machine-readable artifacts are added under `benchmark/perf/results/`.

## Security

Artifacts contain no API keys, database URLs or passwords, tenant/user IDs, prompts, memory contents, embedding vectors, Authorization headers, or raw provider responses. Bound SQL parameters are never captured — literals are stripped before any shape is recorded, which is asserted by tests since the profiler runs against real data.

gitleaks clean.

## Runtime impact

None. No application runtime code changed — no files under `services/`, `apps/`, `railway/`, `infra/`, or `packages/`.

Live provider calls made while implementing this PR after evidence capture: **0**.