### PR TITLE
feat(web): build public MemoryOps landing experience

### DIFF
--- a/apps/web/__tests__/governance-simulator.test.ts
+++ b/apps/web/__tests__/governance-simulator.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EXAMPLE_CANDIDATES,
+  RULE_SUMMARY,
+  SIMPLIFICATIONS,
+  simulate,
+} from "@/components/public/sections/simulate";
+
+/**
+ * The public page's illustrative policy simulation.
+ *
+ * It is a marketing illustration, but it is an illustration *about refusing to
+ * store secrets* — so a credential coming back as anything other than BLOCK would
+ * discredit the exact claim the page is making. Rule order is the load-bearing
+ * part: "remember my api key just for this session" matches both the credential
+ * pattern and the session-scoped pattern, and the credential rule has to win.
+ */
+
+describe("the four example candidates behave as the page claims", () => {
+  const [metric, credential, sessionScoped, sensitive] = EXAMPLE_CANDIDATES;
+
+  it("saves a durable preference", () => {
+    expect(simulate(metric)?.verdict).toBe("SAVE");
+  });
+
+  it("blocks a credential", () => {
+    expect(simulate(credential)?.verdict).toBe("BLOCK");
+  });
+
+  it("keeps an explicitly session-scoped statement out of durable memory", () => {
+    expect(simulate(sessionScoped)?.verdict).toBe("SESSION ONLY");
+  });
+
+  it("defers high-sensitivity business content to review", () => {
+    expect(simulate(sensitive)?.verdict).toBe("REVIEW");
+  });
+});
+
+describe("credential detection wins over every other rule", () => {
+  // Each of these also matches a later pattern. Order is what makes them BLOCK.
+  //
+  // Values are deliberately inert. The rules key off the *shape* of a credential
+  // reference, so a fixture only needs the prefix or the assignment — inventing a
+  // realistic-looking token would trip the repository's secret scanner for no
+  // extra coverage, and a scanner allowlist is exactly the thing that later hides
+  // a real leak.
+  const overlapping = [
+    "Use this only for this conversation: my key is sk-live-REDACTED.",
+    "I always use api_key=REDACTED-TEST-FIXTURE for the staging environment.",
+    "Our team password: hunter2correcthorse",
+    "Temporarily remember ghp_aaaabbbbccccddddeeeeffff1111222233",
+    "-----BEGIN RSA PRIVATE KEY-----",
+    "AKIAIOSFODNN7EXAMPLE is our access key id",
+  ];
+
+  for (const candidate of overlapping) {
+    it(`blocks: ${candidate.slice(0, 44)}…`, () => {
+      const decision = simulate(candidate);
+      expect(decision?.verdict).toBe("BLOCK");
+      expect(decision?.outcome).toContain("Not stored");
+    });
+  }
+});
+
+describe("honesty properties", () => {
+  it("returns NO MATCH instead of guessing", () => {
+    // Inventing a verdict for unrecognised input would misrepresent the real broker
+    // in the one direction that matters — looking more decisive than it is here.
+    const decision = simulate("The number seven.");
+    expect(decision?.verdict).toBe("NO MATCH");
+    expect(decision?.rationale).toContain("real broker");
+  });
+
+  it("always names the rule that produced the verdict", () => {
+    for (const candidate of [...EXAMPLE_CANDIDATES, "The number seven."]) {
+      const decision = simulate(candidate);
+      expect(decision?.rule, candidate).toBeTruthy();
+    }
+  });
+
+  it("returns nothing for empty input rather than a default verdict", () => {
+    expect(simulate("")).toBeNull();
+    expect(simulate("   ")).toBeNull();
+  });
+
+  it("publishes what it does not model, for the UI to render", () => {
+    expect(SIMPLIFICATIONS.length).toBeGreaterThanOrEqual(4);
+    expect(RULE_SUMMARY.length).toBe(4);
+  });
+});

--- a/apps/web/__tests__/public-landing-independence.test.ts
+++ b/apps/web/__tests__/public-landing-independence.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -25,10 +25,19 @@ import { describe, expect, it } from "vitest";
 
 const WEB_ROOT = join(__dirname, "..");
 
-/** Entry points that must stay renderable with no session. */
+/**
+ * Entry points that must stay renderable with no session.
+ *
+ * The graph walk below reaches everything under `components/public/` through
+ * `app/page.tsx`, so the landing sections are covered transitively. The shell is
+ * also listed directly: a section that is written but not yet wired into the page
+ * would otherwise sit outside the graph and go unchecked until the day it is
+ * imported — which is the day it would break production.
+ */
 const PUBLIC_ENTRY_POINTS = [
   join("app", "page.tsx"),
   join("app", "architecture", "page.tsx"),
+  join("components", "public", "PublicShell.tsx"),
 ];
 
 /**
@@ -116,5 +125,61 @@ describe("public landing pages are session-independent", () => {
     const graph = importGraph(join("app", "layout.tsx"));
     const specifiers = [...graph.values()].flat().map((s) => s.replace(/^@\//, ""));
     expect(specifiers).toContain("lib/identity");
+  });
+});
+
+/**
+ * Directory sweep over `components/public/`.
+ *
+ * The graph walk above only reaches components that are actually imported. A
+ * section written, committed, and wired in a later change would sit outside the
+ * graph until the moment it ships — so every file in the public tree is checked
+ * whether or not anything imports it yet.
+ */
+describe("the public component tree is inert", () => {
+  const PUBLIC_DIR = join(WEB_ROOT, "components", "public");
+
+  function walk(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return walk(full);
+      return /\.tsx?$/.test(entry.name) ? [full] : [];
+    });
+  }
+
+  const files = walk(PUBLIC_DIR);
+
+  it("contains the sections it is supposed to", () => {
+    // Guards the guard: an empty or mis-resolved directory would pass everything.
+    expect(files.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("imports no session-dependent module anywhere", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      for (const specifier of importsOf(file)) {
+        const bare = specifier.replace(/^@\//, "");
+        if (SESSION_DEPENDENT.some((m) => bare === m || bare.startsWith(`${m}/`))) {
+          offenders.push(`${file.slice(WEB_ROOT.length + 1)} -> ${specifier}`);
+        }
+      }
+    }
+    expect(offenders, offenders.join("\n")).toEqual([]);
+  });
+
+  it("issues no network call of its own", () => {
+    // The governance simulator is illustrative and must stay that way. A `fetch`
+    // here would either hit the BFF (401 for the anonymous visitors this page
+    // exists for) or an external host from a page that promises it sends nothing.
+    const offenders: string[] = [];
+    for (const file of files) {
+      const code = readFileSync(file, "utf8")
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/^\s*\/\/.*$/gm, "");
+      if (/\b(fetch|XMLHttpRequest|EventSource|WebSocket)\s*\(/.test(code)) {
+        offenders.push(file.slice(WEB_ROOT.length + 1));
+      }
+    }
+    expect(offenders, offenders.join("\n")).toEqual([]);
   });
 });

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,165 +1,49 @@
-import Link from "next/link";
+import type { Metadata } from "next";
 
-import { NAV_GROUPS } from "@/components/shell/navigation";
-import NavIcon from "@/components/shell/NavIcon";
-import {
-  Badge,
-  Panel,
-  PanelBody,
-  PanelHeader,
-  PageHeader,
-  SectionHeader,
-} from "@/components/ui";
+import { PublicShell } from "@/components/public/PublicShell";
+import ArchitecturePreview from "@/components/public/sections/ArchitecturePreview";
+import BeforeWith from "@/components/public/sections/BeforeWith";
+import Capabilities from "@/components/public/sections/Capabilities";
+import DecisionTrace from "@/components/public/sections/DecisionTrace";
+import GovernanceSimulator from "@/components/public/sections/GovernanceSimulator";
+import Hero from "@/components/public/sections/Hero";
+import Lifecycle from "@/components/public/sections/Lifecycle";
 
 /**
- * Control-plane overview.
+ * The public product page.
  *
- * Static and claim-free: it describes the lifecycle MemoryOps implements and routes
- * to the surfaces that show real state. It renders no counts of its own — a landing
- * page full of numbers nobody fetched is exactly the fabricated-state problem the
- * rest of this UI exists to avoid.
+ * Ordered for a first-time visitor rather than for completeness: state the category
+ * (Hero), show one concrete governed decision (DecisionTrace), then explain why the
+ * architecture is shaped that way (BeforeWith) and let them try it (Simulator).
+ * Lifecycle, Capabilities and Architecture only arrive once someone has a reason to
+ * care about the detail.
+ *
+ * Session-independent by construction. Nothing here imports `lib/api`,
+ * `lib/identity` or `auth`, and `__tests__/public-landing-independence.test.ts`
+ * walks the whole import graph to keep it that way — a page that is publicly
+ * reachable but session-dependent renders an error for exactly the visitors it was
+ * opened for, and only in production.
+ *
+ * It renders its own chrome via `PublicShell`; `AppShell` stands aside for `/`
+ * (see `components/shell/navigation.ts`).
  */
 
-/** The lifecycle, in the product's own vocabulary. */
-const LIFECYCLE = [
-  { stage: "Capture", note: "Candidate memory is extracted from the turn." },
-  { stage: "Evaluate", note: "The policy broker decides before anything is written." },
-  { stage: "Store", note: "Typed, provenanced, tenant-scoped governed state." },
-  { stage: "Retrieve", note: "Tenant-scoped candidate search. Deleted rows never surface." },
-  { stage: "Rank", note: "Semantic, keyword, importance, recency, reinforcement." },
-  { stage: "Compose", note: "Admitted memory becomes model context." },
-  { stage: "Update", note: "Reinforcement, edits and conflict resolution." },
-  { stage: "Forget", note: "Retention windows, consent withdrawal, soft delete." },
-  { stage: "Audit", note: "Every mutation commits with its audit event." },
-];
-
-/** The guarantees the codebase enforces in tests — stated as behaviour, not as a badge. */
-const INVARIANTS = [
-  "Every memory query filters by tenant and user.",
-  "Memories with status 'deleted' are never retrieved.",
-  "Every memory carries a non-null source.",
-  "Retrieval failure never blocks a response.",
-  "The policy broker runs before any write.",
-  "Temporary chat writes nothing and reads nothing.",
-  "Each lifecycle mutation and its audit event commit together.",
-];
-
-const PLANES = [
-  {
-    title: "Write path",
-    body: "Gateway → Extractor → Policy Broker → Write Service → Typed Store → Audit. Nothing is stored without an explicit, audited policy decision.",
-  },
-  {
-    title: "Read path",
-    body: "Retriever → Ranker → Admission Gate → Context Composer → Response. A memory enters context only if it is both relevant and allowed.",
-  },
-  {
-    title: "Wrapping planes",
-    body: "Security, Governance, Observability, Reliability and Evaluation wrap the lifecycle rather than sitting beside it.",
-  },
-];
+export const metadata: Metadata = {
+  title: "MemoryOps AI — Govern what AI remembers",
+  description:
+    "A governed memory layer for AI assistants and agents. Every candidate memory passes a policy decision before it is stored, and every memory that reaches model context leaves an audit record.",
+};
 
 export default function Home() {
   return (
-    <div className="space-y-8">
-      <PageHeader
-        eyebrow="Overview"
-        title="Govern what AI remembers."
-        description="MemoryOps AI is a governed memory lifecycle for AI assistants — not a vector store with a chat box in front of it. Memory is typed, policy-gated, provenanced and auditable state."
-      />
-
-      <section className="space-y-3">
-        <SectionHeader
-          title="Lifecycle"
-          description="The nine stages every candidate memory passes through."
-        />
-        <ol className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-          {LIFECYCLE.map((step, index) => (
-            <li
-              key={step.stage}
-              className="flex gap-3 rounded-panel border border-line bg-surface px-3.5 py-3"
-            >
-              <span
-                aria-hidden
-                className="mt-0.5 font-mono text-xs text-fg-muted"
-              >
-                {String(index + 1).padStart(2, "0")}
-              </span>
-              <div className="min-w-0">
-                <p className="text-sm font-medium text-fg">{step.stage}</p>
-                <p className="mt-0.5 text-xs leading-relaxed text-fg-secondary">
-                  {step.note}
-                </p>
-              </div>
-            </li>
-          ))}
-        </ol>
-      </section>
-
-      <section className="grid gap-3 lg:grid-cols-3">
-        {PLANES.map((plane) => (
-          <Panel key={plane.title}>
-            <PanelHeader title={plane.title} />
-            <PanelBody>
-              <p className="text-sm leading-relaxed text-fg-secondary">{plane.body}</p>
-            </PanelBody>
-          </Panel>
-        ))}
-      </section>
-
-      <section className="space-y-3">
-        <SectionHeader
-          title="Enforced invariants"
-          description="Each of these is asserted in the API's test and eval suites, not asserted here."
-        />
-        <Panel>
-          <PanelBody>
-            <ul className="grid gap-2.5 sm:grid-cols-2">
-              {INVARIANTS.map((invariant) => (
-                <li key={invariant} className="flex gap-2.5 text-sm text-fg-secondary">
-                  <span aria-hidden className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-ok" />
-                  <span className="leading-relaxed">{invariant}</span>
-                </li>
-              ))}
-            </ul>
-          </PanelBody>
-        </Panel>
-      </section>
-
-      <section className="space-y-3">
-        <SectionHeader
-          title="Surfaces"
-          description="Each of these renders live state from the API for the tenant you are operating on."
-        />
-        <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-          {NAV_GROUPS.flatMap((group) =>
-            group.items
-              .filter((item) => item.href !== "/")
-              .map((item) => (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className="group flex gap-3 rounded-panel border border-line bg-surface px-3.5 py-3 transition-colors hover:border-line-strong hover:bg-surface-raised"
-                >
-                  <span className="mt-0.5 text-fg-muted group-hover:text-accent-strong">
-                    <NavIcon glyph={item.glyph} />
-                  </span>
-                  <span className="min-w-0">
-                    <span className="flex items-center gap-2 text-sm font-medium text-fg">
-                      {item.label}
-                      <Badge tone="quiet" className="font-mono text-[10px]">
-                        {group.label}
-                      </Badge>
-                    </span>
-                    <span className="mt-0.5 block text-xs leading-relaxed text-fg-secondary">
-                      {item.summary}
-                    </span>
-                  </span>
-                </Link>
-              )),
-          )}
-        </div>
-      </section>
-    </div>
+    <PublicShell>
+      <Hero />
+      <DecisionTrace />
+      <BeforeWith />
+      <GovernanceSimulator />
+      <Lifecycle />
+      <Capabilities />
+      <ArchitecturePreview />
+    </PublicShell>
   );
 }

--- a/apps/web/components/public/Illustrative.tsx
+++ b/apps/web/components/public/Illustrative.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from "react";
+
+import { Badge, cn } from "@/components/ui";
+
+/**
+ * The label that separates worked examples from product claims.
+ *
+ * Everything on the public page that shows a *specific* memory, verdict or trace is
+ * invented for explanation. None of it came from a running MemoryOps instance, and
+ * a visitor must not have to work that out. So the label is a required prop on the
+ * wrapper rather than an optional decoration a section can forget to pass — the
+ * only way to render a walkthrough here is to say what it is.
+ *
+ * There are no counters, adoption figures, customer names, benchmark results,
+ * latency numbers or compliance marks anywhere on this page, illustrative or
+ * otherwise. Those would be fabrications, not illustrations, and no label makes
+ * them acceptable.
+ */
+export type IllustrativeKind = "Illustrative" | "Example" | "Simulation";
+
+export function IllustrativeBadge({
+  kind,
+  className,
+}: {
+  kind: IllustrativeKind;
+  className?: string;
+}) {
+  return (
+    <Badge tone="warn" className={cn("shrink-0", className)}>
+      {kind}
+    </Badge>
+  );
+}
+
+/**
+ * Wraps a worked example. The label sits inside the same bordered region as the
+ * content, so it cannot be scrolled away from or read as belonging to a neighbour.
+ */
+export function IllustrativeBlock({
+  kind,
+  note,
+  children,
+  className,
+}: {
+  kind: IllustrativeKind;
+  /** What specifically is invented, in one line. Required — "Illustrative" alone is vague. */
+  note: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-panel border border-warn/30 bg-warn/[0.03]",
+        className,
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-warn/25 bg-warn/[0.06] px-4 py-2.5">
+        <IllustrativeBadge kind={kind} />
+        <p className="text-xs leading-relaxed text-fg-secondary">{note}</p>
+      </div>
+      <div className="p-4 sm:p-5">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/components/public/PublicShell.tsx
+++ b/apps/web/components/public/PublicShell.tsx
@@ -1,0 +1,187 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { cn } from "@/components/ui";
+
+/**
+ * Chrome for the public product page.
+ *
+ * Separate from `AppShell` on purpose. The control-plane shell exists to tell an
+ * operator which tenant they are acting on and to move them between governed
+ * surfaces; a visitor who is not signed in has no tenant and cannot open any of
+ * those links. Rendering them a sidebar of redirects-to-sign-in would be noise
+ * dressed as navigation.
+ *
+ * It uses the same tokens and primitives as the control plane rather than a second
+ * visual language — this is the same product, seen from outside.
+ *
+ * Deliberately a server component with no state: the header is a wordmark, two
+ * in-page anchors and one call to action. Nothing here needs hydration, so the
+ * public page ships no shell JavaScript at all.
+ */
+
+/** In-page anchors. Section ids are owned by the section components. */
+const SECTION_LINKS = [
+  { href: "#decision-trace", label: "How it works" },
+  { href: "#lifecycle", label: "Lifecycle" },
+  { href: "#capabilities", label: "Capabilities" },
+] as const;
+
+export function PublicShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-canvas">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:border focus:border-accent focus:bg-surface focus:px-3 focus:py-2 focus:text-sm focus:text-fg"
+      >
+        Skip to content
+      </a>
+      <PublicHeader />
+      <main id="main-content">{children}</main>
+      <PublicFooter />
+    </div>
+  );
+}
+
+function Wordmark({ className }: { className?: string }) {
+  return (
+    <span className={cn("flex items-center gap-2.5 text-sm font-semibold tracking-tight text-fg", className)}>
+      <span
+        aria-hidden
+        className="grid h-7 w-7 place-items-center rounded-md border border-accent/40 bg-accent/10 font-mono text-[11px] text-accent-strong"
+      >
+        MO
+      </span>
+      MemoryOps<span className="text-fg-muted"> AI</span>
+    </span>
+  );
+}
+
+function PublicHeader() {
+  return (
+    <header className="sticky top-0 z-30 border-b border-line bg-canvas/90 backdrop-blur supports-[backdrop-filter]:bg-canvas/75">
+      <div className="mx-auto flex h-16 max-w-6xl items-center gap-6 px-5 sm:px-8">
+        <Link href="/" className="shrink-0 rounded-md">
+          <Wordmark />
+        </Link>
+
+        {/* Hidden on small screens rather than collapsed into a drawer: three
+            in-page anchors do not justify a toggle, and the page is short enough
+            to scroll. The CTA stays visible at every width. */}
+        <nav aria-label="Page sections" className="hidden flex-1 items-center gap-6 md:flex">
+          {SECTION_LINKS.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              className="rounded-sm text-sm text-fg-secondary transition-colors hover:text-fg"
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+
+        <div className="ml-auto flex items-center gap-3 md:ml-0">
+          {/*
+           * `/chat` rather than `/signin`, because it is correct in every mode:
+           * authenticated + no session redirects to sign-in with a callback back
+           * here, authenticated + session lands in the control plane, and demo mode
+           * opens the demo directly. `/signin` would dead-end in demo mode, where it
+           * redirects to `/` — a button that returns you to the page you clicked it
+           * on.
+           */}
+          <Link
+            href="/chat"
+            className="inline-flex h-9 shrink-0 items-center justify-center rounded-lg bg-accent px-4 text-sm font-medium text-canvas transition-colors hover:bg-accent-strong"
+          >
+            Open control plane
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function PublicFooter() {
+  return (
+    <footer className="border-t border-line">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-5 py-10 sm:px-8 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <Wordmark />
+          <p className="max-w-sm text-xs leading-relaxed text-fg-muted">
+            A governed memory lifecycle for AI assistants and agents: capture,
+            evaluate, store, retrieve, rank, compose, update, forget, audit.
+          </p>
+        </div>
+        <nav aria-label="Footer" className="flex flex-col gap-2 text-sm">
+          <Link
+            href="/chat"
+            className="rounded-sm text-fg-secondary underline-offset-4 hover:text-fg hover:underline"
+          >
+            Open control plane
+          </Link>
+          <Link
+            href="/architecture"
+            className="rounded-sm text-fg-secondary underline-offset-4 hover:text-fg hover:underline"
+          >
+            Technical architecture reference
+          </Link>
+        </nav>
+      </div>
+    </footer>
+  );
+}
+
+/** Shared section wrapper: consistent rhythm and a single max width. */
+export function Section({
+  id,
+  children,
+  className,
+  bordered = true,
+}: {
+  id?: string;
+  children: ReactNode;
+  className?: string;
+  bordered?: boolean;
+}) {
+  return (
+    <section
+      id={id}
+      // scroll-mt clears the sticky header when an anchor link jumps here.
+      className={cn(
+        "scroll-mt-20 px-5 py-16 sm:px-8 sm:py-20",
+        bordered && "border-t border-line",
+        className,
+      )}
+    >
+      <div className="mx-auto max-w-6xl">{children}</div>
+    </section>
+  );
+}
+
+/** Section heading block. `<h2>` so the page keeps one `<h1>` in the hero. */
+export function SectionIntro({
+  eyebrow,
+  title,
+  children,
+  aside,
+}: {
+  eyebrow: string;
+  title: string;
+  children?: ReactNode;
+  aside?: ReactNode;
+}) {
+  return (
+    <div className="mb-10 flex flex-wrap items-end justify-between gap-4">
+      <div className="max-w-2xl space-y-3">
+        <p className="text-label uppercase text-accent-strong">{eyebrow}</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-fg sm:text-3xl">
+          {title}
+        </h2>
+        {children ? (
+          <p className="text-base leading-relaxed text-fg-secondary">{children}</p>
+        ) : null}
+      </div>
+      {aside ? <div className="shrink-0">{aside}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/components/public/sections/ArchitecturePreview.tsx
+++ b/apps/web/components/public/sections/ArchitecturePreview.tsx
@@ -1,0 +1,144 @@
+import Link from "next/link";
+
+import { Section, SectionIntro } from "../PublicShell";
+
+/**
+ * Self-contained architecture summary.
+ *
+ * Self-contained on purpose: `/architecture` is the operator-facing technical
+ * reference and still renders inside the control-plane shell, so sending a visitor
+ * there from this page would drop them into a different chrome without warning. The
+ * link out is secondary and explicitly labelled as a technical/system view, so the
+ * transition is expected rather than surprising.
+ *
+ * Component names match the codebase — Gateway, Extractor, Policy Broker, Retriever,
+ * Ranker, Admission Gate, Context Composer — so this stays a smaller view of the
+ * same system rather than a parallel description of it.
+ */
+
+const WRITE_PATH = [
+  "Gateway",
+  "Extractor",
+  "Policy Broker",
+  "Write Service",
+  "Typed Store",
+  "Audit",
+];
+
+const READ_PATH = [
+  "Retriever",
+  "Ranker",
+  "Admission Gate",
+  "Context Composer",
+  "Response",
+];
+
+const PLANES: { name: string; body: string }[] = [
+  {
+    name: "Security",
+    body: "Tenant and user scoping on every query, row-level security beneath it, secret detection before storage.",
+  },
+  {
+    name: "Governance",
+    body: "Typed lifecycle states, approval queue, retention, legal hold, consent.",
+  },
+  {
+    name: "Observability",
+    body: "Structured logs, per-request traces, Prometheus metrics.",
+  },
+  {
+    name: "Reliability",
+    body: "Retrieval failure degrades instead of blocking a response; background jobs lease, retry and dead-letter.",
+  },
+  {
+    name: "Evaluation",
+    body: "Golden and adversarial suites gate releases on the invariants that matter.",
+  },
+];
+
+function Path({
+  label,
+  steps,
+  note,
+}: {
+  label: string;
+  steps: string[];
+  note: string;
+}) {
+  return (
+    <div className="rounded-panel border border-line bg-surface p-5">
+      <h3 className="text-sm font-semibold text-fg">{label}</h3>
+      <ol className="mt-3.5 flex flex-wrap items-center gap-x-1.5 gap-y-2">
+        {steps.map((step, i) => (
+          <li key={step} className="flex items-center gap-1.5">
+            {i > 0 ? (
+              <span aria-hidden className="text-line-strong">
+                →
+              </span>
+            ) : null}
+            <span className="rounded-md border border-line bg-surface-raised px-2.5 py-1 text-xs text-fg-secondary">
+              {step}
+            </span>
+          </li>
+        ))}
+      </ol>
+      <p className="mt-3.5 text-xs leading-relaxed text-fg-muted">{note}</p>
+    </div>
+  );
+}
+
+export default function ArchitecturePreview() {
+  return (
+    <Section id="architecture-preview">
+      <SectionIntro eyebrow="System" title="How it is put together">
+        Two request paths and five planes that wrap them. The planes are not a layer
+        beside the lifecycle — every stage passes through all of them.
+      </SectionIntro>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Path
+          label="Write path"
+          steps={WRITE_PATH}
+          note="The policy broker is the choke point. Nothing reaches the store without an audited decision."
+        />
+        <Path
+          label="Read path"
+          steps={READ_PATH}
+          note="Deleted memory is never retrieved, and retrieval failure degrades rather than blocking the response."
+        />
+      </div>
+
+      <div className="mt-4 rounded-panel border border-line bg-surface p-5">
+        <h3 className="text-sm font-semibold text-fg">Wrapping planes</h3>
+        <dl className="mt-4 grid gap-x-6 gap-y-4 sm:grid-cols-2 lg:grid-cols-3">
+          {PLANES.map((plane) => (
+            <div key={plane.name} className="space-y-1">
+              <dt className="text-xs font-medium text-accent-strong">{plane.name}</dt>
+              <dd className="text-xs leading-relaxed text-fg-secondary">{plane.body}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      <div className="mt-8 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-line pt-6">
+        <Link
+          href="/chat"
+          className="inline-flex h-10 items-center justify-center rounded-lg bg-accent px-5 text-sm font-medium text-canvas transition-colors hover:bg-accent-strong"
+        >
+          Open control plane
+        </Link>
+        {/* Secondary and explicitly labelled: this leaves the product page for the
+            operator-facing technical reference, which renders in a different shell. */}
+        <Link
+          href="/architecture"
+          className="rounded-sm text-sm text-fg-secondary underline-offset-4 hover:text-fg hover:underline"
+        >
+          View the technical architecture reference →
+        </Link>
+        <span className="text-xs text-fg-muted">
+          Detailed system view, written for engineers and operators.
+        </span>
+      </div>
+    </Section>
+  );
+}

--- a/apps/web/components/public/sections/BeforeWith.tsx
+++ b/apps/web/components/public/sections/BeforeWith.tsx
@@ -1,0 +1,108 @@
+import { cn } from "@/components/ui";
+import { Section, SectionIntro } from "../PublicShell";
+
+/**
+ * Architectural contrast, not a competitive claim.
+ *
+ * The left column describes the *direct-write pattern* — an agent appending text
+ * straight into a retrieval index — because that is a real architecture with real
+ * consequences, and it is what MemoryOps is shaped against. It deliberately names
+ * no product and makes no claim about how any particular system behaves. Plenty of
+ * memory tools do more than this; the point is the pattern, not the field.
+ *
+ * The closing line says so outright, so the section cannot be read as a scoreboard.
+ */
+
+const DIRECT = {
+  title: "Direct-write memory",
+  summary: "The agent appends to a retrieval index. The index is the system of record.",
+  points: [
+    "Any text the model produces can become memory.",
+    "There is no separate decision to inspect later — the write *is* the decision.",
+    "Retrieval returns whatever is nearest in vector space.",
+    "Deletion is a best-effort index operation; derived copies are not tracked.",
+    "Why a memory exists, and why it influenced an answer, is not recorded.",
+  ],
+};
+
+const GOVERNED = {
+  title: "Governed memory",
+  summary:
+    "A policy broker decides before any write. Storage holds typed state; evidence is a first-class output.",
+  points: [
+    "Every candidate gets an explicit verdict — save, defer, block, drop, merge.",
+    "The verdict and its reason are recorded whether or not anything is stored.",
+    "Retrieval is tenant- and user-scoped, and an admission gate decides what enters context.",
+    "Deletion is a governed state with a tombstone; derived artefacts inherit it.",
+    "Provenance on every memory, and a trace explaining every memory used.",
+  ],
+};
+
+function Column({
+  data,
+  tone,
+  label,
+}: {
+  data: typeof DIRECT;
+  tone: "muted" | "accent";
+  label: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex h-full flex-col gap-4 rounded-panel border p-5",
+        tone === "accent" ? "border-accent/35 bg-accent/[0.04]" : "border-line bg-surface",
+      )}
+    >
+      <div className="space-y-2">
+        <p
+          className={cn(
+            "text-label uppercase",
+            tone === "accent" ? "text-accent-strong" : "text-fg-muted",
+          )}
+        >
+          {label}
+        </p>
+        <h3 className="text-lg font-semibold tracking-tight text-fg">{data.title}</h3>
+        <p className="text-sm leading-relaxed text-fg-secondary">{data.summary}</p>
+      </div>
+      <ul className="space-y-2.5">
+        {data.points.map((point) => (
+          <li key={point} className="flex gap-2.5 text-sm leading-relaxed text-fg-secondary">
+            <span
+              aria-hidden
+              className={cn(
+                "mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full",
+                tone === "accent" ? "bg-ok" : "bg-line-strong",
+              )}
+            />
+            <span>{point}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default function BeforeWith() {
+  return (
+    <Section>
+      <SectionIntro eyebrow="Architecture" title="Two ways to give a model memory">
+        The difference is not how text is stored. It is whether a decision exists
+        between producing a memory and being able to retrieve it.
+      </SectionIntro>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Column data={DIRECT} tone="muted" label="Pattern" />
+        <Column data={GOVERNED} tone="accent" label="MemoryOps" />
+      </div>
+
+      <p className="mt-6 max-w-3xl text-xs leading-relaxed text-fg-muted">
+        This contrasts two architectures, not two products. &ldquo;Direct-write
+        memory&rdquo; describes a pattern — writing straight into a retrieval index —
+        and is not a claim about how any specific system behaves. Many tools sit
+        somewhere between these columns.
+      </p>
+    </Section>
+  );
+}

--- a/apps/web/components/public/sections/Capabilities.tsx
+++ b/apps/web/components/public/sections/Capabilities.tsx
@@ -1,0 +1,73 @@
+import { Section, SectionIntro } from "../PublicShell";
+
+/**
+ * Capability categories that exist in the runtime today.
+ *
+ * Each entry names something the codebase implements — no roadmap items dressed as
+ * features, no counts, no maturity badges. Where a capability has a limit worth
+ * stating up front, it is stated here rather than discovered later: tamper-evidence
+ * is not tamper-proofing, and governed deletion is not cryptographic erasure.
+ */
+const CAPABILITIES: { title: string; body: string }[] = [
+  {
+    title: "Governance",
+    body: "A policy broker runs before every write and records an explicit verdict — save, defer to approval, block, drop or merge — with its reason, whether or not anything is stored.",
+  },
+  {
+    title: "Memory types and state",
+    body: "Memory is typed (preference, constraint, project, semantic, procedural and more) and moves through a lifecycle status rather than existing as undifferentiated text.",
+  },
+  {
+    title: "Retention and deletion",
+    body: "Retention windows by sensitivity tier, consent withdrawal, and legal hold that fails closed. Deletion is a governed state with a tombstone, and derived memory inherits it. This is governed erasure, not cryptographic shredding.",
+  },
+  {
+    title: "Context admission",
+    body: "Relevance is not sufficient. A memory enters the model's context only if it is also allowed, and each response carries a trace of what was admitted, withheld and why.",
+  },
+  {
+    title: "Audit and evidence",
+    body: "Every lifecycle mutation commits in the same transaction as its audit event, on a per-tenant hash chain. Read-only evidence reports can be produced per response, per deletion and per policy. Tamper-evident, which is not the same as tamper-proof.",
+  },
+  {
+    title: "Tenant isolation",
+    body: "Every query is scoped by tenant and user at the application layer, with Postgres row-level security enforced beneath it.",
+  },
+  {
+    title: "Lifecycle loops",
+    body: "Background work — decay, archival, retention, deletion compaction and verification, conflict scanning, reflection — runs off the request path as leased, retried, audited jobs.",
+  },
+  {
+    title: "Evaluation",
+    body: "Golden and adversarial suites, including deletion-leakage batteries that treat cross-session and derived-memory leakage as release-gating rather than advisory.",
+  },
+  {
+    title: "Runtime integrations",
+    body: "Swappable LLM, embedding and vector backends behind contracts, a typed Python SDK, and a framework-agnostic memory adapter for common agent frameworks.",
+  },
+];
+
+export default function Capabilities() {
+  return (
+    <Section id="capabilities">
+      <SectionIntro eyebrow="Capabilities" title="What the runtime does today">
+        Implemented capability areas, with their limits stated where the distinction
+        matters.
+      </SectionIntro>
+
+      <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+        {CAPABILITIES.map((capability) => (
+          <article
+            key={capability.title}
+            className="rounded-panel border border-line bg-surface p-5"
+          >
+            <h3 className="text-sm font-semibold text-fg">{capability.title}</h3>
+            <p className="mt-2 text-sm leading-relaxed text-fg-secondary">
+              {capability.body}
+            </p>
+          </article>
+        ))}
+      </div>
+    </Section>
+  );
+}

--- a/apps/web/components/public/sections/DecisionTrace.tsx
+++ b/apps/web/components/public/sections/DecisionTrace.tsx
@@ -1,0 +1,182 @@
+import { Badge, Code } from "@/components/ui";
+import { IllustrativeBlock } from "../Illustrative";
+import { Section, SectionIntro } from "../PublicShell";
+
+/**
+ * One concrete memory decision, end to end.
+ *
+ * This is the section that has to land. A visitor who has just read "governed
+ * memory layer" needs to see what a governed decision actually *is* before any
+ * lifecycle vocabulary arrives — so this comes second, before Lifecycle and
+ * Governance, and follows a single message through the whole runtime rather than
+ * describing the stages abstractly.
+ *
+ * Every value shown is invented. That is what `IllustrativeBlock` declares.
+ */
+
+type Verdict = "SAVE" | "SESSION ONLY" | "BLOCK";
+
+const VERDICT_TONE = {
+  SAVE: "ok",
+  "SESSION ONLY": "info",
+  BLOCK: "danger",
+} as const;
+
+const STEPS: {
+  stage: string;
+  detail: string;
+  body?: React.ReactNode;
+}[] = [
+  {
+    stage: "1 · Message",
+    detail: "A turn arrives from the assistant's session.",
+    body: (
+      <p className="rounded-lg border border-line bg-surface-sunken p-3 text-sm leading-relaxed text-fg">
+        &ldquo;We run Postgres 16 on RDS. Always have two people review a migration
+        before it ships. My AWS key is <span className="text-danger">AKIA…</span> if
+        you need it.&rdquo;
+      </p>
+    ),
+  },
+  {
+    stage: "2 · Capture",
+    detail: "The extractor proposes candidate memories. Nothing is stored yet.",
+  },
+  {
+    stage: "3 · Evaluate",
+    detail:
+      "The policy broker decides on each candidate, before any write. Its verdict is the record.",
+  },
+  {
+    stage: "4 · Store",
+    detail:
+      "Only admitted candidates become typed, provenanced, tenant-scoped state.",
+  },
+  {
+    stage: "5 · Retrieve & admit",
+    detail:
+      "On a later turn, retrieval is scoped to the tenant and the admission gate decides what may enter context.",
+  },
+  {
+    stage: "6 · Audit",
+    detail:
+      "The mutation and its audit event commit together, so the record cannot disagree with what happened.",
+  },
+];
+
+const CANDIDATES: {
+  content: string;
+  type: string;
+  verdict: Verdict;
+  reason: string;
+}[] = [
+  {
+    content: "Team runs Postgres 16 on RDS.",
+    type: "project",
+    verdict: "SAVE",
+    reason: "Durable, low-sensitivity project fact. Useful beyond this session.",
+  },
+  {
+    content: "Migrations require two-person review before shipping.",
+    type: "constraint",
+    verdict: "SAVE",
+    reason: "Stable working agreement. Stored as a constraint, not a preference.",
+  },
+  {
+    content: "AWS access key AKIA…",
+    type: "credential",
+    verdict: "BLOCK",
+    reason:
+      "Credential-shaped content is refused at the broker. It is never written, so it can never be retrieved.",
+  },
+];
+
+export default function DecisionTrace() {
+  return (
+    <Section id="decision-trace">
+      <SectionIntro eyebrow="How it works" title="One message, one governed decision">
+        Memory is not a side effect of a conversation. Each candidate is evaluated
+        on its own, and the verdict — with its reason — is what gets recorded.
+      </SectionIntro>
+
+      <IllustrativeBlock
+        kind="Illustrative"
+        note="A worked example. The message, candidates, verdicts and reasons below are written for explanation and did not come from a running instance."
+      >
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,22rem)_minmax(0,1fr)]">
+          <ol className="space-y-5 border-l border-line pl-5">
+            {STEPS.map((step) => (
+              <li key={step.stage} className="relative space-y-2">
+                <span
+                  aria-hidden
+                  className="absolute -left-[1.4375rem] top-1.5 h-2 w-2 rounded-full bg-accent ring-4 ring-canvas"
+                />
+                <p className="text-sm font-medium text-fg">{step.stage}</p>
+                <p className="text-xs leading-relaxed text-fg-secondary">
+                  {step.detail}
+                </p>
+                {step.body}
+              </li>
+            ))}
+          </ol>
+
+          <div className="space-y-5">
+            <div className="space-y-3">
+              <p className="text-label uppercase text-fg-muted">
+                Broker verdicts · 3 candidates
+              </p>
+              <ul className="space-y-2.5">
+                {CANDIDATES.map((c) => (
+                  <li
+                    key={c.content}
+                    className="rounded-lg border border-line bg-surface p-3.5"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p className="min-w-0 break-words text-sm text-fg">{c.content}</p>
+                      <Badge tone={VERDICT_TONE[c.verdict]}>{c.verdict}</Badge>
+                    </div>
+                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                      <Badge tone="quiet">{c.type}</Badge>
+                    </div>
+                    <p className="mt-2 text-xs leading-relaxed text-fg-muted">
+                      {c.reason}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="rounded-lg border border-line bg-surface p-4">
+              <p className="text-label uppercase text-fg-muted">
+                A later turn: &ldquo;draft the migration plan&rdquo;
+              </p>
+              <ul className="mt-3 space-y-2 text-sm leading-relaxed text-fg-secondary">
+                <li className="flex gap-2.5">
+                  <span aria-hidden className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-ok" />
+                  <span>
+                    Both saved memories are retrieved and admitted, and the answer is
+                    shaped by the two-person review constraint.
+                  </span>
+                </li>
+                <li className="flex gap-2.5">
+                  <span aria-hidden className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-danger" />
+                  <span>
+                    The credential is not retrieved, because it was never stored.
+                  </span>
+                </li>
+                <li className="flex gap-2.5">
+                  <span aria-hidden className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-info" />
+                  <span>
+                    The response carries a trace naming which memories entered context
+                    and why — <Code>memory_retrieved</Code>, <Code>memory_blocked</Code>{" "}
+                    and the rest land in the audit log.
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </IllustrativeBlock>
+    </Section>
+  );
+}

--- a/apps/web/components/public/sections/GovernanceSimulator.tsx
+++ b/apps/web/components/public/sections/GovernanceSimulator.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState } from "react";
+
+import { Badge, Button, Field, TextInput, type Tone } from "@/components/ui";
+import { IllustrativeBlock } from "../Illustrative";
+import { Section, SectionIntro } from "../PublicShell";
+import {
+  EXAMPLE_CANDIDATES,
+  RULE_SUMMARY,
+  SIMPLIFICATIONS,
+  simulate,
+  type SimulatedVerdict,
+} from "./simulate";
+
+/**
+ * Client-side policy illustration.
+ *
+ * Interactive because the point is felt rather than read: type a candidate, watch a
+ * verdict come back with a reason. It calls nothing — the whole rule set is in
+ * `simulate.ts` and runs in the browser.
+ *
+ * The rules it checks are listed on screen, and so is what it leaves out. A visitor
+ * should finish this section knowing they saw a simplification, which is why the
+ * simplifications are rendered next to the control rather than buried under it.
+ */
+
+const VERDICT_TONE: Record<SimulatedVerdict, Tone> = {
+  SAVE: "ok",
+  BLOCK: "danger",
+  "SESSION ONLY": "info",
+  REVIEW: "warn",
+  "NO MATCH": "quiet",
+};
+
+export default function GovernanceSimulator() {
+  const [candidate, setCandidate] = useState(EXAMPLE_CANDIDATES[0]);
+  const decision = simulate(candidate);
+
+  return (
+    <Section id="simulator">
+      <SectionIntro eyebrow="Policy" title="Try a policy decision">
+        Different candidates deserve different outcomes. Not everything worth saying
+        is worth remembering, and some of it must never be stored at all.
+      </SectionIntro>
+
+      <IllustrativeBlock
+        kind="Simulation"
+        note="A simplified illustration running entirely in your browser. It calls no MemoryOps API, stores nothing, and is not the policy broker — the real broker runs server-side and considers far more than the patterns below."
+      >
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,20rem)]">
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <p className="text-label uppercase text-fg-muted">Example candidates</p>
+              <div className="flex flex-wrap gap-2">
+                {EXAMPLE_CANDIDATES.map((example, i) => (
+                  <Button
+                    key={example}
+                    size="sm"
+                    variant={example === candidate ? "primary" : "secondary"}
+                    onClick={() => setCandidate(example)}
+                    className="max-w-full"
+                  >
+                    <span className="truncate">Example {i + 1}</span>
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            <Field
+              label="Candidate memory"
+              hint="Edit it, or write your own. Nothing you type leaves the page."
+            >
+              <TextInput
+                value={candidate}
+                onChange={(e) => setCandidate(e.target.value)}
+                placeholder="e.g. I prefer short answers with no emojis."
+              />
+            </Field>
+
+            <div
+              // Announced so a screen-reader user hears the verdict change as they
+              // type, rather than having to hunt for what moved.
+              role="status"
+              aria-live="polite"
+              className="min-h-[9rem] rounded-lg border border-line bg-surface p-4"
+            >
+              {decision === null ? (
+                <p className="text-sm text-fg-muted">
+                  Enter a candidate memory to see an illustrative verdict.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge tone={VERDICT_TONE[decision.verdict]}>
+                      {decision.verdict}
+                    </Badge>
+                    <span className="font-mono text-xs text-fg-muted">
+                      {decision.rule}
+                    </span>
+                  </div>
+                  <p className="text-sm leading-relaxed text-fg-secondary">
+                    {decision.rationale}
+                  </p>
+                  <p className="border-t border-line pt-3 text-xs text-fg-muted">
+                    <span className="text-fg-secondary">Outcome:</span>{" "}
+                    {decision.outcome}
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-5">
+            <div className="space-y-2">
+              <p className="text-label uppercase text-fg-muted">
+                What this illustration checks
+              </p>
+              <ol className="space-y-1.5">
+                {RULE_SUMMARY.map((rule, i) => (
+                  <li
+                    key={rule.label}
+                    className="flex items-start gap-2 text-xs leading-relaxed text-fg-secondary"
+                  >
+                    <span aria-hidden className="font-mono text-fg-muted">
+                      {i + 1}.
+                    </span>
+                    <span className="min-w-0">
+                      {rule.label}
+                      <span className="text-fg-muted"> → {rule.verdict}</span>
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-label uppercase text-fg-muted">
+                What it does not model
+              </p>
+              <ul className="space-y-1.5">
+                {SIMPLIFICATIONS.map((item) => (
+                  <li
+                    key={item}
+                    className="flex gap-2 text-xs leading-relaxed text-fg-muted"
+                  >
+                    <span aria-hidden className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-line-strong" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </IllustrativeBlock>
+    </Section>
+  );
+}

--- a/apps/web/components/public/sections/Hero.tsx
+++ b/apps/web/components/public/sections/Hero.tsx
@@ -1,0 +1,97 @@
+import Link from "next/link";
+
+/**
+ * First screen.
+ *
+ * One job: a visitor should leave it knowing MemoryOps is a governed memory layer
+ * for AI systems — not a vector database, not a chatbot. So the headline states the
+ * promise, the paragraph names the category in its first clause, and the strip
+ * underneath is the write path in six words rather than a feature list.
+ *
+ * No metrics, no logos, no badges. There is nothing true to put there yet, and a
+ * placeholder would be a fabrication.
+ */
+
+/**
+ * The path a memory travels, compressed. Stage names from the runtime, not
+ * marketing nouns — and not invented data, so it needs no illustrative label.
+ *
+ * Rendered as a vertical rail rather than a horizontal chip row: horizontally it
+ * wrapped mid-sequence at tablet widths, orphaning a leading "→" on its own line,
+ * and it left the right half of the hero empty on wide screens.
+ */
+const PATH: { step: string; note: string }[] = [
+  { step: "Candidate", note: "Extracted from the turn" },
+  { step: "Policy decision", note: "Before any write" },
+  { step: "Typed state", note: "Provenanced, tenant-scoped" },
+  { step: "Scoped retrieval", note: "Deleted memory never surfaces" },
+  { step: "Admission", note: "Relevant and allowed" },
+  { step: "Evidence", note: "Committed with the mutation" },
+];
+
+export default function Hero() {
+  return (
+    <section className="px-5 pb-16 pt-16 sm:px-8 sm:pb-20 sm:pt-24">
+      <div className="mx-auto grid max-w-6xl gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,20rem)] lg:items-start lg:gap-16">
+        <div className="max-w-3xl space-y-6">
+          <p className="text-label uppercase text-accent-strong">
+            Governed memory runtime
+          </p>
+
+          <h1 className="text-4xl font-semibold leading-[1.1] tracking-tight text-fg sm:text-5xl lg:text-6xl">
+            Govern what AI remembers.
+          </h1>
+
+          <p className="text-lg leading-relaxed text-fg-secondary">
+            MemoryOps AI is a governed memory layer for AI assistants and agents.
+            Every candidate memory passes a policy decision before it is stored, every
+            stored memory is typed and traceable to its source, and every memory that
+            reaches the model&apos;s context leaves an audit record explaining why.
+          </p>
+
+          <p className="text-base leading-relaxed text-fg-muted">
+            Most memory systems are a vector store with writes in front of them.
+            MemoryOps treats memory as governed state: something that is admitted,
+            explained, retained, forgotten and evidenced on purpose.
+          </p>
+
+          <div className="flex flex-wrap items-center gap-3 pt-2">
+            <Link
+              href="/chat"
+              className="inline-flex h-11 items-center justify-center rounded-lg bg-accent px-5 text-sm font-medium text-canvas transition-colors hover:bg-accent-strong"
+            >
+              Open control plane
+            </Link>
+            {/*
+             * Secondary CTA stays on this page. The technical architecture reference
+             * lives behind a clearly-labelled link further down, so a visitor is never
+             * moved into the operator-facing shell by the hero.
+             */}
+            <a
+              href="#decision-trace"
+              className="inline-flex h-11 items-center justify-center rounded-lg border border-line-strong bg-surface-raised px-5 text-sm font-medium text-fg transition-colors hover:bg-surface-hover"
+            >
+              See a memory decision
+            </a>
+          </div>
+        </div>
+
+        <div className="rounded-panel border border-line bg-surface p-5">
+          <p className="text-label uppercase text-fg-muted">Path of a memory</p>
+          <ol className="mt-4 space-y-4 border-l border-line pl-5">
+            {PATH.map((entry) => (
+              <li key={entry.step} className="relative">
+                <span
+                  aria-hidden
+                  className="absolute -left-[1.4375rem] top-1.5 h-2 w-2 rounded-full bg-accent/70 ring-4 ring-surface"
+                />
+                <p className="text-sm font-medium text-fg">{entry.step}</p>
+                <p className="text-xs leading-relaxed text-fg-muted">{entry.note}</p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/public/sections/Lifecycle.tsx
+++ b/apps/web/components/public/sections/Lifecycle.tsx
@@ -1,0 +1,51 @@
+import { Section, SectionIntro } from "../PublicShell";
+
+/**
+ * The nine lifecycle stages, in the product's own vocabulary.
+ *
+ * These are the stage names the codebase uses, not a marketing rewrite of them, so
+ * a reader who goes on to the docs or the API meets the same words.
+ */
+const STAGES: { stage: string; note: string }[] = [
+  { stage: "Capture", note: "Candidate memories are extracted from the turn." },
+  { stage: "Evaluate", note: "The policy broker decides before anything is written." },
+  { stage: "Store", note: "Typed, provenanced, tenant-scoped governed state." },
+  { stage: "Retrieve", note: "Scoped candidate search. Deleted memory never surfaces." },
+  { stage: "Rank", note: "Semantic, keyword, importance, recency, reinforcement." },
+  { stage: "Compose", note: "An admission gate decides what becomes model context." },
+  { stage: "Update", note: "Reinforcement, edits and conflict resolution." },
+  { stage: "Forget", note: "Retention windows, consent withdrawal, governed deletion." },
+  { stage: "Audit", note: "Every mutation commits together with its audit event." },
+];
+
+export default function Lifecycle() {
+  return (
+    <Section id="lifecycle">
+      <SectionIntro eyebrow="Lifecycle" title="Nine stages, each one governed">
+        Memory has a lifecycle whether or not a system models it. MemoryOps models it
+        explicitly, so each stage is a place where policy applies and evidence is
+        produced.
+      </SectionIntro>
+
+      <ol className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {STAGES.map((step, index) => (
+          <li
+            key={step.stage}
+            className="flex gap-3.5 rounded-panel border border-line bg-surface p-4"
+          >
+            <span
+              aria-hidden
+              className="mt-0.5 font-mono text-xs text-fg-muted"
+            >
+              {String(index + 1).padStart(2, "0")}
+            </span>
+            <div className="min-w-0 space-y-1">
+              <h3 className="text-sm font-medium text-fg">{step.stage}</h3>
+              <p className="text-xs leading-relaxed text-fg-secondary">{step.note}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </Section>
+  );
+}

--- a/apps/web/components/public/sections/simulate.ts
+++ b/apps/web/components/public/sections/simulate.ts
@@ -1,0 +1,140 @@
+/**
+ * The public page's illustrative policy simulation.
+ *
+ * This is **not** the policy broker. It is five regular expressions running in the
+ * visitor's browser, and it exists to make the *shape* of a governed decision
+ * tangible — a candidate goes in, a verdict and a reason come out — without calling
+ * the real API.
+ *
+ * Three deliberate constraints:
+ *
+ *  1. It runs entirely client-side and reaches nothing. The public page must stay
+ *     session-independent (see `__tests__/public-landing-independence.test.ts`), and
+ *     a marketing page must never be able to write to a tenant's memory.
+ *  2. Every result names the rule that produced it. A visitor who sees
+ *     "matched: credential-shaped token" understands they are looking at a pattern
+ *     match, not a judgement — which is a more honest illustration than a confident
+ *     verdict with no visible reasoning.
+ *  3. Unmatched input returns `NO_MATCH` rather than guessing. The real broker
+ *     scores utility, confidence, duplication and tenant policy; inventing a verdict
+ *     here would misrepresent it in the one direction that matters.
+ *
+ * The real broker's inputs are listed in `SIMPLIFICATIONS` and shown in the UI.
+ */
+
+export type SimulatedVerdict =
+  | "SAVE"
+  | "BLOCK"
+  | "SESSION ONLY"
+  | "REVIEW"
+  | "NO MATCH";
+
+export interface SimulatedDecision {
+  readonly verdict: SimulatedVerdict;
+  /** The pattern that fired, in plain words. Shown to the visitor. */
+  readonly rule: string;
+  readonly rationale: string;
+  /** What the runtime would do with the candidate. */
+  readonly outcome: string;
+}
+
+interface Rule {
+  readonly pattern: RegExp;
+  readonly label: string;
+  readonly decision: Omit<SimulatedDecision, "rule">;
+}
+
+/**
+ * Ordered. The first match wins, and credentials are checked first on purpose:
+ * "remember my api key for this session" must block, not become session-scoped.
+ */
+const RULES: readonly Rule[] = [
+  {
+    // The word boundary is per-alternative, not wrapped around the whole group:
+    // `\b` cannot match before the `-` in `-----BEGIN`, so a hoisted `\b(…)` let
+    // PEM private-key headers fall through to NO MATCH entirely.
+    pattern:
+      /(\bsk-[a-z0-9]|\bAKIA[0-9A-Z]|\bghp_|\bxox[baprs]-|-----BEGIN|\bpassword\s*[:=]|\bapi[\s_-]?key|\bsecret[\s_-]?key|\bbearer\s+[a-z0-9._-]{8})/i,
+    label: "credential-shaped token",
+    decision: {
+      verdict: "BLOCK",
+      rationale:
+        "Content that looks like a secret is refused before storage. Nothing is written, so it can never be retrieved or leak into a later answer.",
+      outcome: "Not stored. The refusal itself is audited.",
+    },
+  },
+  {
+    pattern:
+      /\b(only for (this|the current)|just for (this|now)|this (conversation|chat|session) only|don'?t (remember|save|store)|do not (remember|save|store)|temporar(y|ily))\b/i,
+    label: "session-scoped instruction",
+    decision: {
+      verdict: "SESSION ONLY",
+      rationale:
+        "The user scoped this to the current conversation. It can inform this session without becoming durable memory.",
+      outcome: "Held for the session. Nothing persists after it ends.",
+    },
+  },
+  {
+    pattern:
+      /\b(acquisition|acquire|merger|layoffs?|redundanc(y|ies)|salary|compensation|termination|lawsuit|litigation|confidential|unreleased|under embargo|nda)\b/i,
+    label: "high-sensitivity business content",
+    decision: {
+      verdict: "REVIEW",
+      rationale:
+        "Sensitive enough that an automatic write is the wrong default. It waits in the approval queue for a human decision.",
+      outcome: "Queued for approval. Not retrievable until approved.",
+    },
+  },
+  {
+    pattern:
+      /\b(prefer|prefers|preference|always|never|use|uses|using|default to|stick to|we run|i am|i'?m|my|our|team)\b/i,
+    label: "durable preference or working fact",
+    decision: {
+      verdict: "SAVE",
+      rationale:
+        "A stable, low-sensitivity statement that stays useful beyond this turn. Stored as typed memory with its source.",
+      outcome: "Stored, provenanced, and retrievable within this tenant.",
+    },
+  },
+];
+
+const NO_MATCH: SimulatedDecision = {
+  verdict: "NO MATCH",
+  rule: "no illustrative rule matched",
+  rationale:
+    "This simplified illustration only recognises the four patterns above. The real broker would still reach a verdict here — it scores utility, confidence, duplication and tenant policy, none of which are modelled on this page.",
+  outcome: "Undetermined by this illustration.",
+};
+
+/** What this simulation leaves out. Rendered next to it, not hidden in a comment. */
+export const SIMPLIFICATIONS: readonly string[] = [
+  "Sensitivity tiers and per-tenant policy packs",
+  "Confidence and importance scoring",
+  "Duplicate detection and reinforcement of existing memory",
+  "Legal hold, consent state and retention windows",
+  "The LLM-assisted extractor that produces candidates in the first place",
+];
+
+/** The four candidates offered as one-click examples. */
+export const EXAMPLE_CANDIDATES: readonly string[] = [
+  "User prefers metric units in all explanations.",
+  "My OpenAI key is sk-live-8f3a2c laid out in the config.",
+  "Use this only for this conversation: the client is called Northwind.",
+  "The company acquisition target is a competitor in the logistics space.",
+];
+
+export function simulate(candidate: string): SimulatedDecision | null {
+  const text = candidate.trim();
+  if (!text) return null;
+
+  for (const rule of RULES) {
+    if (rule.pattern.test(text)) {
+      return { ...rule.decision, rule: `matched: ${rule.label}` };
+    }
+  }
+  return NO_MATCH;
+}
+
+/** Rule descriptions for the "what this checks" list, in evaluation order. */
+export const RULE_SUMMARY: readonly { label: string; verdict: SimulatedVerdict }[] =
+  RULES.map((r) => ({ label: r.label, verdict: r.decision.verdict }));

--- a/apps/web/components/shell/NavIcon.tsx
+++ b/apps/web/components/shell/NavIcon.tsx
@@ -13,15 +13,6 @@ import type { NavGlyph } from "./navigation";
  * decorative: every link has a text label, so the SVG is `aria-hidden`.
  */
 const PATHS: Record<NavGlyph, React.ReactNode> = {
-  // Four panes — the whole surface at a glance.
-  overview: (
-    <>
-      <rect x="2.5" y="2.5" width="4.5" height="4.5" rx="1" />
-      <rect x="9" y="2.5" width="4.5" height="4.5" rx="1" />
-      <rect x="2.5" y="9" width="4.5" height="4.5" rx="1" />
-      <rect x="9" y="9" width="4.5" height="4.5" rx="1" />
-    </>
-  ),
   // A turn of conversation.
   chat: (
     <>

--- a/apps/web/components/shell/SidebarNav.tsx
+++ b/apps/web/components/shell/SidebarNav.tsx
@@ -30,8 +30,11 @@ export default function SidebarNav({
   return (
     <div className="flex h-full flex-col">
       <div className="border-b border-line px-4 py-4">
+        {/* Points at the control plane's first surface, not `/`. Since v2.6 `/` is
+            the public product page, so a brand link there would walk an operator
+            out of the application they are working in. */}
         <Link
-          href="/"
+          href="/chat"
           onClick={onNavigate}
           className="flex items-center gap-2.5 rounded-md text-sm font-semibold tracking-tight text-fg"
         >

--- a/apps/web/components/shell/navigation.ts
+++ b/apps/web/components/shell/navigation.ts
@@ -11,7 +11,6 @@
  */
 
 export type NavGlyph =
-  | "overview"
   | "chat"
   | "memories"
   | "governance"
@@ -37,12 +36,9 @@ export const NAV_GROUPS: readonly NavGroup[] = [
   {
     label: "Runtime",
     items: [
-      {
-        href: "/",
-        label: "Overview",
-        summary: "What MemoryOps governs and how the lifecycle fits together",
-        glyph: "overview",
-      },
+      // `/` is deliberately absent. Since v2.6 it is the public product page, not a
+      // control-plane surface — listing it here would send an operator from the
+      // sidebar straight out of the application and into the marketing shell.
       {
         href: "/chat",
         label: "Chat",
@@ -126,14 +122,21 @@ export function activeNavItem(pathname: string): NavItem | undefined {
 }
 
 /**
- * Routes that render without the control-plane chrome.
+ * Routes that render without the control-plane chrome, because they supply their
+ * own: `/` uses the public product shell, `/signin` is a bare centred form.
  *
- * Presentation only. `/signin` is the one surface where a sidebar full of links the
- * visitor cannot yet open would be noise rather than navigation.
+ * Presentation only — this grants and protects nothing. `/` is public because
+ * middleware.ts says so, not because it appears here.
+ *
+ * `/` is matched **exactly** and must never move into `CHROMELESS_PREFIXES`. Prefix
+ * matching on `/` would strip the sidebar from every authenticated surface in the
+ * app, which is the same trap the middleware's public-path matching had to avoid.
  */
+const CHROMELESS_EXACT = new Set<string>(["/"]);
 const CHROMELESS_PREFIXES = ["/signin"] as const;
 
 export function isChromeless(pathname: string): boolean {
+  if (CHROMELESS_EXACT.has(pathname)) return true;
   return CHROMELESS_PREFIXES.some(
     (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
   );


### PR DESCRIPTION
Builds the public product page on `/` — seven sections, a dedicated public shell, and a client-side policy illustration.

**The authorization change making `/` public already landed separately, in #154.** This PR changes no auth semantics: `middleware.ts`, `auth.ts`, `lib/identity.ts`, `lib/capabilities.ts`, `lib/scope.ts`, the BFF proxy and `/api/auth` are all absent from the diff.

No API, backend, database, Railway, CI or dependency changes. 16 files, `apps/web` only.

---

## The seven sections

Ordered for a first-time visitor rather than for completeness — state the category, show one concrete governed decision, and only then get into detail:

1. **Hero** — establishes that MemoryOps is a governed memory layer for AI assistants and agents, before any technical vocabulary arrives.
2. **Decision trace** — one message followed end to end: capture → evaluate → store → retrieve & admit → audit, with three candidates receiving three different verdicts.
3. **Before / With** — architectural contrast between direct-write memory and governed memory.
4. **Governance simulator** — interactive, client-side, illustrative.
5. **Memory lifecycle** — the nine stages, in the runtime's own vocabulary.
6. **Capabilities** — implemented capability areas, with limits stated.
7. **Architecture preview** — self-contained system summary.

## PublicShell

`AppShell` exists to tell an operator which tenant they are acting on and to move them between governed surfaces. A visitor who is not signed in has no tenant and cannot open any of those links, so rendering them a sidebar of redirects-to-sign-in is noise dressed as navigation.

`components/public/PublicShell.tsx` is a header, a footer and three in-page anchors — a server component with no state, so `/` ships no shell JavaScript. It uses the same tokens and primitives as the control plane rather than a second visual language.

`isChromeless` gained an exact-match list so `AppShell` stands aside for `/`. That list is exact rather than prefix-matched for the same reason the middleware's public paths are: prefix-matching `/` would strip the sidebar from every authenticated surface in the app.

## Architecture-preview seam

The preview is deliberately self-contained on `/`. `/architecture` is the operator-facing technical reference and still renders inside the control-plane shell, so the only link out is **secondary**, labelled "View the technical architecture reference →" and captioned *"Detailed system view, written for engineers and operators"* — the shell transition is expected rather than surprising.

`/architecture` itself is untouched in this PR and remains operational and compatible with its production healthcheck role.

## The simulator is illustrative, and says so

Five regular expressions running in the visitor's browser. It calls nothing, stores nothing, and is not the policy broker.

- Labelled **Simulation** with a disclaimer inside the same bordered region as the content, so it cannot be read as belonging to a neighbouring section.
- Every result names the rule that produced it — "matched: credential-shaped token" is a more honest illustration than a confident verdict with no visible reasoning.
- Verdicts: `SAVE`, `BLOCK`, `SESSION ONLY`, `REVIEW`, and `NO MATCH` for unrecognised input rather than a guess — inventing a verdict would misrepresent the real broker in the one direction that matters.
- What it does **not** model (sensitivity tiers, confidence scoring, duplicate detection, legal hold, the extractor) is rendered beside the control, not beneath it.

## Authenticated navigation adjustment

Two consequences of `/` no longer being a control-plane surface, handled here rather than left as loose ends:

- `/` removed from the sidebar's Runtime group.
- Sidebar brand link now points at `/chat`, and the now-unused `overview` glyph is removed.

Both previously walked an operator out of the application they were working in. These are presentation/navigation changes only — `navigation.ts` is a presentation model and documents itself as such. Route protection, session requirements, BFF authorization and role/capability semantics are unchanged.

## Real browser validation

System Chrome driven over CDP from a scratchpad script using Node's built-in WebSocket. **No Playwright/Puppeteer or any other dependency was added**, and none is proposed for CI.

| Check | Result |
| --- | --- |
| Horizontal overflow @ 360 / 390 / 768 / 1024 / 1440 / 1920 | **0px at every width** |
| Tab order | starts at the skip link; every focusable stop shows a focus ring |
| Simulator live | Example 2 flips the verdict to BLOCK; input syncs; `aria-live` announces |
| Console errors / warnings / exceptions | **0** on `/` and `/architecture` |
| Hydration mismatches | **0** |
| Route matrix | `/`, `/architecture`, `/signin` → 200; all six application routes → 307 to sign-in |

Two layout defects were found this way and fixed: the hero left the right half of a 1440px viewport empty, and the write-path chip row wrapped mid-sequence at 768px, orphaning a leading arrow. Both are now a single vertical "Path of a memory" rail.

One methodology correction worth recording: initial screenshots used Chrome's `--window-size` + `--screenshot` flags and appeared to show severe mobile clipping. That was an artefact — those flags render wide and crop rather than emulating a viewport. Proper `Emulation.setDeviceMetricsOverride` showed 0px overflow. The method was corrected rather than a non-existent bug "fixed".

## Claims discipline

No adoption figures, customer names or logos, benchmark results, latency or throughput numbers, compliance certifications, scale guarantees, or competitor comparisons. There is nothing true to put in those places, and a placeholder would be a fabrication rather than an illustration.

Qualifications deliberately preserved:

- tamper-evidence is **not** tamper-proofing
- governed deletion is **not** cryptographic erasure
- Before/With compares two **architectures, not two products** — it names no vendor and says so explicitly

## Guards

- `public-landing-independence.test.ts` now sweeps the entire `components/public/` tree, not only what the page imports, so a section written now and wired in later cannot smuggle in a session dependency. It also fails on any `fetch`/`XMLHttpRequest`/`EventSource`/`WebSocket` in that tree.
- `governance-simulator.test.ts` covers rule ordering — which caught a real bug: `\b` cannot match before the `-` in `-----BEGIN`, so a hoisted word boundary sent PEM private-key headers to `NO MATCH` instead of `BLOCK`.

Local: 141/141 web tests, lint clean, typecheck clean, both build modes pass.

## Secret-scan note

An initial local test fixture (`api_key=abc123def456`) tripped gitleaks' `generic-api-key` rule. The fixture was replaced with an inert value; **no allowlist entry and no rule suppression were added** — an allowlist there is exactly what hides a real leak later. Final local scan: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)