### PR TITLE
feat(web): make landing route public safely

### DIFF
--- a/apps/web/__tests__/middleware-route-protection.test.ts
+++ b/apps/web/__tests__/middleware-route-protection.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+
+import { config, isPublicPath, middleware } from "@/middleware";
+
+/**
+ * The web's public/protected route boundary.
+ *
+ * v2.6 Stage B makes `/` a public landing surface. That is an authorization
+ * boundary change, and the failure mode it invites is severe and quiet: public
+ * paths used to be matched with a bare `pathname.startsWith(p)`, under which the
+ * single character `/` is a prefix of *every* route. Adding it to that list would
+ * have made the entire control plane anonymous without naming a single one of
+ * those routes in the diff, and no existing test would have noticed.
+ *
+ * So the matrix below is asserted route by route rather than by re-deriving the
+ * rule the implementation uses. These tests are deliberately dumb: they encode
+ * the intended answer for each path, so a change to the matching strategy has to
+ * survive the list.
+ *
+ * Scope: this is the human-redirect layer only. It is not the security boundary —
+ * the BFF re-resolves identity server-side on every API call and is covered by
+ * lib/__tests__/scope.test.ts and lib/__tests__/capabilities.test.ts.
+ */
+
+const AUTHENTICATED = "authenticated";
+
+/** Routes reachable with no session, by deliberate decision. */
+const PUBLIC_ROUTES = ["/", "/signin", "/architecture"];
+
+/**
+ * Application surfaces. Every one must redirect an anonymous visitor.
+ * `/memories/[id]` is included concretely: a nested dynamic route is exactly the
+ * shape a prefix-matching mistake would leak.
+ */
+const PROTECTED_ROUTES = [
+  "/chat",
+  "/memories",
+  "/memories/mem_01H8XYZ",
+  "/governance",
+  "/audit",
+  "/loops",
+  "/admin",
+];
+
+function request(pathname: string, { session = false } = {}) {
+  const headers = new Headers();
+  if (session) headers.set("cookie", "authjs.session-token=stub-session-value");
+  return new NextRequest(new URL(pathname, "https://control.example.com"), { headers });
+}
+
+/** Middleware returns a plain `NextResponse.next()` when it lets a request through. */
+function isPassThrough(response: Response): boolean {
+  return response.status === 200 && response.headers.get("location") === null;
+}
+
+afterEach(() => {
+  delete process.env.MEMORYOPS_WEB_MODE;
+});
+
+describe("authenticated mode — anonymous visitor", () => {
+  for (const route of PUBLIC_ROUTES) {
+    it(`serves ${route} without a session`, () => {
+      process.env.MEMORYOPS_WEB_MODE = AUTHENTICATED;
+      expect(isPassThrough(middleware(request(route)))).toBe(true);
+    });
+  }
+
+  for (const route of PROTECTED_ROUTES) {
+    it(`redirects ${route} to sign-in without a session`, () => {
+      process.env.MEMORYOPS_WEB_MODE = AUTHENTICATED;
+      const response = middleware(request(route));
+
+      expect(response.status).toBe(307);
+      const location = new URL(response.headers.get("location") ?? "");
+      expect(location.pathname).toBe("/signin");
+      // The visitor must land back where they were going, not on the home page.
+      expect(location.searchParams.get("callbackUrl")).toBe(route);
+    });
+  }
+
+  it("keeps the Auth.js callback subtree reachable", () => {
+    process.env.MEMORYOPS_WEB_MODE = AUTHENTICATED;
+    for (const route of [
+      "/api/auth",
+      "/api/auth/csrf",
+      "/api/auth/session",
+      "/api/auth/callback/credentials",
+    ]) {
+      expect(isPassThrough(middleware(request(route))), route).toBe(true);
+    }
+  });
+
+  it("protects the BFF proxy, which is not part of the public surface", () => {
+    process.env.MEMORYOPS_WEB_MODE = AUTHENTICATED;
+    expect(middleware(request("/api/memoryops/api/memories")).status).toBe(307);
+  });
+});
+
+describe("authenticated mode — with a session cookie", () => {
+  it("serves every application route", () => {
+    process.env.MEMORYOPS_WEB_MODE = AUTHENTICATED;
+    for (const route of [...PUBLIC_ROUTES, ...PROTECTED_ROUTES]) {
+      expect(
+        isPassThrough(middleware(request(route, { session: true }))),
+        route,
+      ).toBe(true);
+    }
+  });
+
+  it("accepts the __Secure- cookie name used over HTTPS", () => {
+    process.env.MEMORYOPS_WEB_MODE = AUTHENTICATED;
+    const headers = new Headers({
+      cookie: "__Secure-authjs.session-token=stub-session-value",
+    });
+    const secure = new NextRequest(new URL("/chat", "https://control.example.com"), {
+      headers,
+    });
+    expect(isPassThrough(middleware(secure))).toBe(true);
+  });
+});
+
+describe("demo mode", () => {
+  it("does not redirect anything — the public demo has no sign-in", () => {
+    process.env.MEMORYOPS_WEB_MODE = "demo";
+    for (const route of [...PUBLIC_ROUTES, ...PROTECTED_ROUTES]) {
+      expect(isPassThrough(middleware(request(route))), route).toBe(true);
+    }
+  });
+
+  it("treats an unset mode as not-authenticated, matching lib/identity's default", () => {
+    for (const route of PROTECTED_ROUTES) {
+      expect(isPassThrough(middleware(request(route))), route).toBe(true);
+    }
+  });
+});
+
+describe("isPublicPath fails closed", () => {
+  it("does not let `/` act as a prefix for anything", () => {
+    // The single assertion this whole stage exists to guarantee.
+    for (const route of PROTECTED_ROUTES) {
+      expect(isPublicPath(route), route).toBe(false);
+    }
+  });
+
+  it("does not treat a longer path as a public one it merely starts with", () => {
+    for (const route of [
+      "/architecture-internal",
+      "/architecturex",
+      "/signin-as-admin",
+      "/signinx",
+      "/api/authz",
+    ]) {
+      expect(isPublicPath(route), route).toBe(false);
+    }
+  });
+
+  it("refuses dot segments, literal or percent-encoded", () => {
+    // `new URL()` resolves literal `..` but leaves `%2e%2e` alone, so a path could
+    // otherwise satisfy a public prefix while routing somewhere else.
+    for (const route of [
+      "/architecture/%2e%2e/chat",
+      "/architecture/%2E%2E/admin",
+      "/architecture/../chat",
+      "/signin/%2e%2e/memories",
+    ]) {
+      expect(isPublicPath(route), route).toBe(false);
+    }
+  });
+
+  it("handles trailing slashes without widening the public surface", () => {
+    // `/architecture/` is the same resource as `/architecture` — Next redirects it
+    // there — so it stays public. What matters is that a trailing slash cannot
+    // turn a protected route into a public one.
+    expect(isPublicPath("/architecture/")).toBe(true);
+    for (const route of PROTECTED_ROUTES) {
+      expect(isPublicPath(`${route}/`), `${route}/`).toBe(false);
+    }
+  });
+
+  it("recognises exactly the three intended public surfaces", () => {
+    for (const route of PUBLIC_ROUTES) {
+      expect(isPublicPath(route), route).toBe(true);
+    }
+  });
+});
+
+describe("matcher coverage", () => {
+  it("excludes only build assets, so no application route escapes the guard", () => {
+    // A broadened exclusion here would unprotect routes without touching any of
+    // the logic above, and nothing else in the suite would fail.
+    expect(config.matcher).toEqual(["/((?!_next/static|_next/image|favicon.ico).*)"]);
+  });
+
+  it("matches every protected route", () => {
+    const [pattern] = config.matcher;
+    const matcher = new RegExp(`^${pattern}$`);
+    for (const route of PROTECTED_ROUTES) {
+      expect(matcher.test(route), route).toBe(true);
+    }
+  });
+});

--- a/apps/web/__tests__/public-landing-independence.test.ts
+++ b/apps/web/__tests__/public-landing-independence.test.ts
@@ -1,0 +1,120 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression guard: the public landing page must render for an anonymous visitor.
+ *
+ * v2.6 Stage B makes `/` publicly reachable. A page that is reachable without a
+ * session but *needs* one does not fail politely — `resolveIdentity()` throws
+ * `UnauthenticatedError` in authenticated mode, and an authenticated API call
+ * through the BFF returns 401. Either turns the new public surface into an error
+ * page for exactly the visitors it was opened for, and only in production, since
+ * demo mode resolves an identity for everyone.
+ *
+ * The realistic way this regresses is not someone importing `lib/api` into
+ * `app/page.tsx` on purpose. It is a later stage adding a "live memory count" or a
+ * usage widget to the landing page, several components deep. So the whole
+ * first-party import graph is walked, not just the page's own import list.
+ *
+ * This asserts a *dependency* property, not a rendering one. It is deliberately
+ * cheap and static; the end-to-end evidence is the anonymous route matrix in
+ * middleware-route-protection.test.ts plus the recorded HTTP check.
+ */
+
+const WEB_ROOT = join(__dirname, "..");
+
+/** Entry points that must stay renderable with no session. */
+const PUBLIC_ENTRY_POINTS = [
+  join("app", "page.tsx"),
+  join("app", "architecture", "page.tsx"),
+];
+
+/**
+ * Modules that make a page session-dependent.
+ *
+ * `lib/api` is the browser's client for the BFF, which is authenticated on every
+ * route. `lib/identity` and `auth` resolve the session itself. `RootLayout` uses
+ * the latter two legitimately — it degrades `UnauthenticatedError` to null — but a
+ * *page* doing so has no such contract.
+ */
+const SESSION_DEPENDENT = ["lib/api", "lib/identity", "auth"];
+
+/** Resolve a first-party `@/…` specifier to a file on disk. */
+function resolveFirstParty(specifier: string): string | null {
+  if (!specifier.startsWith("@/")) return null;
+  const base = join(WEB_ROOT, specifier.slice(2));
+  for (const candidate of [
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, "index.ts"),
+    join(base, "index.tsx"),
+  ]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function importsOf(file: string): string[] {
+  const source = readFileSync(file, "utf8");
+  // Comments are stripped first so a docstring that *names* a forbidden module in
+  // order to explain why it is absent does not register as an import.
+  const code = source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+  return [...code.matchAll(/from\s+["']([^"']+)["']/g)].map((m) => m[1]);
+}
+
+/** Every first-party module reachable from `entry`, including itself. */
+function importGraph(entry: string): Map<string, string[]> {
+  const graph = new Map<string, string[]>();
+  const queue = [join(WEB_ROOT, entry)];
+
+  while (queue.length > 0) {
+    const file = queue.pop() as string;
+    if (graph.has(file)) continue;
+    const specifiers = importsOf(file);
+    graph.set(file, specifiers);
+    for (const specifier of specifiers) {
+      const resolved = resolveFirstParty(specifier);
+      if (resolved && !graph.has(resolved)) queue.push(resolved);
+    }
+  }
+  return graph;
+}
+
+describe("public landing pages are session-independent", () => {
+  for (const entry of PUBLIC_ENTRY_POINTS) {
+    it(`${entry} reaches no session-dependent module`, () => {
+      const graph = importGraph(entry);
+      const offenders: string[] = [];
+
+      for (const [file, specifiers] of graph) {
+        for (const specifier of specifiers) {
+          const bare = specifier.replace(/^@\//, "");
+          if (SESSION_DEPENDENT.some((m) => bare === m || bare.startsWith(`${m}/`))) {
+            offenders.push(`${file.slice(WEB_ROOT.length + 1)} -> ${specifier}`);
+          }
+        }
+      }
+
+      expect(offenders, offenders.join("\n")).toEqual([]);
+    });
+  }
+
+  it("walks past the entry file rather than only checking it", () => {
+    // Guards the guard: if resolution silently broke, every assertion above would
+    // pass vacuously on a one-node graph.
+    const graph = importGraph(join("app", "page.tsx"));
+    expect(graph.size).toBeGreaterThan(3);
+  });
+
+  it("still sees the session-dependent modules it is looking for", () => {
+    // The layout legitimately depends on identity. If this stops being detected,
+    // the matcher has drifted and the assertions above mean nothing.
+    const graph = importGraph(join("app", "layout.tsx"));
+    const specifiers = [...graph.values()].flat().map((s) => s.replace(/^@\//, ""));
+    expect(specifiers).toContain("lib/identity");
+  });
+});

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -4,22 +4,62 @@ import type { NextRequest } from "next/server";
 /**
  * Route guard for the authenticated control plane.
  *
- * In `MEMORYOPS_WEB_MODE=authenticated`, every page except the sign-in flow
- * requires a session cookie. This is a fast redirect for humans, not the security
- * boundary — the real enforcement is in the BFF (`app/api/memoryops/[...path]`),
- * which re-resolves identity server-side on every API call and returns 401/403.
+ * In `MEMORYOPS_WEB_MODE=authenticated`, every application surface requires a
+ * session cookie. This is a fast redirect for humans, not the security boundary —
+ * the real enforcement is in the BFF (`app/api/memoryops/[...path]`), which
+ * re-resolves identity server-side on every API call and returns 401/403.
  * Middleware alone must never be relied on for authorization.
  *
  * In demo mode this is a no-op so the public demo keeps working unauthenticated.
  */
 
-const PUBLIC_PATHS = ["/signin", "/api/auth", "/architecture"];
+/**
+ * Public surfaces matched **exactly**.
+ *
+ * `/` lives here and must never move into `PUBLIC_PREFIXES`. The previous
+ * implementation tested every public path with a bare
+ * `pathname.startsWith(p)` — under that rule the single character `/` is a prefix
+ * of every path in the application, so listing it would have silently made
+ * `/chat`, `/memories`, `/governance`, `/audit`, `/loops` and `/admin` public in
+ * one line, with nothing in the diff naming those routes. Exact matching is what
+ * makes the landing page public without touching anything else.
+ */
+const PUBLIC_EXACT = new Set(["/"]);
+
+/**
+ * Public subtrees, matched as the path itself or a `/`-delimited descendant.
+ *
+ * `/api/auth` needs subtree access for the Auth.js callback, CSRF and session
+ * endpoints. `/signin` and `/architecture` have no children today and are listed
+ * here so that adding one later does not require a second rule.
+ */
+const PUBLIC_PREFIXES = ["/signin", "/api/auth", "/architecture"];
+
+/**
+ * Dot segments, literal or percent-encoded.
+ *
+ * `new URL()` resolves literal `..` before `nextUrl.pathname` is read, but it does
+ * not decode `%2e%2e` — so `/architecture/%2e%2e/chat` would satisfy a
+ * `startsWith("/architecture/")` test while routing somewhere else entirely. Such
+ * a path is never legitimate here (no MemoryOps route contains a dot segment), so
+ * it is refused public status outright rather than normalised and re-checked.
+ */
+const DOT_SEGMENT = /(^|\/|%2f)(\.|%2e){1,2}($|\/|%2f)/i;
+
+/** Is this path served without a session? Fails closed on anything unrecognised. */
+export function isPublicPath(pathname: string): boolean {
+  if (DOT_SEGMENT.test(pathname)) return false;
+  if (PUBLIC_EXACT.has(pathname)) return true;
+  return PUBLIC_PREFIXES.some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`),
+  );
+}
 
 export function middleware(request: NextRequest) {
   if (process.env.MEMORYOPS_WEB_MODE !== "authenticated") return NextResponse.next();
 
   const { pathname } = request.nextUrl;
-  if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) return NextResponse.next();
+  if (isPublicPath(pathname)) return NextResponse.next();
 
   // Presence check only — the cookie's signature is verified server-side by
   // Auth.js when the BFF calls `auth()`. A forged cookie gets past this redirect

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -4,7 +4,8 @@ import { defineConfig } from "vitest/config";
 
 /**
  * Unit tests for the web app's security-relevant logic: BFF scope sanitisation, the
- * role model, the web↔API role contract, and the demo credential boundary.
+ * role model, the web↔API role contract, the demo credential boundary, and the
+ * public/protected route matrix in middleware.ts.
  * Node-only and fast — no Next.js runtime, no DOM, no network.
  */
 export default defineConfig({
@@ -23,6 +24,8 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["lib/__tests__/**/*.test.ts"],
+    // `__tests__/` at the root covers modules that do not live under lib/ —
+    // middleware.ts is at the app root because Next.js requires it there.
+    include: ["lib/__tests__/**/*.test.ts", "__tests__/**/*.test.ts"],
   },
 });

--- a/docs/web-control-plane.md
+++ b/docs/web-control-plane.md
@@ -46,12 +46,12 @@ Browser ──(same-origin session cookie)──▶ Next.js BFF route handler
 | Module | Responsibility |
 | --- | --- |
 | `lib/identity.ts` | `server-only`. Resolves mode + identity. Never falls back to demo in authenticated mode — a broken session fails closed. |
-| `lib/roles.ts` | Pure role model + path→role policy. No `server-only`/NextAuth imports, so it is directly unit-testable. |
+| `lib/webRoles.ts`, `lib/capabilities.ts` | The persona list and the generated capability contract. No `server-only`/NextAuth imports, so both are directly unit-testable. |
 | `lib/scope.ts` | Strips client-supplied `tenant_id`/`user_id` from query and body. The security boundary. |
 | `lib/memoryopsToken.ts` | Mints the short-lived API credential. Never reaches the browser. |
 | `app/api/memoryops/[...path]/route.ts` | The BFF proxy. The browser's only route to the API. |
 | `auth.ts` | Auth.js v5 config; the `jwt` callback maps provider claims → `tenantId`/`memoryopsUserId`/`role`. |
-| `middleware.ts` | Redirects unauthenticated humans to `/signin`. **Not** the security boundary. |
+| `middleware.ts` | Redirects unauthenticated humans to `/signin`. **Not** the security boundary. See [Route protection](#route-protection). |
 
 ### Why the browser cannot switch tenant
 
@@ -68,6 +68,64 @@ exists for the banner only and is never consulted for access decisions.
 
 The upstream API base is `MEMORYOPS_API_URL` (server-only), so no API credential is
 exposed through `NEXT_PUBLIC_*`.
+
+## Route protection
+
+In `MEMORYOPS_WEB_MODE=authenticated`, `middleware.ts` decides which surfaces an
+anonymous visitor may reach. In demo mode it is a no-op — the public demo has no
+sign-in to redirect to.
+
+| Route | Anonymous | Why |
+| --- | --- | --- |
+| `/` | **public** (v2.6) | Product landing surface. Static; makes no authenticated API call. |
+| `/architecture` | public | Public reference, and the Railway web healthcheck (`railway/web.railway.json`). |
+| `/signin` | public | The sign-in flow itself. |
+| `/api/auth/*` | public | Auth.js callback, CSRF and session endpoints. |
+| `/chat` | protected | |
+| `/memories`, `/memories/{id}` | protected | |
+| `/governance` | protected | |
+| `/audit` | protected | |
+| `/loops` | protected | |
+| `/admin` | protected | |
+| `/api/memoryops/*` | protected | The BFF proxy. Also refuses independently — a forged cookie gets a 401 here. |
+
+### `/` is matched exactly, and must stay that way
+
+Public paths were previously all tested with `pathname.startsWith(p)`. Under that
+rule the single character `/` is a prefix of every route in the application, so
+adding `/` to the list would have made the entire control plane anonymous in one
+line — without naming `/chat`, `/memories`, `/governance`, `/audit`, `/loops` or
+`/admin` anywhere in the diff.
+
+`middleware.ts` therefore keeps two lists: `PUBLIC_EXACT` (matched with `===`,
+holding `/`) and `PUBLIC_PREFIXES` (matched as the path itself or a `/`-delimited
+descendant, so `/architecture-internal` is not covered by `/architecture`). Paths
+containing a dot segment — literal or percent-encoded — are refused public status
+outright: `new URL()` resolves `..` before `nextUrl.pathname` is read but does not
+decode `%2e%2e`, so `/architecture/%2e%2e/chat` would otherwise satisfy a prefix
+test while routing elsewhere.
+
+`__tests__/middleware-route-protection.test.ts` asserts the matrix route by route
+rather than re-deriving the rule, including `/memories/{id}`, the `__Secure-`
+cookie name, demo mode, an unset mode, and the `config.matcher` exclusion list.
+Reverting to the naive one-list implementation fails 12 of those tests.
+
+### The public landing page must stay session-independent
+
+A page that is publicly reachable but session-dependent does not fail politely:
+`resolveIdentity()` throws in authenticated mode and the BFF returns 401, so the
+new public surface would render as an error for exactly the visitors it was opened
+for — and only in production, since demo mode resolves an identity for everyone.
+
+`__tests__/public-landing-independence.test.ts` walks the whole first-party import
+graph from `app/page.tsx` and `app/architecture/page.tsx` and fails if any module
+in it reaches `lib/api`, `lib/identity` or `auth`. The realistic regression is not
+a deliberate import — it is a later stage adding a live-metrics widget several
+components deep.
+
+Middleware remains a redirect for humans, not the boundary. Authorization is the
+BFF's `canAttempt()` check plus the API's own re-decision after it loads the
+record.
 
 ## Roles
 


### PR DESCRIPTION
Makes `/` intentionally public while preserving authentication requirements for all application surfaces.

Introduces exact-vs-prefix public-route matching to avoid `/` accidentally exposing protected routes, tightens prefix matching and traversal handling, and adds explicit middleware regression coverage plus a guard ensuring the public landing page remains independent of authenticated/session-bound modules.

No backend, API, database, Railway, CI, or dependency changes.

---

## Why this is its own PR

Public paths were all tested with `pathname.startsWith(p)`. **The single character `/` is a prefix of every route in the application.** Adding `/` to that list would have made `/chat`, `/memories`, `/governance`, `/audit`, `/loops` and `/admin` anonymous in one line — with none of those routes appearing anywhere in the diff.

`middleware.ts` now keeps two lists with different matching semantics:

- `PUBLIC_EXACT` — matched with `===`. `/` lives here and must stay here.
- `PUBLIC_PREFIXES` — matched as the path itself or a `/`-delimited descendant.

## Before / after — anonymous, authenticated mode, against the built app

| Route | Before | After |
| --- | --- | --- |
| `/` | 307 → `/signin` | **200** |
| `/architecture` | 200 | 200 |
| `/signin` | 200 | 200 |
| `/chat` | 307 → `/signin` | 307 → `/signin` |
| `/memories` | 307 → `/signin` | 307 → `/signin` |
| `/memories/{id}` | 307 → `/signin` | 307 → `/signin` |
| `/governance` | 307 → `/signin` | 307 → `/signin` |
| `/audit` | 307 → `/signin` | 307 → `/signin` |
| `/loops` | 307 → `/signin` | 307 → `/signin` |
| `/admin` | 307 → `/signin` | 307 → `/signin` |
| `/api/memoryops/*` | 307 → `/signin` | 307 → `/signin` |

Exactly one cell changed. `callbackUrl` is preserved on every redirect. With a session cookie every route still passes through, and the BFF still answers `401 {"detail":"not authenticated"}` to a forged one — the actual security boundary is untouched, only the human-redirect layer moved.

## Two tightenings, both strictly narrowing

- **Prefix delimiter.** `/architecture-internal`, `/signin-as-admin` and `/api/authz` are no longer covered by their near-neighbours.
- **Dot segments.** `new URL()` resolves literal `..` before `nextUrl.pathname` is read, but does not decode `%2e%2e` — so `/architecture/%2e%2e/chat` would otherwise satisfy a prefix test while routing somewhere else. Such paths are refused public status outright; no MemoryOps route contains a dot segment. Verified over HTTP: all three traversal forms return 307.

Both reduce what matches. Neither broadens access.

## Regression coverage

Node-only, no new dependency, no browser or request harness.

- `__tests__/middleware-route-protection.test.ts` asserts the matrix **route by route** rather than re-deriving the rule the implementation uses. Covers `/memories/{id}`, the `__Secure-` cookie name, demo mode, an unset mode, prefix near-misses, dot segments, trailing slashes, and the `config.matcher` exclusion list.

  Reverting `middleware.ts` to the naive one-list implementation **fails 12 of these tests**, including every protected route. That was run and then restored.

- `__tests__/public-landing-independence.test.ts` walks the whole first-party import graph from `app/page.tsx` and `app/architecture/page.tsx` and fails if any module in it reaches `lib/api`, `lib/identity` or `auth`. A publicly reachable but session-dependent page does not fail politely — `resolveIdentity()` throws in authenticated mode and the BFF returns 401, so the new public surface would render as an error for exactly the visitors it was opened for, and only in production. The realistic regression is a later stage adding a live-metrics widget several components deep, not a deliberate import. The suite includes two self-checks so it cannot pass vacuously.

`vitest.config.mts` gains one include entry, because `middleware.ts` must live at the app root.

## Scope

- 5 files, +433/−10
- 0 backend / API / database / Railway / CI files
- 0 dependency changes
- 0 homepage content — `/` ships exactly as it is; the landing experience is Stage C
- `/architecture` untouched and still 200 anonymously, so the Railway healthcheck contract holds

## Note

While documenting the route/auth model, one stale entry in the same module table was corrected: it named `lib/roles.ts`, which no longer exists (now `lib/webRoles.ts` + `lib/capabilities.ts`).

The adjacent `## Roles` section of that document is also stale — it still describes the pre-v2.4 ordinal ladder that the generated capability contract replaced — and was deliberately **not** touched here. Rewriting it is a roles-documentation change and does not belong in an authorization-boundary PR. Tracked as a separate docs cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)