### PR TITLE
fix(web): harden v2.6 UX and accessibility

### DIFF
--- a/apps/web/__tests__/drawer-focus-contract.test.ts
+++ b/apps/web/__tests__/drawer-focus-contract.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The mobile drawer's keyboard contract.
+ *
+ * Browser evidence is the real proof here and was captured over CDP; these
+ * assertions exist so the contract cannot be deleted silently between browser runs.
+ * The test environment is node-only by design (no DOM, no jsdom dependency), so what
+ * is checked is the presence of each load-bearing behaviour, not its rendered effect.
+ *
+ * Two defects motivate it, both measured before the fix at 390px:
+ *
+ *   - Tab from the last nav link walked into the page *behind* the scrim (6 of 14
+ *     stops landed outside the drawer). `aria-modal` tells assistive tech the
+ *     background is inert but moves no focus, so an operator could reach and
+ *     activate a Delete button hidden underneath the overlay.
+ *   - Dismissing with Escape left focus wherever the DOM happened to drop it — in
+ *     practice the memories table's scroll region — instead of the toggle.
+ */
+
+const src = readFileSync(
+  join(__dirname, "..", "components", "shell", "AppShell.tsx"),
+  "utf8",
+);
+const code = src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+
+describe("drawer keyboard contract", () => {
+  it("handles Tab, not only Escape", () => {
+    expect(code).toMatch(/event\.key !== "Tab"|event\.key === "Tab"/);
+  });
+
+  it("wraps focus at both ends of the drawer", () => {
+    // Shift+Tab off the first item must land on the last, and vice versa.
+    expect(code).toMatch(/shiftKey/);
+    expect(code).toMatch(/preventDefault\(\)/);
+  });
+
+  it("pulls focus back in if it is already outside", () => {
+    expect(code).toMatch(/contains\(active\)|contains\(document\.activeElement\)/);
+  });
+
+  it("remembers what to restore focus to when it opens", () => {
+    expect(code).toMatch(/restoreFocusRef/);
+    expect(code).toMatch(/document\.activeElement as HTMLElement/);
+  });
+
+  it("restores focus on dismissal rather than in an effect cleanup", () => {
+    // By cleanup time the panel is unmounted and focus has fallen to <body>, so the
+    // "was focus inside?" question is no longer answerable.
+    const close = code.slice(code.indexOf("const closeNav"), code.indexOf("const dismissForNavigation"));
+    expect(close).toMatch(/restoreFocusRef\.current/);
+    expect(close).toMatch(/focus\(\)/);
+  });
+
+  it("does not steal focus back when the user is navigating away", () => {
+    const dismiss = code.slice(code.indexOf("const dismissForNavigation"));
+    const body = dismiss.slice(0, dismiss.indexOf(";") + 1);
+    expect(body).not.toMatch(/restoreFocusRef/);
+    // The nav links use the non-restoring dismissal.
+    expect(code).toMatch(/onNavigate=\{dismissForNavigation\}/);
+  });
+
+  it("routes Escape through the restoring path", () => {
+    expect(code).toMatch(/if \(event\.key === "Escape"\) \{\s*closeNav\(\);/);
+  });
+
+  it("keeps the toggle's expanded state and target wired up", () => {
+    const topbar = readFileSync(
+      join(__dirname, "..", "components", "shell", "TopBar.tsx"),
+      "utf8",
+    );
+    expect(topbar).toMatch(/aria-expanded=\{navOpen\}/);
+    expect(topbar).toMatch(/aria-controls="control-plane-nav"/);
+    expect(code).toMatch(/id="control-plane-nav"/);
+  });
+
+  it("still locks background scroll while open", () => {
+    expect(code).toMatch(/document\.body\.style\.overflow = "hidden"/);
+  });
+});

--- a/apps/web/__tests__/shell-landmarks.test.ts
+++ b/apps/web/__tests__/shell-landmarks.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { isChromeless } from "@/components/shell/navigation";
+
+/**
+ * Landmark ownership between the two shells.
+ *
+ * `/` renders `PublicShell` inside `AppShell`'s chromeless branch. When *both*
+ * emitted `<main id="main-content">`, the landing page shipped two nested `<main>`
+ * elements and a duplicate DOM id — so landmark navigation offered a phantom
+ * region and the skip link resolved to the outer wrapper instead of the content.
+ *
+ * The rule this locks in: a chromeless route supplies its own landmarks, and
+ * `AppShell` supplies them only for routes it actually wraps in chrome.
+ */
+
+const WEB_ROOT = join(__dirname, "..");
+const read = (...p: string[]) => readFileSync(join(WEB_ROOT, ...p), "utf8");
+
+/** Strip comments so prose describing the bug does not count as code. */
+function code(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+describe("main landmark ownership", () => {
+  it("AppShell emits exactly one <main>, in its chrome branch only", () => {
+    const mains = code(read("components", "shell", "AppShell.tsx")).match(/<main\b/g) ?? [];
+    expect(mains).toHaveLength(1);
+  });
+
+  it("the chromeless branch returns children without wrapping them", () => {
+    const src = code(read("components", "shell", "AppShell.tsx"));
+    const branch = src.slice(src.indexOf("isChromeless(pathname)"), src.indexOf("return (\n    <div"));
+    expect(branch).not.toMatch(/<main\b/);
+  });
+
+  it("every chromeless route's own shell supplies a main landmark", () => {
+    // `/` -> PublicShell, `/signin` -> the page itself.
+    for (const [label, source] of [
+      ["PublicShell", read("components", "public", "PublicShell.tsx")],
+      ["signin page", read("app", "signin", "page.tsx")],
+    ] as const) {
+      const mains = code(source).match(/<main\b/g) ?? [];
+      expect(mains, label).toHaveLength(1);
+      expect(code(source), label).toContain('id="main-content"');
+    }
+  });
+
+  it("routes that keep the chrome do not also ship their own main", () => {
+    for (const page of [
+      ["app", "chat", "page.tsx"],
+      ["app", "memories", "page.tsx"],
+      ["app", "governance", "page.tsx"],
+      ["app", "audit", "page.tsx"],
+      ["app", "loops", "page.tsx"],
+      ["app", "admin", "page.tsx"],
+      ["app", "architecture", "page.tsx"],
+    ]) {
+      expect(code(read(...page)), page.join("/")).not.toMatch(/<main\b/);
+    }
+  });
+});
+
+describe("isChromeless still matches only the two intended routes", () => {
+  it("covers / and /signin", () => {
+    expect(isChromeless("/")).toBe(true);
+    expect(isChromeless("/signin")).toBe(true);
+  });
+
+  it("leaves every application surface in the chrome", () => {
+    for (const route of [
+      "/chat",
+      "/memories",
+      "/memories/mem_01H8XYZ",
+      "/governance",
+      "/audit",
+      "/loops",
+      "/admin",
+      "/architecture",
+    ]) {
+      expect(isChromeless(route), route).toBe(false);
+    }
+  });
+});

--- a/apps/web/__tests__/text-wrapping.test.ts
+++ b/apps/web/__tests__/text-wrapping.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Long unbroken tokens must never push the document sideways.
+ *
+ * MemoryOps renders a lot of verbatim, server-supplied text: provenance excerpts,
+ * audit reasons, loop event reasons, memory content. Real messages contain URLs and
+ * opaque identifiers, and a token with no break opportunity paints straight past its
+ * container — `getBoundingClientRect` still reports the box as in-bounds while the
+ * *document* grows, which is why this is easy to ship without noticing.
+ *
+ * It was shipped: a memory whose source excerpt held a runbook URL gave
+ * `/memories/{id}` 78px of horizontal overflow at 360px, traced to `SourceQuote`.
+ *
+ * These assertions are structural because the failure is structural — the fix is a
+ * wrapping declaration on the element that renders free text, and its absence is
+ * exactly what regresses.
+ */
+
+const WEB_ROOT = join(__dirname, "..");
+const read = (...p: string[]) => readFileSync(join(WEB_ROOT, ...p), "utf8");
+
+/** Tailwind classes that give a long token somewhere to break. */
+const WRAPS = /break-words|break-all|overflow-wrap|\[overflow-wrap|truncate|line-clamp|overflow-hidden|overflow-auto|whitespace-pre-wrap/;
+
+describe("primitives that render free text can break long tokens", () => {
+  const cases: [string, string[], string][] = [
+    ["SourceQuote", ["components", "ui", "Values.tsx"], "SourceQuote"],
+    ["KeyValue", ["components", "ui", "Values.tsx"], "KeyValue"],
+    ["TimelineItem description", ["components", "ui", "Timeline.tsx"], "description ?"],
+    ["ErrorState detail", ["components", "ui", "States.tsx"], "detail ?"],
+  ];
+
+  for (const [label, path, marker] of cases) {
+    it(`${label} declares a wrapping rule`, () => {
+      const src = read(...path);
+      const start = src.indexOf(marker);
+      expect(start, `${marker} not found`).toBeGreaterThan(-1);
+      // Look at the JSX immediately following the marker, where the class lives.
+      expect(src.slice(start, start + 700), label).toMatch(WRAPS);
+    });
+  }
+});
+
+describe("MonoId keeps the full identifier addressable", () => {
+  it("clips with CSS rather than slicing the value", () => {
+    const src = read("components", "ui", "Values.tsx");
+    const block = src.slice(src.indexOf("export function MonoId"));
+    // Truncating with `.slice()` would make a copied id silently wrong.
+    expect(block.slice(0, 900)).not.toMatch(/value\.slice\(/);
+    expect(block.slice(0, 900)).toMatch(/overflow-hidden/);
+    expect(block.slice(0, 900)).toMatch(/title=\{value\}/);
+  });
+});
+
+describe("the registry does not strand columns off-screen on small viewports", () => {
+  const src = readFileSync(join(WEB_ROOT, "components", "memories", "MemoryTable.tsx"), "utf8");
+
+  it("renders a card presentation below the table breakpoint", () => {
+    expect(src).toMatch(/md:hidden/);
+    expect(src).toMatch(/hidden md:block/);
+  });
+
+  it("the card carries every field the row does", () => {
+    const card = src.slice(src.indexOf("md:hidden"), src.indexOf("hidden md:block"));
+    for (const field of [
+      "StatusBadge",
+      "memory_type",
+      "sensitivity",
+      "importance",
+      "confidence",
+      "source.kind",
+      "MemoryActions",
+    ]) {
+      expect(card, field).toContain(field);
+    }
+  });
+
+  it("removes the inactive presentation instead of only hiding it visually", () => {
+    // `sr-only` would leave both in the accessibility tree; `hidden` does not.
+    expect(src).not.toMatch(/sr-only[^"]*md:block/);
+  });
+});
+
+describe("no public component reintroduces an unwrapped free-text block", () => {
+  function walk(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+      const full = join(dir, e.name);
+      return e.isDirectory() ? walk(full) : /\.tsx?$/.test(e.name) ? [full] : [];
+    });
+  }
+
+  it("keeps whitespace-nowrap off long-form text containers", () => {
+    // nowrap belongs on short enum-shaped values (badges, table headers), never on
+    // a paragraph of server-supplied prose.
+    const offenders: string[] = [];
+    for (const file of walk(join(WEB_ROOT, "components"))) {
+      const src = readFileSync(file, "utf8");
+      for (const m of src.matchAll(/<p[^>]*className="([^"]*whitespace-nowrap[^"]*)"/g)) {
+        offenders.push(`${file.slice(WEB_ROOT.length + 1)}: ${m[1]}`);
+      }
+    }
+    expect(offenders, offenders.join("\n")).toEqual([]);
+  });
+});

--- a/apps/web/app/memories/[id]/page.tsx
+++ b/apps/web/app/memories/[id]/page.tsx
@@ -19,7 +19,7 @@ export default function MemoryDetailPage() {
         actions={
           <Link
             href="/memories"
-            className="rounded-md text-sm text-fg-secondary underline-offset-4 hover:text-fg hover:underline"
+            className="inline-flex min-h-[2.25rem] items-center rounded-md text-sm text-fg-secondary underline-offset-4 hover:text-fg hover:underline"
           >
             ← Back to memories
           </Link>

--- a/apps/web/app/signin/page.tsx
+++ b/apps/web/app/signin/page.tsx
@@ -29,7 +29,10 @@ export default function SignInPage({
   const failed = Boolean(searchParams?.error);
 
   return (
-    <div className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-6 py-16">
+    <main
+      id="main-content"
+      className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-6 py-16"
+    >
       <div className="mb-8 space-y-2">
         <span className="flex items-center gap-2.5 text-sm font-semibold tracking-tight text-fg">
           <span
@@ -89,6 +92,6 @@ export default function SignInPage({
         Your session determines the tenant and user every request is scoped to. The
         browser never chooses that scope — it is attached server-side on each call.
       </p>
-    </div>
+    </main>
   );
 }

--- a/apps/web/components/audit/AuditTimeline.tsx
+++ b/apps/web/components/audit/AuditTimeline.tsx
@@ -65,7 +65,7 @@ export default function AuditTimeline({
               {e.memory_id ? (
                 <Link
                   href={`/memories/${e.memory_id}`}
-                  className="rounded-sm underline-offset-4 hover:underline"
+                  className="inline-flex min-h-[2rem] items-center rounded-sm underline-offset-4 hover:underline"
                 >
                   <MonoId label="memory" value={e.memory_id} chars={10} />
                 </Link>

--- a/apps/web/components/governance/PolicyDecisionCard.tsx
+++ b/apps/web/components/governance/PolicyDecisionCard.tsx
@@ -60,7 +60,7 @@ export default function PolicyDecisionCard({ event }: { event: AuditEvent }) {
           {event.memory_id ? (
             <Link
               href={`/memories/${event.memory_id}`}
-              className="ml-auto rounded-sm text-xs text-accent-strong underline-offset-4 hover:underline"
+              className="ml-auto inline-flex min-h-[2rem] items-center rounded-sm text-xs text-accent-strong underline-offset-4 hover:underline"
             >
               View memory →
             </Link>

--- a/apps/web/components/loops/LoopRunTable.tsx
+++ b/apps/web/components/loops/LoopRunTable.tsx
@@ -12,9 +12,11 @@ import {
   toneForRunStatus,
 } from "@/components/ui";
 
+// Four informational columns and no controls, so 26rem is what the widest row
+// genuinely needs — the region scrolls far less than the registry's default.
 export default function LoopRunTable({ runs }: { runs: LoopRun[] }) {
   return (
-    <DataTable caption="Recent loop runs" className="min-w-0">
+    <DataTable caption="Recent loop runs" className="min-w-0" minWidth="26rem">
       <THead>
         <TH>Loop</TH>
         <TH>Status</TH>

--- a/apps/web/components/memories/MemoryTable.tsx
+++ b/apps/web/components/memories/MemoryTable.tsx
@@ -7,6 +7,7 @@ import type { UiCapabilities } from "@/lib/capabilities";
 import {
   Badge,
   DataTable,
+  EmptyState,
   StatusBadge,
   TBody,
   TD,
@@ -18,12 +19,19 @@ import {
 import MemoryActions from "./MemoryActions";
 
 /**
- * The memory registry table.
+ * The memory registry, in two presentations of the same records.
  *
- * Content is the scanning column and gets the width; every other column is a fixed,
- * narrow, comparable value. The row does not become a link — the actions cell holds
- * real buttons, and nesting interactive controls inside a link is both invalid and
- * unusable with a keyboard.
+ * Below `md` the eight-column table is replaced by a card list rather than left to
+ * scroll sideways. The table needs ~40rem, so on a 390px viewport Status
+ * and Actions sat roughly 600px off-screen inside the scroll region: an operator
+ * could not see a memory's lifecycle state, let alone act on it, without discovering
+ * that the region scrolled horizontally at all.
+ *
+ * The card carries every field the row does — content, type, sensitivity, importance,
+ * confidence, status, source and the same actions — so this is a reflow, not a
+ * mobile-only subset. Only one presentation is in the accessibility tree at a time;
+ * the hidden one is removed with `hidden`, not merely visually clipped, so a screen
+ * reader never encounters both.
  */
 export default function MemoryTable({
   rows,
@@ -36,54 +44,118 @@ export default function MemoryTable({
   onChanged: () => void | Promise<void>;
   capabilities?: UiCapabilities;
 }) {
+  const empty = !loading && rows.length === 0;
+
   return (
-    <DataTable caption="Governed memories">
-      <THead>
-        <TH className="w-[38%]">Content</TH>
-        <TH>Type</TH>
-        <TH>Sensitivity</TH>
-        <TH className="text-right">Imp.</TH>
-        <TH className="text-right">Conf.</TH>
-        <TH>Status</TH>
-        <TH>Source</TH>
-        <TH>Actions</TH>
-      </THead>
-      <TBody>
-        {rows.map((m) => (
-          <TR key={m.id}>
-            <TD className="text-fg">
-              <Link
-                href={`/memories/${m.id}`}
-                className="line-clamp-3 rounded-sm hover:text-accent-strong hover:underline"
+    <>
+      {/* ── narrow: card list ─────────────────────────────────────────────── */}
+      <div className="md:hidden">
+        {empty ? (
+          <EmptyState title="No memories match these filters." />
+        ) : (
+          <ul className="space-y-3">
+            {rows.map((m) => (
+              <li
+                key={m.id}
+                className="space-y-3 rounded-panel border border-line bg-surface p-4"
               >
-                {m.content}
-              </Link>
-            </TD>
-            <TD>
-              <Badge tone="quiet">{m.memory_type}</Badge>
-            </TD>
-            <TD className="whitespace-nowrap">{m.sensitivity}</TD>
-            <TD className="text-right font-mono text-xs">{m.importance}</TD>
-            <TD className="text-right font-mono text-xs">{m.confidence.toFixed(2)}</TD>
-            <TD>
-              <StatusBadge status={m.status} />
-            </TD>
-            <TD className="whitespace-nowrap text-xs" title={m.source.excerpt}>
-              {m.source.kind}
-            </TD>
-            <TD>
-              <MemoryActions
-                memory={m}
-                onChanged={onChanged}
-                capabilities={capabilities}
-              />
-            </TD>
-          </TR>
-        ))}
-        {!loading && rows.length === 0 ? (
-          <TableEmptyRow colSpan={8}>No memories match these filters.</TableEmptyRow>
-        ) : null}
-      </TBody>
-    </DataTable>
+                <div className="flex flex-wrap items-center gap-2">
+                  <StatusBadge status={m.status} />
+                  <Badge tone="quiet">{m.memory_type}</Badge>
+                </div>
+
+                <Link
+                  href={`/memories/${m.id}`}
+                  className="block break-words rounded-sm text-sm leading-relaxed text-fg underline-offset-4 hover:text-accent-strong hover:underline"
+                >
+                  {m.content}
+                </Link>
+
+                <dl className="grid grid-cols-2 gap-x-4 gap-y-2 border-t border-line pt-3 text-xs">
+                  <div>
+                    <dt className="text-fg-muted">Sensitivity</dt>
+                    <dd className="text-fg-secondary">{m.sensitivity}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-fg-muted">Source</dt>
+                    <dd className="break-words text-fg-secondary">{m.source.kind}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-fg-muted">Importance</dt>
+                    <dd className="font-mono text-fg-secondary">{m.importance}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-fg-muted">Confidence</dt>
+                    <dd className="font-mono text-fg-secondary">
+                      {m.confidence.toFixed(2)}
+                    </dd>
+                  </div>
+                </dl>
+
+                <div className="border-t border-line pt-3">
+                  <MemoryActions
+                    memory={m}
+                    onChanged={onChanged}
+                    capabilities={capabilities}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* ── md and wider: dense table ─────────────────────────────────────── */}
+      <div className="hidden md:block">
+        <DataTable caption="Governed memories">
+          <THead>
+            <TH className="w-[38%]">Content</TH>
+            <TH>Type</TH>
+            <TH>Sensitivity</TH>
+            <TH className="text-right">Imp.</TH>
+            <TH className="text-right">Conf.</TH>
+            <TH>Status</TH>
+            <TH>Source</TH>
+            <TH>Actions</TH>
+          </THead>
+          <TBody>
+            {rows.map((m) => (
+              <TR key={m.id}>
+                <TD className="text-fg">
+                  <Link
+                    href={`/memories/${m.id}`}
+                    className="line-clamp-3 break-words rounded-sm hover:text-accent-strong hover:underline"
+                  >
+                    {m.content}
+                  </Link>
+                </TD>
+                <TD>
+                  <Badge tone="quiet">{m.memory_type}</Badge>
+                </TD>
+                <TD className="whitespace-nowrap">{m.sensitivity}</TD>
+                <TD className="text-right font-mono text-xs">{m.importance}</TD>
+                <TD className="text-right font-mono text-xs">{m.confidence.toFixed(2)}</TD>
+                <TD>
+                  <StatusBadge status={m.status} />
+                </TD>
+                <TD className="whitespace-nowrap text-xs" title={m.source.excerpt}>
+                  {m.source.kind}
+                </TD>
+                <TD>
+                  <MemoryActions
+                    memory={m}
+                    onChanged={onChanged}
+                    capabilities={capabilities}
+                  />
+                </TD>
+              </TR>
+            ))}
+            {empty ? (
+              <TableEmptyRow colSpan={8}>No memories match these filters.</TableEmptyRow>
+            ) : null}
+          </TBody>
+        </DataTable>
+      </div>
+    </>
   );
 }

--- a/apps/web/components/public/PublicShell.tsx
+++ b/apps/web/components/public/PublicShell.tsx
@@ -61,7 +61,7 @@ function PublicHeader() {
   return (
     <header className="sticky top-0 z-30 border-b border-line bg-canvas/90 backdrop-blur supports-[backdrop-filter]:bg-canvas/75">
       <div className="mx-auto flex h-16 max-w-6xl items-center gap-6 px-5 sm:px-8">
-        <Link href="/" className="shrink-0 rounded-md">
+        <Link href="/" className="inline-flex min-h-[2.5rem] shrink-0 items-center rounded-md">
           <Wordmark />
         </Link>
 
@@ -73,7 +73,7 @@ function PublicHeader() {
             <a
               key={link.href}
               href={link.href}
-              className="rounded-sm text-sm text-fg-secondary transition-colors hover:text-fg"
+              className="inline-flex min-h-[2rem] items-center rounded-sm text-sm text-fg-secondary transition-colors hover:text-fg"
             >
               {link.label}
             </a>
@@ -115,13 +115,13 @@ function PublicFooter() {
         <nav aria-label="Footer" className="flex flex-col gap-2 text-sm">
           <Link
             href="/chat"
-            className="rounded-sm text-fg-secondary underline-offset-4 hover:text-fg hover:underline"
+            className="inline-flex min-h-[2rem] items-center rounded-sm text-fg-secondary underline-offset-4 hover:text-fg hover:underline"
           >
             Open control plane
           </Link>
           <Link
             href="/architecture"
-            className="rounded-sm text-fg-secondary underline-offset-4 hover:text-fg hover:underline"
+            className="inline-flex min-h-[2rem] items-center rounded-sm text-fg-secondary underline-offset-4 hover:text-fg hover:underline"
           >
             Technical architecture reference
           </Link>

--- a/apps/web/components/public/sections/ArchitecturePreview.tsx
+++ b/apps/web/components/public/sections/ArchitecturePreview.tsx
@@ -131,7 +131,7 @@ export default function ArchitecturePreview() {
             operator-facing technical reference, which renders in a different shell. */}
         <Link
           href="/architecture"
-          className="rounded-sm text-sm text-fg-secondary underline-offset-4 hover:text-fg hover:underline"
+          className="inline-flex min-h-[2.5rem] items-center rounded-sm text-sm text-fg-secondary underline-offset-4 hover:text-fg hover:underline"
         >
           View the technical architecture reference →
         </Link>

--- a/apps/web/components/shell/AppShell.tsx
+++ b/apps/web/components/shell/AppShell.tsx
@@ -34,8 +34,34 @@ export default function AppShell({
   const pathname = usePathname() ?? "/";
   const [navOpen, setNavOpen] = useState(false);
   const drawerRef = useRef<HTMLDivElement>(null);
+  /** Whatever had focus when the drawer opened — almost always the toggle button. */
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
 
-  const closeNav = useCallback(() => setNavOpen(false), []);
+  /**
+   * Dismiss and hand focus back to whatever opened it.
+   *
+   * Restoring here rather than in an effect cleanup is deliberate: by the time a
+   * cleanup runs the panel is already unmounted and focus has fallen to <body>, so
+   * there is no longer any way to tell whether focus *was* inside the drawer. Doing
+   * it at the point of dismissal keeps the decision unambiguous.
+   */
+  const closeNav = useCallback(() => {
+    setNavOpen(false);
+    const target = restoreFocusRef.current;
+    if (target?.isConnected) {
+      // After the commit that removes the drawer, or the browser drops the focus.
+      requestAnimationFrame(() => target.focus());
+    }
+  }, []);
+
+  /**
+   * Dismiss because the user is navigating away.
+   *
+   * No focus restoration: the destination page decides where focus belongs, and
+   * yanking it back to a hamburger button the user has just navigated away from
+   * would be worse than leaving it at the document start.
+   */
+  const dismissForNavigation = useCallback(() => setNavOpen(false), []);
 
   // Navigating with the drawer open must not leave it covering the page it just
   // loaded. Keyed on the path so it also fires for links inside the content.
@@ -43,21 +69,63 @@ export default function AppShell({
     setNavOpen(false);
   }, [pathname]);
 
-  // Escape closes the drawer — the expected exit from any overlay, and the only one
-  // available to a keyboard user who cannot click the backdrop.
+  /**
+   * Keyboard contract for the open drawer: Escape closes it, and Tab stays inside it.
+   *
+   * The trap is the load-bearing half. The panel already declares
+   * `role="dialog" aria-modal="true"`, which tells assistive tech the background is
+   * inert — but `aria-modal` moves no focus. Without this, tabbing past the last nav
+   * link walked straight into the page underneath, which the scrim has covered: an
+   * operator could focus and activate a Delete button they could not see.
+   */
   useEffect(() => {
     if (!navOpen) return;
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") setNavOpen(false);
+
+    function focusable(): HTMLElement[] {
+      const root = drawerRef.current;
+      if (!root) return [];
+      return [
+        ...root.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ].filter((el) => el.offsetParent !== null);
     }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        closeNav();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const items = focusable();
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement;
+
+      // Wrap at both ends, and pull focus back in if it is somehow outside already.
+      if (!drawerRef.current?.contains(active)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+      } else if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [navOpen]);
+  }, [navOpen, closeNav]);
 
-  // Move focus into the drawer when it opens so the next Tab lands on a nav link
-  // rather than continuing through the page behind it.
+  // Seed focus inside the drawer, and remember where to send it back to.
   useEffect(() => {
-    if (navOpen) drawerRef.current?.focus();
+    if (!navOpen) return;
+    restoreFocusRef.current = document.activeElement as HTMLElement | null;
+    drawerRef.current?.focus();
   }, [navOpen]);
 
   // Stop the page behind the overlay from scrolling with it.
@@ -71,12 +139,15 @@ export default function AppShell({
   }, [navOpen]);
 
   if (isChromeless(pathname)) {
+    // A chromeless route supplies its own landmarks. Wrapping `children` in a
+    // <main> here produced two nested <main> elements on `/` — one from this
+    // branch and one from PublicShell — both carrying id="main-content", so the
+    // document had a duplicate id and the skip link pointed at the outer wrapper
+    // rather than the page content.
     return (
       <>
         {banner}
-        <main id="main-content" className="min-h-screen">
-          {children}
-        </main>
+        {children}
       </>
     );
   }
@@ -122,7 +193,7 @@ export default function AppShell({
             >
               <SidebarNav
                 pathname={pathname}
-                onNavigate={closeNav}
+                onNavigate={dismissForNavigation}
                 footer={<ShellFooter identity={identity} />}
               />
             </div>

--- a/apps/web/components/ui/DataTable.tsx
+++ b/apps/web/components/ui/DataTable.tsx
@@ -22,11 +22,21 @@ export function DataTable({
   caption,
   children,
   className,
+  minWidth = "40rem",
 }: {
   /** Accessible name for the table and its scroll region. Required, not optional. */
   caption: string;
   children: ReactNode;
   className?: string;
+  /**
+   * Width below which the table starts scrolling horizontally inside its region.
+   *
+   * A single global 40rem was tuned for the eight-column memory registry and made
+   * narrower tables scroll for no reason. Set it to what the widest row genuinely
+   * needs — the less a table scrolls, the less an operator has to discover that the
+   * region scrolls at all.
+   */
+  minWidth?: string;
 }) {
   return (
     <div
@@ -38,7 +48,10 @@ export function DataTable({
         className,
       )}
     >
-      <table className="w-full min-w-[40rem] border-collapse text-left text-sm">
+      <table
+        className="w-full border-collapse text-left text-sm"
+        style={{ minWidth }}
+      >
         <caption className="sr-only">{caption}</caption>
         {children}
       </table>

--- a/apps/web/components/ui/Timeline.tsx
+++ b/apps/web/components/ui/Timeline.tsx
@@ -73,7 +73,11 @@ export function TimelineItem({
           ) : null}
         </div>
         {description ? (
-          <p className="text-sm leading-relaxed text-fg-secondary">{description}</p>
+          // Audit reasons and loop event reasons are server-supplied free text and
+          // can carry an unbroken identifier; break rather than push the page.
+          <p className="break-words text-sm leading-relaxed text-fg-secondary">
+            {description}
+          </p>
         ) : null}
         {meta ? (
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1">{meta}</div>

--- a/apps/web/components/ui/Values.tsx
+++ b/apps/web/components/ui/Values.tsx
@@ -103,7 +103,15 @@ export function DefinitionList({
   return <dl className={cn("grid gap-x-6 gap-y-4", cols, className)}>{children}</dl>;
 }
 
-/** Quoted provenance excerpt — source text, visually distinct from governed content. */
+/**
+ * Quoted provenance excerpt — source text, visually distinct from governed content.
+ *
+ * `break-words` is load-bearing, not cosmetic. A source excerpt is verbatim user
+ * text, so it routinely contains a URL or an opaque identifier with no break
+ * opportunity in it. Without this the token painted straight past its container and
+ * pushed the whole document sideways: a memory whose excerpt held a runbook URL
+ * gave `/memories/{id}` 78px of horizontal page overflow at 360px.
+ */
 export function SourceQuote({
   children,
   className,
@@ -115,6 +123,7 @@ export function SourceQuote({
     <blockquote
       className={cn(
         "border-l-2 border-line-strong bg-surface-sunken/60 py-2 pl-3 pr-2 text-sm italic text-fg-secondary",
+        "break-words",
         className,
       )}
     >

--- a/docs/governance-ui.md
+++ b/docs/governance-ui.md
@@ -18,7 +18,14 @@ every view is tenant-scoped and every action is audited. See
 ## Components
 
 - `components/memories/`
-  - `MemoryTable` — inventory table; rows link to detail; inline actions.
+  - `MemoryTable` — the inventory in two presentations of the same records: a
+    dense eight-column table at `md` and wider, and a card list below it. The
+    table needs ~40rem, so on a 390px viewport Status and Actions sat roughly
+    600px inside a horizontal scroll region the operator had no reason to know
+    existed. The card carries every field the row does — content, type,
+    sensitivity, importance, confidence, status, source and the same actions — so
+    it is a reflow, not a mobile-only subset, and only one presentation is in the
+    accessibility tree at a time.
   - `MemoryFilters` — search + status + type filters (`deleted` is intentionally
     not selectable — it is never part of the active inventory).
   - `MemoryDetailPanel` — self-fetching detail (memory + provenance + audit),
@@ -117,6 +124,24 @@ Applies to every surface, enforced by the primitives rather than per page:
 - one `:focus-visible` ring for the whole app, defined with the token set;
 - a skip link as the first focusable element, and `aria-current="page"` on the
   active section;
+- exactly one `<main id="main-content">` per page, owned by whichever shell
+  actually wraps the route. `AppShell`'s chromeless branch emits none, because a
+  chromeless route supplies its own — when both emitted one, `/` shipped nested
+  `<main>` elements and a duplicate id, and the skip link resolved to the outer
+  wrapper instead of the content;
+- the mobile navigation drawer traps Tab while open and returns focus to the
+  control that opened it. `aria-modal` marks the background inert for assistive
+  tech but moves no focus, so without a trap an operator could tab onto — and
+  activate — a destructive control the scrim was covering. Restoration happens at
+  the point of dismissal, not in an effect cleanup, because by cleanup time the
+  panel is unmounted and focus has fallen to `<body>`; following a nav link
+  deliberately does not restore, since the destination decides where focus goes;
+- every primitive that renders verbatim server text (`SourceQuote`, `KeyValue`,
+  `TimelineItem`, `ErrorState`) declares a wrapping rule. Provenance excerpts and
+  audit reasons routinely carry a URL or an opaque identifier with no break
+  opportunity, and such a token paints past its container and grows the document
+  while every element still reports itself in bounds — `/memories/{id}` carried
+  78px of horizontal overflow at 360px before this was found;
 - form controls labelled by wrapping — no generated id to drift or lose, and no
   placeholder standing in for a label;
 - tables as labelled, focusable scroll regions with real `<th scope="col">`, so
@@ -126,6 +151,18 @@ Applies to every surface, enforced by the primitives rather than per page:
 
 Every token pair used for text measures at or above WCAG AA (4.5:1) on its
 surface; the lowest is `fg-muted` on `surface-raised` at 4.85:1.
+
+Verified by driving the built app in a real browser (system Chrome over CDP, no
+browser dependency in the repo) at 360 / 390 / 768 / 1024 / 1440 / 1920 against a
+live API with seeded data: 0px horizontal overflow on every route, a focus ring on
+every tab stop, the skip link first in tab order, 0 console errors and 0 hydration
+mismatches, and every animation and transition clamped under
+`prefers-reduced-motion: reduce`.
+
+One accepted limitation: `/loops` still scrolls its four-column run table
+horizontally at 360-390px. The columns are informational, no control is stranded,
+and the scroll region is labelled and keyboard-reachable, so it is recorded rather
+than reflowed.
 
 ### Real state only
 


### PR DESCRIPTION
A defect pass over the surfaces v2.6 already built — not a redesign. Every change below is a measured failure found by driving the real application in a real browser, four of them only reachable with genuine data or a keyboard.

No dependency, backend, API or Railway changes. No authorization-semantic changes.

---

## Significant fixes

**1. Nested duplicate `<main>` landmark on `/`.** `AppShell`'s chromeless branch wrapped children in `<main id="main-content">` and `PublicShell` did the same inside it, so the landing page shipped nested `<main>` elements and a duplicate DOM id — landmark navigation offered a phantom region and the skip link resolved to the outer wrapper instead of the content. A chromeless route now owns its own landmarks; `/signin` gained the `<main>` it had been borrowing. No landmark was removed from any authenticated page.

**2. Mobile drawer leaked focus.** `role="dialog" aria-modal="true"` marks the background inert for assistive tech but moves no focus, so tabbing past the last nav link walked into the page underneath. Measured at 390px: **6 of 14 tab stops landed outside the open drawer**, on controls the scrim was covering — an operator could focus and activate a Delete button they could not see. Tab now wraps at both ends and is pulled back in if it is already outside. After the fix: **0 of 14**. Escape still closes.

**3. The drawer never gave focus back.** Dismissing left the caret wherever the DOM dropped it — in practice the memories table's scroll region. Focus is now restored to the control that opened it, at the point of dismissal rather than in an effect cleanup: by cleanup time the panel is unmounted and focus has fallen to `<body>`, which makes "was focus inside?" unanswerable. Following a nav link deliberately does *not* restore, since the destination page decides where focus belongs.

**4. Long-token overflow on `/memories/[id]`.** `SourceQuote` renders verbatim provenance excerpts, which routinely carry a URL or opaque identifier with no break opportunity. The token painted past its container and grew the document: **78px of horizontal overflow at 360px, 48px at 390px**. This was invisible to rect-based checks — every element reported itself in bounds while `scrollWidth` grew — and took a DOM bisection to isolate. The fix is a wrapping rule; the provenance value itself is unchanged and still selectable and copyable in full.

**5. The registry stranded its controls off-screen.** The eight-column table has a 40rem minimum, so on a 390px viewport Status and Actions sat roughly 600px inside a horizontal scroll region an operator had no reason to know existed. Below `md` it now renders as cards carrying **every field the row does** — content, type, sensitivity, importance, confidence, status, source and the same actions. A reflow, not a mobile-only subset, and only one presentation is in the accessibility tree at a time. Nothing was dropped to make it fit.

## Minor fixes

- `TimelineItem` had the same latent wrapping gap as `SourceQuote` (it renders server-supplied audit and loop reasons).
- Seven interactive targets under 32px raised without changing the visual rhythm — footer links, the wordmark, "View memory", audit-log id links.
- `DataTable`'s minimum width became per-table. The single global 40rem was tuned for the eight-column registry and made the four-column loop-runs table scroll for no reason; it needs 26rem.

## Validation

All 11 routes at 360 / 390 / 768 / 1024 / 1440 / 1920, driven with system Chrome over CDP using Node's built-in WebSocket. **No browser dependency was added to the repo**, and none is proposed for CI.

| Check | Result |
| --- | --- |
| Page horizontal overflow | **0px** on every route at every width |
| Focus ring | present on every tab stop, every route, no exceptions |
| Tab order | skip link first on every route |
| Landmarks | exactly one `<main>` and one `#main-content` per page |
| Console errors / warnings | **0** |
| Uncaught exceptions | **0** |
| Hydration mismatches | **0** |
| React key warnings | **0** |
| `prefers-reduced-motion: reduce` | every animation and transition clamps |

Loading / empty / error states were inventoried across every protected surface. `/audit` and `/admin` delegate their empty state to `AuditTimeline`; `/chat` uses an inline composer state, which is correct for a composer rather than a skeleton. No records were fabricated to make any screen look fuller.

### About the validation environment

`MEMORYOPS_STORAGE=memory` with **stub LLM and stub embedding providers** was local browser-validation infrastructure only. Records were seeded through the real write path so tables held genuine governed state — including a memory whose provenance excerpt carried a 358-character URN and URL, which is what surfaced fix #4.

**This was not production testing and involved no live-provider calls.**

## Accepted limitation

At 360–390px the four-column loop-runs table intentionally remains horizontally scrollable. The scroll region is labelled and keyboard-reachable, and no action is hidden outside the user's reachable interaction path. Its minimum width was reduced from 40rem to 26rem, but it was not converted to cards.

Not every table transforms to a mobile card layout — the registry does, because interactive controls were stranded there; this one does not, because its columns are informational.

## Route semantics

Unchanged and re-verified anonymously in authenticated mode: `/`, `/architecture` and `/signin` serve 200; `/chat`, `/memories`, `/memories/{id}`, `/governance`, `/audit`, `/loops` and `/admin` all still 307 to sign-in with their `callbackUrl` intact. `middleware.ts`, `auth.ts`, `lib/identity.ts`, `lib/capabilities.ts` and `lib/scope.ts` are absent from this diff.

## Tests

165, up from 141. They cover contracts rather than styling: landmark ownership across both shells, the drawer's keyboard contract, wrapping declarations on every primitive that renders free text, and that the registry's card presentation carries the full field set.

## Documentation

`docs/governance-ui.md` is the only non-`apps/web` change. The PR invariant gate **failed first** and was right to: the registry's presentation genuinely changed and the committed UI contract still described the old single-table component. The documentation was updated to match shipped behaviour — the rule was not weakened and no allowlist was added.

## Not in this PR

The queued npm advisories are a separate pre-v2.6-RC triage item; `package.json` and `package-lock.json` are untouched and those advisories are not attributable to this work. The stale `## Roles` section in `docs/web-control-plane.md` also remains a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)