### PR TITLE
docs(web): reconcile role and dependency security truth

### DIFF
--- a/docs/web-control-plane.md
+++ b/docs/web-control-plane.md
@@ -129,20 +129,91 @@ record.
 
 ## Roles
 
-Least privilege first: `viewer` → `developer` → `auditor` → `memory_admin` → `owner`.
+**Web roles are UI personas. API roles are authorization bundles.** They are
+different vocabularies, and the translation between them is explicit,
+single-sourced in `contracts/auth-role-map.json`, and tested from both sides.
 
-| API path | GET | Write |
-| --- | --- | --- |
-| `/api/memories` | `viewer` | `memory_admin` |
-| `/api/chat` | — | `developer` (chat writes memory) |
-| `/api/audit`, `/api/evidence` | `auditor` | `auditor` |
-| `/api/retention` | `auditor` | `owner` |
-| `/api/evals` | `owner` | `owner` |
-| anything else | `viewer` | `viewer` |
+| Web persona | API role |
+| --- | --- |
+| `viewer` | `memory_viewer` |
+| `developer` | `memory_user` |
+| `auditor` | `auditor` |
+| `memory_admin` | `memory_admin` |
+| `owner` | `tenant_admin` |
 
-Unknown paths default to the **least** privileged role, so a newly added endpoint
-is readable rather than accidentally open to mutation. This is defence in depth on
-top of the API's governance — it only ever *removes* access.
+Two API roles exist that no web persona maps to. `service_worker` is a machine
+identity for the worker fleet and is never assignable to a human at all.
+`platform_operator` *is* assignable to a person — it runs the deployment — but is
+**never web-assignable**: no customer's UI session may become deployment
+authority. Both are listed in `NEVER_WEB_ASSIGNABLE`, and `apiRoleFor()` returns
+`null` for either.
+
+### Personas are a list, not a ladder
+
+There is no ordinal ranking. Authority is **capability-based**: each API role
+holds a set of permissions, and those sets are not nested. Two concrete cases from
+the generated contract disprove any ordering:
+
+- `memory_admin` holds no `evidence:read`; `auditor` does. Managing memory does not
+  confer access to the evidence of who managed it.
+- `tenant_admin` (the `owner` persona) holds no `ops:*` permission of any kind;
+  only `platform_operator` does. The highest tenant role reaches no deployment
+  surface.
+
+Do not reintroduce prose implying that `memory_admin` outranks `auditor`, or that
+`owner` outranks everything. A ladder cannot express orthogonal capabilities, and
+the previous `hasAtLeast()` model let both of those mistakes through.
+
+### How a request is decided
+
+```
+web persona
+  → explicit persona → API-role mapping        (contracts/auth-role-map.json)
+  → generated authorization contract           (lib/authzCapabilities.generated.ts)
+  → route + HTTP method + action-shape check   (lib/capabilities.ts, canAttempt)
+  → BFF proxy decision                         (app/api/memoryops/[...path])
+  → API authoritative, record- and state-aware authorization
+```
+
+`lib/authzCapabilities.generated.ts` is generated from the API's own
+`authz_spec` and `roles` modules, so the web cannot drift from what the server
+enforces. A CI gate (`python scripts/generate_web_capabilities.py --check`)
+fails if it does.
+
+`canAttempt()` answers exactly one question:
+
+> May this persona attempt this request shape?
+
+It does **not** answer:
+
+> Is this operation authorized on this actual record?
+
+The browser does not know a memory's stored owner, whether a request resolves to
+self or tenant scope, the record's current lifecycle status, or anything about
+legal hold, consent or revisions. `status: "active"` is genuinely ambiguous from
+the client — it is *approve* from `pending` and *restore* from `archived` — so
+both readings are permitted to be attempted and the API resolves the real
+transition. **The API remains authoritative.** The BFF check only ever *removes*
+access; it never grants any.
+
+### Fail closed
+
+Every unrecognised shape is denied, not defaulted:
+
+| Situation | Result |
+| --- | --- |
+| Unknown or non-web-assignable persona | DENY |
+| Route with no authorization contract | DENY |
+| Unknown HTTP method for a known route | DENY |
+| Unrecognised field in a `PATCH` body | DENY |
+| Unrecognised lifecycle transition | DENY |
+| Body that requests no change at all | DENY |
+| Route classified but naming no permission | DENY |
+
+A newly added API endpoint is therefore **unreachable through the BFF until it is
+classified** — it is not readable by default. The earlier model fell through to the
+least-privileged role, which meant an unclassified endpoint was readable by
+everyone; that is the specific bug this replaced.
 
 ## Identity provider
 
@@ -179,6 +250,52 @@ MEMORYOPS_API_TOKEN_TTL_SECONDS=120
 `AUTH_SECRET` is a **runtime** signing key. The build does not need it, and no
 placeholder is baked into the image.
 
+## Runtime dependencies
+
+The web runtime is **Next.js 16.3.1** on React 18.3.1, with `next-auth`
+5.0.0-beta.32. The production dependency tree audits clean.
+
+### Why 16.3.1 specifically
+
+This is worth stating precisely, because the short version is wrong.
+
+The known **Next.js advisories themselves cleared earlier** — every one of them is
+fixed by 15.5.21. What forced the move to 16 was a transitive dependency: `next`
+pins `postcss` *exactly*, and the tested 15.x releases (15.5.21, 15.5.22, 15.5.23)
+and 16.0.0 all still bundle the vulnerable `postcss@8.4.31`. Because the pin is
+exact, no patched postcss could be hoisted underneath them.
+
+`next@16.3.1` is the first release that ships the patched `postcss@8.5.23`. On
+16.3.1 the nested `node_modules/next/node_modules/postcss` resolution disappears
+entirely and the tree dedupes to the patched top-level copy.
+
+So: **16.3.1 was selected to obtain a clean production dependency tree, not
+because the Next.js advisories required Next 16.** Do not restate it the short way.
+
+### Production tree vs development tree
+
+These are different questions and should not be collapsed:
+
+| Scope | Result |
+| --- | --- |
+| Production dependency tree (`npm audit --omit=dev`) | **clean** |
+| Full development tree (`npm audit`) | findings remain in the ESLint/glob chain |
+| Packages present in the production image | dev tooling excluded by the `prod-deps` stage |
+
+See [Known limitations](#known-limitations) for why the development-tooling chain
+is deferred rather than fixed.
+
+### The build compiler is pinned
+
+Next 16 defaults to Turbopack. The `build` and `dev` scripts pass `--webpack`
+explicitly, so the compiler did not change when the framework did. Builds report
+`▲ Next.js 16.3.1 (webpack)`. Adopting Turbopack is a separate, deliberate
+decision rather than a side effect of a dependency upgrade.
+
+`next lint` was removed in Next 16, so linting invokes ESLint directly
+(`eslint . --ext .ts,.tsx,.js,.jsx`) against the existing ESLint 8 configuration.
+That is a command-compatibility change only — no ESLint upgrade and no flat config.
+
 ## Known limitations
 
 - `next-auth@5.0.0-beta.32` is a **beta** release. It is the App-Router-native
@@ -193,5 +310,12 @@ placeholder is baked into the image.
 - Organisation/project/service-account management, and first-class consent /
   legal-hold / retention / evidence pages, are not built yet — the API and SDK
   expose them but the UI does not.
-- `next@14.2.35` currently carries open advisories (see `npm audit`); fixing them
-  requires a Next 16 upgrade, tracked separately from this change.
+- **Development-tooling advisories remain in the lockfile.** The production
+  dependency tree audits clean, but `eslint-config-next` →
+  `@next/eslint-plugin-next` → `glob` still carries findings. The vulnerable code
+  is the glob **CLI** (`-c/--cmd`), which lint tooling never invokes, and the
+  production image excludes these packages entirely via the `prod-deps` stage —
+  but **not shipped is not the same as remediated**. Remediating it requires
+  `eslint-config-next@16.3.1`, whose ESLint peer is `>=9.0.0`, i.e. an ESLint 9
+  flat-config migration. That is deliberately deferred and tracked separately.
+  Do not describe the repository's whole dependency graph as clean.


### PR DESCRIPTION
Documentation-only reconciliation. **One changed file:** `docs/web-control-plane.md` (+138/−14). No runtime, auth, dependency, packaging or Railway changes.

The doc had drifted from the code in two places, both in ways that would mislead someone reasoning about authorization or about what is actually vulnerable.

---

## 1. The Roles section described a ladder that does not exist

It still documented `viewer → developer → auditor → memory_admin → owner` plus a path/minimum-role table. That model was replaced in v2.4 by a generated capability contract, and it was wrong in a specific, checkable way. From `lib/authzCapabilities.generated.ts`:

- `memory_admin` holds **no** `evidence:read`; `auditor` does. Managing memory does not confer access to the evidence of who managed it.
- `tenant_admin` (the `owner` persona) holds **no** `ops:*` permission at all; only `platform_operator` does. The highest tenant role reaches no deployment surface.

So `memory_admin` does not outrank `auditor`, and `owner` does not outrank everything. **Personas are a list, not a ladder**, and authority is capability-based.

The section now documents the exact mapping, verified against `contracts/auth-role-map.json`:

| Web persona | API role |
| --- | --- |
| `viewer` | `memory_viewer` |
| `developer` | `memory_user` |
| `auditor` | `auditor` |
| `memory_admin` | `memory_admin` |
| `owner` | `tenant_admin` |

It also records why `service_worker` and `platform_operator` are never web-assignable — noting that `platform_operator` *is* assignable to a person, just never as a tenant's web session.

### The decision path, and where authority actually lives

```
web persona → explicit persona→API-role mapping → generated authorization contract
  → route + method + action-shape check (canAttempt) → BFF → API
```

`canAttempt()` answers **"may this persona attempt this request shape?"** It does **not** answer **"is this operation authorized on this actual record?"** The browser cannot know a memory's stored owner, its lifecycle status, or its legal-hold state, and `status: "active"` is genuinely ambiguous from the client — *approve* from `pending`, *restore* from `archived`. **The API remains authoritative**; the BFF check only ever removes access.

### The fail-closed claim was inverted

The doc said an unknown path defaults to the least-privileged role so a new endpoint is "readable rather than accidentally open to mutation". The implementation denies: unknown persona, unclassified route, unknown method, unrecognised `PATCH` field, unrecognised transition, a body requesting no change, and a route classified but naming no permission. **A new endpoint is unreachable through the BFF until it is classified** — being readable by default was the bug that model replaced.

## 2. The advisory wording named a runtime that no longer exists

It said `next@14.2.35` carries advisories and that "fixing them requires a Next 16 upgrade". Both are wrong.

A new **Runtime dependencies** section states the current runtime (**Next.js 16.3.1**, React 18.3.1, next-auth 5.0.0-beta.32) and the actual reason for 16.3.1:

> Every known Next.js advisory clears at **15.5.21**. What forced 16 is that `next` pins postcss *exactly*, and 15.5.21, 15.5.22, 15.5.23 and 16.0.0 all still bundle the vulnerable `postcss@8.4.31`. `next@16.3.1` is the first release shipping the patched `postcss@8.5.23`.

The doc says this explicitly — *"16.3.1 was selected to obtain a clean production dependency tree, not because the Next.js advisories required Next 16"* — and warns against restating it the short way.

It also separates three things the old text collapsed:

| Scope | Result |
| --- | --- |
| Production dependency tree | **clean** |
| Full development tree | ESLint/glob findings remain |
| Packages in the production image | dev tooling excluded by the `prod-deps` stage |

Known limitations now states plainly that **not shipped is not the same as remediated**: the vulnerable code is a glob **CLI** that lint tooling never invokes, and remediation requires `eslint-config-next@16.3.1` → ESLint 9 → a flat-config migration, which stays deferred. It also records that the build compiler is pinned to webpack so Next 16's Turbopack default was not silently adopted, and that `next lint` was removed in 16 so linting invokes ESLint directly against the existing ESLint 8 config.

## Verification

Every claim was cross-checked against code, not prose: the persona mapping machine-compared against `contracts/auth-role-map.json`; the `evidence:read` and `ops:*` counter-examples read from the generated permissions; all eleven stale phrases confirmed absent.

Local gates: `git diff --check`, capability contract, role map, dependency drift, authz matrix, PR invariant gate, gitleaks, and repository trust guards (`✓ 5 structural guard(s) clean`) — all pass.

## Deliberately excluded

Dependabot **#160** is open and proposes `eslint` 8.57.1 → 10.9.0 and `eslint-config-next` 14.2.35 → 16.3.2 bundled with unrelated patch bumps. That is the deferred Option D migration and is **not** part of this PR; nothing here incorporates, modifies or depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
