### PR TITLE
chore(web): harden production dependency packaging

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -9,6 +9,23 @@ COPY package.json package-lock.json ./
 # versions no one reviewed and CI never saw.
 RUN npm ci
 
+# Production dependency tree, resolved from the same lockfile.
+#
+# This stage exists because the runtime image used to copy `node_modules` straight
+# out of the build stage, and that tree is the output of a plain `npm ci` — every
+# devDependency included. The shipped image therefore carried eslint, typescript,
+# vitest, tailwind and the whole lint toolchain, none of which `next start` ever
+# loads. They were not reachable, but they were present: extra bytes, extra CVE
+# surface in image scans, and a runtime that did not match what it claimed to be.
+#
+# `npm ci --omit=dev` from the identical lockfile, rather than pruning the build
+# tree, so the runtime dependency set is derived from the lock rather than from
+# whatever `npm prune` decides is unreachable.
+FROM node:20-slim AS prod-deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
 FROM node:20-slim AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
@@ -20,7 +37,8 @@ WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=build /app/.next ./.next
 COPY --from=build /app/public ./public
-COPY --from=build /app/node_modules ./node_modules
+# Runtime dependencies only — note this comes from `prod-deps`, not `build`.
+COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/package.json ./package.json
 USER node
 EXPOSE 3000

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -4970,7 +4970,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Two independent, low-risk remediations from the pre-RC advisory triage. Neither touches a framework version.

**This does not make the audit clean.** See the boundary section at the end.

---

## A. Transitive security remediation — nanoid

`nanoid` **3.3.16 → 3.3.18** — [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), CVSS 5.9: custom generators can loop indefinitely when `size` is zero.

It reaches the tree as `next > postcss > nanoid`, and `postcss@8.4.31` declares `nanoid: ^3.3.6` — so the patched release was **already inside the permitted range** and needed only a lockfile resolution.

- lockfile-only; `package.json` is unchanged
- nanoid was **not** promoted to a direct dependency
- exactly one resolved version moved; zero packages added, zero removed

Audit movement, from actual `npm audit` output:

| | before | after |
| --- | --- | --- |
| all dependencies | 6 high package-level findings | **5** |
| production only (`--omit=dev`) | 3 high package-level findings | **2** |

## B. Production artifact hardening

The final image copied `node_modules` straight out of the build stage, and that tree is the output of a plain `npm ci` — every devDependency included. A `prod-deps` stage now runs `npm ci --omit=dev` against the **identical lockfile**, and the runtime stage copies from there.

A fresh production install rather than pruning the build tree, so the runtime dependency set is derived from the lock rather than from whatever `npm prune` judges unreachable.

Measured in the **actual image filesystem**, not inferred from `package.json` classification:

| | top-level packages |
| --- | --- |
| before | **369** — eslint, eslint-config-next, typescript, vitest, tailwindcss all present |
| after | **48** — all of the above absent |

Verified absent in the runtime image: `eslint`, `eslint-config-next`, `@next/eslint-plugin-next`, `typescript`, `vitest`, `tailwindcss`, `autoprefixer`, top-level `postcss`, `@types/react`.

Verified present at expected versions: `next@14.2.35`, `react@18.3.1`, `react-dom@18.3.1`, `next-auth@5.0.0-beta.32`, `jose@6.2.7`, `server-only@0.0.1`, and `nanoid@3.3.18` — confirming the fix in A actually ships.

### Wording that matters

The dev-only chain (`eslint-config-next > @next/eslint-plugin-next > glob@10.3.10`) **remains represented in the repository lockfile**. It is simply **no longer physically shipped** in the production web image.

That is not the same as remediating it. Remediation requires `eslint-config-next@16.3.1`, which needs ESLint 9 and a flat-config migration — deliberately deferred.

Those packages were never reachable at runtime either: `next start` serves prebuilt `.next` output and loads none of them. This removes 321 packages of CVE surface from image scans and makes the artifact match what it claims to be; it does not fix an exploited vulnerability.

## Local container evidence

Docker was unavailable locally, so the image was built and exercised with **Podman 5.7.1**. Remote CI builds the same Dockerfile under Docker, and that is the authoritative portability check for this PR — Podman success is not treated as sufficient.

Container starts (`next start`, ready in 119ms) and serves. Anonymous route matrix from the pruned image, authenticated mode:

| Route | Result |
| --- | --- |
| `/` | 200 — 89KB, `h1="Govern what AI remembers."`, not an error page |
| `/architecture` | 200 — `h1="Architecture"` |
| `/signin` | 200 — `h1="Sign in"` |
| `/chat` `/memories` `/memories/{id}` `/governance` `/audit` `/loops` `/admin` | 307 → `/signin` with `callbackUrl` intact |

Demo mode serves every route. **No auth or middleware change was needed to make the container start**, and none is present in this diff.

Local gates: lint, typecheck, 165/165 tests, demo build, authenticated build, and `npm ci` installs cleanly from the modified lockfile.

## Framework boundary — Option C has not started

Unchanged: `next@14.2.35`, `react@18.3.1`, `react-dom@18.3.1`, `next-auth@5.0.0-beta.32`, `eslint@8.57.1`, `eslint-config-next@14.2.35`.

**The web audit is not clean.** `next@14.2.35` and its **exactly pinned** `postcss@8.4.31` remain — and there is no 15.x escape route: 15.5.21, 15.5.22 and 15.5.23 all still bundle 8.4.31, and only `next@16.3.1` moves to the patched 8.5.23. That upgrade is the next isolated PR.

What this PR is: **it removes the independently patchable nanoid finding and stops shipping development-only dependencies in the production image.** It is not "dependency vulnerabilities fixed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)