### PR TITLE
chore(repo): reconcile repository status and phase gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,19 @@
 All notable releases. Git tags + GitHub Releases are the source of truth; this
 file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
 
-## Unreleased — API authorization boundary
+## v2.4.1 — Railway Deployment Hardening (2026-08-10)
+Deployment reproducibility only; no API or runtime behaviour change. Makes the
+production Railway deployment reproducible from the repository (canonical
+per-service configuration, Dockerfile-owned start commands) and closes the
+deployment drift found during the v2.4 rollout. See the
+[v2.4.1 release](https://github.com/patibandlavenkatamanideep/memoryops-ai/releases/tag/v2.4.1).
+
+## v2.4 — API Trust Boundary (2026-08-09)
+Closes the trust boundary between authenticated identities, tenant data,
+operational access, and the production deployment. The subsections below were
+written incrementally as the work landed and shipped together in this release.
+
+### API authorization boundary
 
 - **Every route is classified, and the classification is enforced in CI.**
   `app/auth/authz_spec.py` states each route's scope (public / authenticated /
@@ -24,7 +36,7 @@ file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
 - **`GET /api/audit`** now resolves its subject through the shared helper; only
   the resolved tenant/user reach the repository.
 
-### Behaviour changes
+#### Behaviour changes
 - **`PATCH /api/memories/{id}` with no changed field now returns 422** (was 200
   with the unchanged record). Such a body requests no action, so there is no
   permission it could be authorized against, and it wrote a governance loop run
@@ -35,7 +47,7 @@ file is the consolidated narrative. Versions are `vMAJOR.MINOR[.PATCH]`.
   correction rather than an additive change; every patch that requests a real
   change is unaffected.
 
-## Unreleased — repository trust guards
+### repository trust guards
 
 Structural checks for regressions this repository has actually had, in
 `scripts/repo_trust_guards.py`. Not general linting — each guard was written from a
@@ -48,7 +60,7 @@ documenting the constants it no longer exports, and `import redis` matched
 `test_no_unused_infrastructure`'s docstring. A guard that fires on its own
 documentation trains people to ignore it.
 
-### Fixed
+#### Fixed
 - **`services/worker/jobs.py` mutated `sys.path` at import time** — inserting
   `../api` so it could reach the API package — while `services/worker/pyproject.toml`
   stated that no such call remained in a production entrypoint. The file ships in the
@@ -64,14 +76,14 @@ documentation trains people to ignore it.
 - The Redis import check moved from substring matching to the AST guard, which also
   stops confusing `redis_notes` for `redis`.
 
-### Guards
+#### Guards
 `sys-path-mutation` · `committed-secret-literal` · `demo-identity-in-server-code` ·
 `retired-infrastructure`. Documented in
 [docs/security/repository-trust-guards.md](docs/security/repository-trust-guards.md),
 enforced in CI, and each with negative tests proving a representative bad edit is
 rejected — plus the false-positive cases it must *not* fire on.
 
-## Unreleased — web capabilities replace the role ladder
+### web capabilities replace the role ladder
 
 - **`hasAtLeast()`, `ROLE_RANK` and `requiredRole()` are gone.** The web ranked
   personas — viewer < developer < auditor < memory_admin < owner — and asked "is this
@@ -95,7 +107,7 @@ rejected — plus the false-positive cases it must *not* fire on.
 - `NEVER_WEB_ASSIGNABLE` is now emitted to the web mirror and enforced: no persona can
   resolve to `service_worker` or `platform_operator`.
 
-### The boundary this deliberately does not cross
+#### The boundary this deliberately does not cross
 The web answers *may this persona attempt this route and action shape* — never *is
 this operation authorized on this record*. The browser does not know a memory's stored
 owner, whether a call is self- or tenant-scoped, the record's lifecycle status, or
@@ -104,11 +116,11 @@ anything about legal hold, revisions or consent. So `status: "active"` is treate
 resolving the real transition after loading the record. This layer only ever removes
 access; the API stays authoritative.
 
-## Unreleased — the platform operational boundary
+### the platform operational boundary
 
 **31 of 40 routes enforced. Zero planned.** 9 public, each reviewed below.
 
-### The distinction this draws
+#### The distinction this draws
 "Administrator of tenant A" and "operator of this deployment" are different
 authorities. Three surfaces describe the *installation* rather than any tenant, and
 now say so: `/api/traces` (a process-wide span buffer), `/api/evals/{latest,run}` (a
@@ -125,13 +137,13 @@ harness over its own fixtures and a process-wide result store), and the worker f
 - `GET /api/loops/{runs,events,trace}` now use `audit:read:tenant`; both they and the
   audit trail answer "who acted in this tenant", and `traces:read:tenant` is retired.
 
-### Fixed
+#### Fixed
 - **`tenant_admin` was `frozenset(set(Permission))`** — every permission in the enum,
   including ones that did not exist yet. Any capability added anywhere became tenant
   authority by definition. The bundle is explicit, and a guard fails while any
   permission is neither granted nor recorded as deployment-scoped with a reason.
 
-### Behaviour changes
+#### Behaviour changes
 - **`tenant_admin` no longer reads `/api/admin/workers/health`.** Fleet health is
   deployment state; it held that only through the blanket grant.
 - **`auditor` and `tenant_admin` no longer read or run deployment evaluations.**
@@ -148,7 +160,7 @@ harness over its own fixtures and a process-wide result store), and the worker f
   authenticates that path when the switch is on — without a principal the route's
   check would silently no-op and the setting would look enforced while doing nothing.
 
-## Unreleased — governance mutations enforced
+### governance mutations enforced
 
 **28 of 39 routes enforced.** Planned 2 (`POST /api/evals/run`, `GET /api/traces`),
 public 9.
@@ -157,7 +169,7 @@ public 9.
   `consent:manage`.** `auditor` reads governance state and cannot change it;
   `memory_admin` and `tenant_admin` manage it within their tenant.
 
-### Fixed
+#### Fixed
 - **An admin could not govern another user's memory.** `_load()` ran
   `enforce_scope(request, tenant_id, user_id)` and then looked the record up with
   `repo.get_memory(tenant_id, user_id, memory_id)` — both halves trusting the
@@ -166,7 +178,7 @@ public 9.
   request's `user_id` is a compatibility hint about where to look, and the lookup is
   tenant-scoped and user-spanning.
 
-### Audit evidence
+#### Audit evidence
 - **Actor and target are recorded separately.** Once an admin can change someone
   else's governance state, `audit.user_id = "bob"` cannot say whether Bob acted or was
   acted upon. `user_id` stays the *target* for query compatibility, and content-free
@@ -174,7 +186,7 @@ public 9.
   service_account), `target_user_id`, `authorized_permission`, and
   `acted_on_behalf_of_another_user`. Never the credential, its claims, or memory text.
 
-## Unreleased — governance and evidence reads enforced
+### governance and evidence reads enforced
 
 **24 of 39 routes enforced** (was 10). Planned 6, public 9.
 
@@ -197,7 +209,7 @@ public 9.
 - Every route forces the query to `principal.tenant_id` after authorizing; the
   request's own value is not reused.
 
-### Behaviour changes
+#### Behaviour changes
 - **`GET /api/evals/latest` is now a pure read** and returns `404 no_result_available`
   when the process has completed no run. It previously regenerated whenever the cache
   was cold or older than `evals_cache_ttl_seconds`, so holding `evals:read` granted
@@ -210,7 +222,7 @@ public 9.
   *These are deployment-wide results — the harness runs against its own isolated
   fixtures — not per-tenant evidence; the route takes no tenant parameter.*
 
-### Deliberately still `planned`
+#### Deliberately still `planned`
 - **`GET /api/traces`** is permission-gated (`traces:read:tenant`) as defence in
   depth, but stays `planned` because it is **not tenant-isolated**: the in-process
   span buffer has no tenant dimension, so a permitted caller observes the timing,
@@ -223,9 +235,9 @@ public 9.
   A tenant auditor should not implicitly become a deployment-wide observability
   operator.
 
-## Unreleased — governance read boundary
+### governance read boundary
 
-### Fixed
+#### Fixed
 - **Loop evidence could be read across tenants on the in-memory backend.**
   `list_loop_runs` / `list_loop_events` filtered with `if tenant_id:`, so an empty
   string meant *no filter* and returned every tenant's loop runs — who did what,
@@ -241,7 +253,7 @@ public 9.
   lookup is skipped instead, so evidence recording can never be the reason a request
   fails (invariant #4).
 
-## Unreleased — memory routes enforced
+### memory routes enforced
 
 Ten of 39 routes now enforce their declared permission (was three): `POST /api/chat`,
 `GET /api/memories`, and the five `/api/memories/{id}` routes join `/api/audit`,
@@ -269,7 +281,7 @@ Ten of 39 routes now enforce their declared permission (was three): `POST /api/c
   audited — authorization decides whether a caller may *attempt* deletion, never
   whether a preservation control applies.
 
-### Fixed
+#### Fixed
 - **A JWT `roles` claim in array form was silently discarded.** `claim_path` rejects
   containers by design (a tenant or subject arriving as a list is malformed), but
   roles are normally a JSON array — so `["auditor"]` read as *no claim* and every
@@ -289,7 +301,7 @@ Ten of 39 routes now enforce their declared permission (was three): `POST /api/c
   valid → those roles. Identity claims are unchanged, where absent and `null` are
   correctly identical because there is no fallback to reach.
 
-## Unreleased — worker mutation atomicity
+### worker mutation atomicity
 Additive; completes invariant #7 across the whole system.
 
 - **Background workers now commit mutation + audit atomically.** v2.3 made the

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ governed state, not just a vector database.
 &nbsp;[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 &nbsp;[![API](https://img.shields.io/badge/API%20%2B%20SDK-1.x%20stable-green)](docs/api-stability.md)
 
-> **Two version tracks:** the **platform release** (`v2.3`, the repo's feature
+> **Two version tracks:** the **platform release** (`v2.4.1`, the repo's feature
 > milestone) is separate from the **public API + SDK contract** (`1.x`, an additive-
 > compatibility promise). See [docs/api-stability.md](docs/api-stability.md#two-version-tracks).
 
@@ -107,7 +107,7 @@ Postgres + pgvector in CI (the `api-postgres` job). Current
 
 ## What's shipped
 
-All capabilities v1.3 → v2.3 are shipped: Context Admission Gate + Memory Usage Trace,
+All capabilities v1.3 → v2.4.1 are shipped: Context Admission Gate + Memory Usage Trace,
 deletion-proof tombstone lineage, deleted-memory leakage evals, auth/authorization
 adapters (JWT/JWKS + trusted header), vector-backend abstraction (Postgres/pgvector ·
 in-memory · Qdrant · LanceDB · Weaviate), distributed tracing + Prometheus metrics,

--- a/docs/agentic-swe-kit-map.md
+++ b/docs/agentic-swe-kit-map.md
@@ -22,15 +22,27 @@ only when its stated conditions are true.
 | 4 Workflow Orchestration | [phase-04](phase-gates/phase-04-workflow-orchestration.md) | Loop definitions, transitions, evidence | ✅ |
 | 5 LLM Reasoning | [phase-05](phase-gates/phase-05-llm-reasoning.md) | Provider adapters, structured intelligence | ✅ |
 | 6 Memory Architecture | [phase-06](phase-gates/phase-06-memory-architecture.md) | Short/long-term, RAG, hybrid retrieval | 🟡 |
+| 6 Human-in-the-Loop | [phase-06-hitl](phase-gates/phase-06-human-in-the-loop.md) | Memory control plane: inspect, approve, correct | ✅ |
 | 9 Evaluation Systems | [phase-09](phase-gates/phase-09-evaluation.md) | Golden + adversarial cases | ✅ |
 | 10 Observability | [phase-10](phase-gates/phase-10-observability.md) | Traces, audit, latency, cost | 🟡 |
 | 11 Security Architecture | [phase-11](phase-gates/phase-11-security.md) | Tenant isolation, PII, secret blocking | ✅ |
 | 12 Reliability Engineering | [phase-12](phase-gates/phase-12-reliability.md) | Retries, breakers, degradation | ✅ |
+| 12 Lifecycle Workers *(addendum)* | [phase-12-workers](phase-gates/phase-12-background-lifecycle-workers.md) | Background decay/archive/retention jobs | ✅ |
+| 13 Infrastructure & Deployment | [phase-13](phase-gates/phase-13-infrastructure.md) | Build, ship, run in production (Railway) | ✅ |
+| 13 Deletion Compaction *(addendum)* | [phase-13-purge](phase-gates/phase-13-deletion-compaction-vector-purge.md) | Content/vector purge + verification | ✅ |
+| 14 Worker Runtime *(addendum)* | [phase-14](phase-gates/phase-14-worker-runtime-orchestration.md) | Leases, retries, scheduling, dead-letter | ✅ |
 | 15 Governance & Compliance | [phase-15](phase-gates/phase-15-governance.md) | Deletion, provenance, explainability | ✅ |
+| 16 Economics & Cost Control | [phase-16](phase-gates/phase-16-economics.md) | Token/cost accounting, compression | ✅ |
 | 18 CI/CD for AI | [phase-18](phase-gates/phase-18-ci-cd-for-ai.md) | Invariant evidence gates | ✅ |
 | 20 Continuous Learning | [phase-20](phase-gates/phase-20-continuous-learning.md) | Decay, reflection, feedback | 🟡 |
 
 Legend: ✅ implemented · 🟡 scaffolded / partial.
 
-The phases not listed (2, 3, 7, 8, 13, 14, 16, 17, 19) are acknowledged but out of
-scope for the current milestones; see [rollout.md](rollout.md).
+Every file in [`phase-gates/`](phase-gates/) is listed above. Several gates are
+enforced: `scripts/pr_invariant_gate.py` names specific gate files as required
+evidence, so a change in those areas fails CI without its gate update. That is why
+gate files stay in place rather than being archived when the work they describe
+ships — they remain the live evidence target.
+
+The phases not listed (2, 3, 7, 8, 17, 19) are acknowledged but out of scope for the
+current milestones; see [rollout.md](rollout.md).

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -11,10 +11,10 @@ questions and move independently, so a single number would be misleading:
 
 | Track | Where it lives | Current | Meaning |
 |-------|----------------|---------|---------|
-| **Platform release** | git tags `vX.Y`, the README release badge, `CHANGELOG.md` | **v2.3** | "What shipped" — the feature-set milestone of the whole repo (API + workers + SDK + docs + demos). |
+| **Platform release** | git tags `vX.Y`, the README release badge, `CHANGELOG.md` | **v2.4.1** | "What shipped" — the feature-set milestone of the whole repo (API + workers + SDK + docs + demos). |
 | **Public API + SDK contract** | `app.__version__`, `packages/memoryops-sdk` `version` | **1.0.0** | The compatibility promise of the public HTTP API and Python SDK. Stays `1.x` as long as the surface is additive-compatible. |
 
-So platform **v2.3** ships the **1.0.0** API/SDK contract: the milestone counter has
+So platform **v2.4.1** ships the **1.0.0** API/SDK contract: the milestone counter has
 advanced through many feature phases while the *public surface* has only grown
 additively and so remains `1.x`. `app.__version__` and the SDK package version are
 kept in lock-step; the platform milestone is independent.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -18,8 +18,9 @@
 > bounded clients, a **fresh scope per scenario**, a **fixed identical seed *request*
 > count**, **≥3 repetitions**, **randomized scenario order**, and **actual
 > before/after memory counts** — see [`run_perf.py`](../benchmark/perf/run_perf.py)).
-> Re-running the sweep with the corrected harness is a tracked follow-up; until then,
-> treat the specific figures here as indicative only.
+> The sweep has since been re-run with the corrected harness on Postgres — see
+> [Phase C](#phase-c--real-request-path-characterization), which supersedes the
+> figures below. Treat the tables in this section as historical only.
 >
 > Two further corrections apply to how these numbers were *computed*, so the tables
 > below are not directly comparable to output from the current harness:

--- a/docs/security.md
+++ b/docs/security.md
@@ -227,7 +227,9 @@ A route added without a spec fails the build, and
 is **generated** from the spec — the published matrix cannot drift from the code.
 
 `planned` is stated deliberately. A route listed as enforced that is not would be
-worse than an unlisted one, because the matrix is what a reader trusts.
+worse than an unlisted one, because the matrix is what a reader trusts. No route
+carries `planned` today; the status remains in the model so a future route declaring
+a contract it does not yet check has an honest way to say so.
 
 ### The four helpers
 
@@ -491,9 +493,10 @@ it is read by operators who may not be cleared for the memory itself.
 
 This is an authorization boundary, not an authorization product. Roles are coarse
 named bundles, not per-record ACLs; there is no delegation, no attribute-based policy,
-and no per-field redaction by role. Route statuses are moving from `planned` to
-`enforced` incrementally — **10 of 39 today** — so read the generated matrix for the
-current state rather than assuming the whole surface is covered.
+and no per-field redaction by role. Every route is now classified: **31 of 40 enforced,
+9 public by design, 0 planned** — read the generated matrix for the current state
+rather than trusting this sentence, since the matrix is regenerated from the code and
+this prose is not.
 
 Two limits specific to the memory routes:
 

--- a/paper/harness/tests/conftest.py
+++ b/paper/harness/tests/conftest.py
@@ -1,9 +1,59 @@
-"""Ensure the repo root is importable so ``paper.harness`` resolves regardless of how
-pytest is invoked (whole dir or a single file)."""
+"""Import path + Mem0 state isolation for the benchmark harness tests.
 
+Two responsibilities, both needed before any test module is imported:
+
+1. Make ``paper.harness`` resolve regardless of how pytest is invoked (whole
+   directory or a single file).
+
+2. Give Mem0 its own throwaway state directory and turn its telemetry off.
+
+Why (2) is here rather than left to the caller
+----------------------------------------------
+Mem0 keeps per-user state under ``~/.mem0`` — a config file, a history database, and
+a Qdrant store used for telemetry/migrations. That path is **global to the machine and
+shared across every Mem0 instance in the process**, so when the suite constructs more
+than one adapter the second one collides with the first on a Qdrant file lock and the
+run dies with "Storage folder … is already accessed by another instance". Individual
+tests pass; the suite does not.
+
+CI worked only because the workflow happened to export ``MEM0_TELEMETRY=False``, which
+meant the local run documented in ``benchmark/COMPARISON.md`` failed while CI stayed
+green. A test file that only passes when its caller sets an environment variable is
+not isolated — so the isolation is established here, where it applies however the
+suite is invoked.
+
+``MEM0_DIR`` moves that shared state into a per-run temporary directory, and telemetry
+is disabled so no telemetry vector store is constructed at all. Both are set before
+Mem0 is imported: ``mem0.memory.telemetry`` reads ``MEM0_TELEMETRY`` at module import
+time, so setting it inside a fixture would be too late.
+
+Neither setting touches what the benchmark measures. The adapter's own vector store is
+a separate temporary directory it creates per instance, and the S4 results are
+unchanged — this only stops two adapters fighting over one machine-global file.
+"""
+
+import atexit
+import os
 import pathlib
+import shutil
 import sys
+import tempfile
 
 _ROOT = pathlib.Path(__file__).resolve().parents[3]
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
+
+# Must happen at import time, before any test module pulls in mem0.
+if "mem0" in sys.modules:  # pragma: no cover - defensive; conftest loads first
+    raise RuntimeError(
+        "mem0 was imported before conftest could isolate MEM0_DIR/MEM0_TELEMETRY"
+    )
+
+_MEM0_STATE = tempfile.mkdtemp(prefix="memoryops-bench-mem0-home-")
+os.environ.setdefault("MEM0_DIR", _MEM0_STATE)
+os.environ.setdefault("MEM0_TELEMETRY", "False")
+
+
+@atexit.register
+def _cleanup_mem0_state() -> None:
+    shutil.rmtree(_MEM0_STATE, ignore_errors=True)

--- a/services/api/tests/test_vector_index.py
+++ b/services/api/tests/test_vector_index.py
@@ -62,12 +62,28 @@ def test_factory_rejects_unknown_backend():
 
 
 def test_external_adapters_import_guarded():
-    # Selecting an external backend never raises at construction; when its client
-    # isn't installed the index simply reports unavailable (→ keyword-only).
-    for name in ("qdrant", "lancedb", "weaviate"):
-        idx = create_vector_index(name)
+    """Selecting an external backend never raises at construction, and reports its
+    readiness as a plain bool rather than throwing.
+
+    The contract under test is the import guard and graceful degradation, which hold
+    regardless of what happens to be installed. An earlier version asserted
+    ``available() is False`` unconditionally, which silently depended on the optional
+    client being *absent* from the environment: installing the benchmark extra pulls
+    in `qdrant-client` transitively, and the test then failed for a reason that had
+    nothing to do with the code under test. Whether a client is installed is a
+    property of the environment, so it is checked rather than assumed below.
+    """
+    import importlib.util
+
+    for name, module in (("qdrant", "qdrant_client"), ("lancedb", "lancedb"), ("weaviate", "weaviate")):
+        idx = create_vector_index(name)  # must not raise, installed or not
         assert idx.name == name
-        assert idx.available() is False  # no client / server in the test env
+        assert isinstance(idx.available(), bool), "readiness must degrade, never throw"
+
+        if importlib.util.find_spec(module) is None:
+            # Client absent: the adapter must report unavailable so retrieval falls
+            # back to keyword-only rather than failing the request (invariant #4).
+            assert idx.available() is False
 
 
 # ── the repository actually uses the seam (load-bearing, not decorative) ─────────


### PR DESCRIPTION
## Purpose

Reconcile repository state with what actually shipped, and remove two environment dependencies from benchmark tests. Documentation and test hygiene only — **no runtime application code, no Railway change, and none of the four Phase C performance follow-ups**.

## Version truth

The latest release is **v2.4.1** (tag + GitHub Release, 2026-08-10), but the README and `docs/api-stability.md` still named `v2.3` as the platform release.

The CHANGELOG was further out of date: **nine sections describing shipped work were still headed "Unreleased"**, and git shows all nine were already in the tree at both the `v2.4` and `v2.4.1` tags. They are now grouped under `## v2.4 — API Trust Boundary`, and v2.4.1 gains the record it never had.

Every subtitle and body is preserved verbatim — only heading levels moved. Verified by diffing all non-heading lines against the base: the sole additions are the two new release descriptions.

The **public API + SDK contract is untouched at 1.0.0**; the two version tracks stay distinct, and no v2.5 is claimed.

## Authorization

Measured from `ROUTE_AUTHZ` rather than prose: **31 enforced, 9 public, 0 planned, 0 unclassified** (40 total), and the generated matrix already publishes `Planned — (none)`. The acceptance target was already met, so **no runtime authorization changed**.

The drift was in `docs/security.md`, which told readers statuses were "moving from `planned` to `enforced` incrementally — **10 of 39 today**". Corrected, with a note on why the `planned` status remains in the model.

## Phase gates — index fixed, nothing moved

No gate file was moved, deliberately. There is no existing archive convention to move them into, none carries a completion marker, and `scripts/pr_invariant_gate.py` names specific gate paths in **nine enforced CI rules** — archiving them would break a CI control and invent a convention in the same change.

The actual defect was the index: `agentic-swe-kit-map.md` listed **12 of 18** gate files while simultaneously describing phases 13, 14 and 16 as "out of scope" when their gate files exist and are enforced. All **18/18 are now indexed**, the out-of-scope list is corrected, and the map records why gates stay in place when the work they describe ships.

No evidence deleted. Zero broken relative links across root/docs/benchmark/infra markdown.

## Benchmark test hygiene

Both previously observed fragilities still reproduced on this base, and both were repository defects rather than local artifacts.

**Mem0 machine-global state.** The adapter suite passed only when its caller exported `MEM0_TELEMETRY=False`. CI did; a local run did not — so the reproduce command published in `benchmark/COMPARISON.md` failed while CI stayed green, with 1 failure and 6 errors from two adapters colliding on a Qdrant file lock under the machine-global `~/.mem0`. The suite now isolates itself in `conftest.py`, before mem0 is imported, pointing `MEM0_DIR` at a per-run temporary directory and disabling telemetry. The user's `~/.mem0` is left alone. Verified: 14 passed / 68 paper passed with **no environment variables set**.

**Optional Qdrant import guard.** `test_external_adapters_import_guarded` asserted `available() is False` unconditionally, which silently depended on `qdrant-client` being *absent*; installing the benchmark extra pulls it in transitively and the test failed for a reason unrelated to the code under test. It now asserts the contract that actually holds either way — construction never raises, readiness degrades to a bool — keeping the strict absent-client assertion behind a real import check. Verified passing **both** with and without qdrant installed.

**Benchmark semantics and canonical results are unchanged:** S0 4/0/0/0, S0-U 4/0/0/0, S1 2/0/2/0, S2 4/0/0/0, S3 2/0/2/0, S4 4/0/0/0, matching `COMPARISON.md`. No adapter, runner, case or result file was modified.

## Drift

`docs/performance.md` still called the corrected-harness re-run a pending follow-up after Phase C completed it. Corrected to point at the Phase C evidence. Every Phase C caveat is preserved: Railway non-equivalence, Gemini-only live scope, planner-dependent ANN behaviour, GIL causality unproven, the scoped async conclusion, superseded historical tables, and the four unimplemented follow-ups.

## Verification

API 1217 passed / 30 skipped · paper 68 passed · perf tooling 53 passed · SDK 25 passed · vector index 5 passed in both environments · Ruff clean · dependency drift 6/6 · authz matrix, web capability contract and role map all match · governance benchmark 50/50 critical perfect · evals PASS · trust guards clean · invariant gate PASS · gitleaks clean · diff-check clean. Collection counts held or rose (API 1246, paper 68, perf 53).

RLS was **not** verifiable locally (no Postgres running; the checker reported `SKIP: cannot reach database`) and was not faked — CI is the authoritative real-Postgres proof.

Live provider calls: **0**.